### PR TITLE
The timeline spine — the portfolio as one navigable time axis

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -1,0 +1,19 @@
+{
+  "root": false,
+  "extends": "//",
+  "files": {
+    "includes": ["**", "!src/lib/openapi.json", "!src/lib/api-schema.d.ts"]
+  },
+  "overrides": [
+    {
+      "includes": ["src/components/TimelineSpine.tsx"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noNoninteractiveTabindex": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -64,6 +64,9 @@ test('the calendar and coverage pages answer', async ({ page }) => {
   await expect(
     page.getByText(/authority that creates it|Nothing on the calendar/).first(),
   ).toBeVisible();
+  // The spine: the portfolio as one navigable time axis, datum at today.
+  await expect(page.getByRole('application').first()).toBeVisible();
+  await expect(page.getByText('TODAY').first()).toBeVisible();
   await page.goto('/coverage');
   await expect(page.getByRole('heading', { name: 'Jurisdiction coverage' })).toBeVisible();
 });

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -2,20 +2,30 @@
 
 import { useEffect, useState } from 'react';
 import { DeadlineList } from '../../components/DeadlineList';
-import { api, type DeadlineOut } from '../../lib/api';
+import { TimelineSpine } from '../../components/TimelineSpine';
+import { api, type DeadlineOut, type LeaseSummary, type LedgerRegister } from '../../lib/api';
+import { localIsoDate } from '../../lib/format';
+import { buildSpine } from '../../lib/timeline';
 
 export default function CalendarPage() {
   const [deadlines, setDeadlines] = useState<DeadlineOut[] | null>(null);
+  const [leases, setLeases] = useState<LeaseSummary[] | null>(null);
+  const [ledger, setLedger] = useState<LedgerRegister | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api
-      .listDeadlines()
-      .then(setDeadlines)
+    Promise.all([api.listDeadlines(), api.listLeases(), api.ledgerRegister()])
+      .then(([deadlineRows, leaseRows, register]) => {
+        setDeadlines(deadlineRows);
+        setLeases(leaseRows);
+        setLedger(register);
+      })
       .catch((caught: unknown) => {
         setError(caught instanceof Error ? caught.message : String(caught));
       });
   }, []);
+
+  const today = localIsoDate(new Date());
 
   return (
     <>
@@ -25,7 +35,27 @@ export default function CalendarPage() {
         on guesses.
       </p>
       {error ? <p className="error-note">{error}</p> : null}
-      {deadlines ? <DeadlineList deadlines={deadlines} /> : <p className="muted">Loading…</p>}
+      {deadlines ? (
+        <>
+          <section className="section">
+            <h2 className="section__title">The spine</h2>
+            <TimelineSpine
+              events={buildSpine({
+                today,
+                ledger: ledger?.events ?? [],
+                deadlines,
+                leases: leases ?? [],
+              })}
+              today={today}
+              wide
+              ariaLabel="Portfolio — ledger and horizon"
+            />
+          </section>
+          <DeadlineList deadlines={deadlines} />
+        </>
+      ) : (
+        <p className="muted">Loading…</p>
+      )}
     </>
   );
 }

--- a/apps/web/src/app/coverage/page.tsx
+++ b/apps/web/src/app/coverage/page.tsx
@@ -21,8 +21,8 @@ export default function CoveragePage() {
     <>
       <h1 className="page-title">Jurisdiction coverage</h1>
       <p className="page-subtitle">
-        What the platform knows for each property, rule domain by rule domain —
-        and, just as loudly, what it does not.
+        What the platform knows for each property, rule domain by rule domain — and, just as loudly,
+        what it does not.
       </p>
       {error ? <p className="error-note">{error}</p> : null}
       {report?.gaps.map((gap) => (

--- a/apps/web/src/app/property/[id]/page.tsx
+++ b/apps/web/src/app/property/[id]/page.tsx
@@ -8,34 +8,44 @@ import { DefectRegister } from '../../../components/DefectRegister';
 import { HazardCard } from '../../../components/HazardCard';
 import { JurisdictionChain } from '../../../components/JurisdictionChain';
 import { StatusPill } from '../../../components/StatusPill';
+import { TimelineSpine } from '../../../components/TimelineSpine';
 import {
   api,
   type CapexForecastOut,
   type DossierStep,
   type DossierView,
   type Financials,
+  type LeaseSummary,
+  type LedgerRegister,
 } from '../../../lib/api';
-import { titleCase } from '../../../lib/format';
+import { localIsoDate, titleCase } from '../../../lib/format';
+import { buildSpine } from '../../../lib/timeline';
 
 export default function PropertyPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const [view, setView] = useState<DossierView | null>(null);
   const [financials, setFinancials] = useState<Financials | null>(null);
   const [capex, setCapex] = useState<CapexForecastOut | null>(null);
+  const [ledger, setLedger] = useState<LedgerRegister | null>(null);
+  const [leases, setLeases] = useState<LeaseSummary[] | null>(null);
   const [steps, setSteps] = useState<DossierStep[] | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const [dossierView, money, forecast] = await Promise.all([
+      const [dossierView, money, forecast, register, leaseRows] = await Promise.all([
         api.readDossier(id),
         api.financials(id),
         api.capexForecast(id),
+        api.ledgerRegister({ propertyId: id }),
+        api.listLeases(),
       ]);
       setView(dossierView);
       setFinancials(money);
       setCapex(forecast);
+      setLedger(register);
+      setLeases(leaseRows);
       setError(null);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -65,6 +75,15 @@ export default function PropertyPage({ params }: { params: Promise<{ id: string 
   }
 
   const nowYear = new Date().getFullYear();
+  const today = localIsoDate(new Date());
+  const spineEvents = buildSpine({
+    today,
+    ledger: ledger?.events ?? [],
+    deadlines: view.deadlines,
+    leases: (leases ?? []).filter((lease) => lease.property_label === view.label),
+    capex,
+    debts: financials?.debts ?? [],
+  });
 
   return (
     <>
@@ -74,6 +93,15 @@ export default function PropertyPage({ params }: { params: Promise<{ id: string 
         {view.county ? ` · ${view.county}` : ''}
         {view.year_built != null ? ` · built ${String(view.year_built)}` : ''}
       </p>
+
+      <section className="section">
+        <h2 className="section__title">The spine</h2>
+        <TimelineSpine
+          events={spineEvents}
+          today={today}
+          ariaLabel={`${view.label} — ledger and horizon`}
+        />
+      </section>
 
       <button
         className="button"

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -2,14 +2,9 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { ScheduleEView } from '../../components/ScheduleEView';
-import {
-  api,
-  type PropertySummary,
-  type RentRollRow,
-  type ScheduleEReport,
-} from '../../lib/api';
-import { formatDate } from '../../lib/format';
 import { formatMoney } from '../../components/TransactionsTable';
+import { api, type PropertySummary, type RentRollRow, type ScheduleEReport } from '../../lib/api';
+import { formatDate } from '../../lib/format';
 
 export default function ReportsPage() {
   const [rentRoll, setRentRoll] = useState<RentRollRow[] | null>(null);
@@ -49,8 +44,8 @@ export default function ReportsPage() {
     <>
       <h1 className="page-title">Reports</h1>
       <p className="page-subtitle">
-        The ledger rolled up with its authorities attached — Schedule E per
-        property, and the portfolio rent roll.
+        The ledger rolled up with its authorities attached — Schedule E per property, and the
+        portfolio rent roll.
       </p>
       {error ? <p className="error-note">{error}</p> : null}
 

--- a/apps/web/src/components/TimelineSpine.tsx
+++ b/apps/web/src/components/TimelineSpine.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import {
+  Button,
+  Card,
+  ChartFrame,
+  CitationChip,
+  Datum,
+  dayOf,
+  isoOf,
+  linearScale,
+  Pill,
+  TimeAxis,
+  timeTicks,
+} from '@hestia/design';
+import {
+  type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent,
+  useRef,
+  useState,
+} from 'react';
+
+import { formatDate } from '../lib/format';
+import {
+  layoutSpine,
+  panned,
+  type SpineEvent,
+  type SpineWindow,
+  visibleEvents,
+  windowAround,
+} from '../lib/timeline';
+import { formatMoney } from './TransactionsTable';
+
+/**
+ * The timeline spine: the portfolio as one navigable time axis. Today is
+ * the datum; everything left of it is the ledger in solid ink, everything
+ * right is dashed projection. Deadline windows render as spans you can aim
+ * at. Pan by drag, wheel, or arrows; T returns to today; every mark is a
+ * real button that opens its detail below the axis.
+ */
+const HEIGHT = 158;
+const AXIS_Y = 118;
+const LANE_Y = [90, 66, 42] as const;
+const PAD = 18;
+const MONTH = 31;
+const YEAR = 366;
+
+/** The three mark lanes above the axis; a lane index is always 0, 1, or 2. */
+const laneHeight = (lane: number): number => LANE_Y[(lane % LANE_Y.length) as 0 | 1 | 2];
+
+const KIND_LABEL: Record<SpineEvent['kind'], string> = {
+  ledger: 'ledger',
+  deadline: 'deadline',
+  'lease-end': 'lease end',
+  capex: 'capex median',
+  debt: 'note maturity',
+};
+
+function Mark({ event, cx, cy }: { event: SpineEvent; cx: number; cy: number }) {
+  const faint = event.faint ? ' chart__mark--faint' : '';
+  switch (event.kind) {
+    case 'ledger':
+      return <circle className={`chart__mark${faint}`} cx={cx} cy={cy} r={3.5} />;
+    case 'deadline':
+      return (
+        <path
+          className={`chart__mark chart__mark--deadline${faint}`}
+          d={`M${cx} ${cy - 5} L${cx + 4.5} ${cy} L${cx} ${cy + 5} L${cx - 4.5} ${cy} Z`}
+        />
+      );
+    case 'lease-end':
+      return (
+        <path
+          className={`chart__mark chart__mark--lease${faint}`}
+          d={`M${cx} ${cy - 5} L${cx + 4.5} ${cy} L${cx} ${cy + 5} L${cx - 4.5} ${cy} Z`}
+        />
+      );
+    case 'capex':
+      return <circle className={`chart__mark chart__mark--capex${faint}`} cx={cx} cy={cy} r={4} />;
+    case 'debt':
+      return (
+        <rect
+          className={`chart__mark chart__mark--debt${faint}`}
+          x={cx - 3.5}
+          y={cy - 3.5}
+          width={7}
+          height={7}
+        />
+      );
+  }
+}
+
+type TimelineSpineProps = {
+  events: readonly SpineEvent[];
+  today: string;
+  wide?: boolean;
+  ariaLabel: string;
+};
+
+export function TimelineSpine({ events, today, wide = false, ariaLabel }: TimelineSpineProps) {
+  const todayDay = dayOf(today);
+  const [window, setWindow] = useState<SpineWindow>(() => windowAround(todayDay));
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const drag = useRef<{ startX: number; window: SpineWindow } | null>(null);
+
+  const viewW = wide ? 1080 : 680;
+  const span = window.endDay - window.startDay;
+  const x = linearScale(window.startDay, window.endDay, PAD, viewW - PAD);
+  const visible = layoutSpine(visibleEvents(events, window), (span * 18) / viewW);
+  const selected = events.find((event) => event.id === selectedId);
+
+  // jsdom reports zero-width rects; the view width is the honest fallback.
+  const surfaceWidth = (element: HTMLDivElement) => element.getBoundingClientRect().width || viewW;
+
+  const pan = (days: number) => {
+    setWindow((current) => panned(current, days));
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    drag.current = { startX: event.clientX, window };
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const state = drag.current;
+    if (state === null) {
+      return;
+    }
+    const daysPerPx = span / surfaceWidth(event.currentTarget);
+    const delta = Math.round((state.startX - event.clientX) * daysPerPx);
+    setWindow(panned(state.window, delta));
+  };
+
+  const onPointerEnd = () => {
+    drag.current = null;
+  };
+
+  const onWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    const horizontal = Math.abs(event.deltaX) > Math.abs(event.deltaY);
+    const delta = horizontal ? event.deltaX : event.shiftKey ? event.deltaY : 0;
+    if (delta !== 0) {
+      pan(Math.round((delta * span) / surfaceWidth(event.currentTarget)));
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? YEAR : MONTH;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      pan(-step);
+      return;
+    }
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      pan(step);
+      return;
+    }
+    if (event.key === 't' || event.key === 'T') {
+      event.preventDefault();
+      setWindow(windowAround(todayDay));
+    }
+  };
+
+  return (
+    <div className="spine">
+      {/* A genuine pan-and-inspect widget: role=application, keyboard-driven,
+          every mark inside a real button. The tabindex rule the linter cannot
+          model is off for this file alone in the app biome.json. */}
+      <div
+        className="spine__surface"
+        role="application"
+        aria-label={`${ariaLabel} — pan with the arrow keys, shift for a year, T for today`}
+        tabIndex={0}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerEnd}
+        onPointerLeave={onPointerEnd}
+        onWheel={onWheel}
+        onKeyDown={onKeyDown}
+      >
+        <ChartFrame viewWidth={viewW} viewHeight={HEIGHT} label={ariaLabel}>
+          <TimeAxis
+            ticks={timeTicks(window.startDay, window.endDay)}
+            x={x}
+            y={AXIS_Y}
+            from={PAD - 8}
+            to={viewW - PAD + 8}
+          />
+          {visible.map((event) => {
+            const laneY = laneHeight(event.lane);
+            const markX = x(event.day);
+            return (
+              <g key={event.id}>
+                {event.spanStart === undefined ? null : (
+                  <line
+                    className="chart__span"
+                    x1={x(Math.max(event.spanStart, window.startDay))}
+                    x2={markX}
+                    y1={laneY}
+                    y2={laneY}
+                  />
+                )}
+                <line
+                  className={event.projected ? 'chart__stem chart__stem--projected' : 'chart__stem'}
+                  x1={markX}
+                  x2={markX}
+                  y1={AXIS_Y}
+                  y2={laneY + 6}
+                />
+                <Mark event={event} cx={markX} cy={laneY} />
+              </g>
+            );
+          })}
+          {todayDay >= window.startDay && todayDay <= window.endDay ? (
+            <Datum x={x(todayDay)} top={8} bottom={AXIS_Y} />
+          ) : null}
+        </ChartFrame>
+        {visible.map((event) => (
+          <button
+            key={event.id}
+            type="button"
+            className="spine__hit"
+            style={{
+              left: `${(x(event.day) / viewW) * 100}%`,
+              top: `${((laneHeight(event.lane) - 8) / HEIGHT) * 100}%`,
+            }}
+            aria-label={`${KIND_LABEL[event.kind]}: ${event.label}, ${formatDate(isoOf(event.day))}`}
+            onClick={() => {
+              setSelectedId((current) => (current === event.id ? null : event.id));
+            }}
+          />
+        ))}
+        {visible.length === 0 ? (
+          <p className="spine__empty muted">
+            Nothing recorded or due in this window — pan with ← and →, or press T for today.
+          </p>
+        ) : null}
+      </div>
+      <p className="spine__legend faint">
+        ● ledger · <span className="spine__legend-ember">◆</span> deadline (span = open window) ·{' '}
+        <span className="spine__legend-fern">◆</span> lease end ·{' '}
+        <span className="spine__legend-graphite">○</span> capex median ·{' '}
+        <span className="spine__legend-umber">■</span> note maturity — solid is record, dashed is
+        projection
+      </p>
+      {selected === undefined ? null : (
+        <Card className="spine__detail">
+          <div className="spine__detail-head">
+            <strong>{selected.label}</strong>{' '}
+            <Pill tone="neutral">{KIND_LABEL[selected.kind]}</Pill>
+            <Button variant="quiet" onClick={() => setSelectedId(null)}>
+              Close
+            </Button>
+          </div>
+          <p className="muted">
+            {formatDate(isoOf(selected.day))}
+            {selected.spanStart === undefined
+              ? ''
+              : ` — window opens ${formatDate(isoOf(selected.spanStart))}`}
+            {selected.money === undefined ? '' : ` · ${formatMoney(selected.money)}`}
+          </p>
+          <p>{selected.detail}</p>
+          {selected.citation === undefined ? null : <CitationChip cite={selected.citation} />}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/timeline.ts
+++ b/apps/web/src/lib/timeline.ts
@@ -1,0 +1,198 @@
+/**
+ * The spine's arithmetic: every source the platform already holds, merged
+ * onto one day-numbered axis. Pure — API rows in, positioned events out —
+ * so the whole flagship surface is testable without a browser. Positioning
+ * runs on UTC day numbers (see @hestia/design dayOf); only DISPLAY of a
+ * date is operator-local, as format.ts insists.
+ */
+import { dayOf } from '@hestia/design';
+import type {
+  CapexForecastOut,
+  DeadlineOut,
+  Financials,
+  LeaseSummary,
+  LedgerEventOut,
+} from './api';
+import { titleCase } from './format';
+
+export type SpineKind = 'ledger' | 'deadline' | 'lease-end' | 'capex' | 'debt';
+
+export interface SpineEvent {
+  id: string;
+  day: number;
+  /** A deadline's open window starts here; the mark sits at `day` (due). */
+  spanStart?: number;
+  kind: SpineKind;
+  label: string;
+  detail: string;
+  money?: string;
+  citation?: string;
+  /** Strictly after today: dashed stem, kind-colored mark. */
+  projected: boolean;
+  /** Reversed ledger entries stay on the record, at reduced ink. */
+  faint: boolean;
+}
+
+export interface SpineWindow {
+  startDay: number;
+  endDay: number;
+}
+
+/** A year of record behind, eighteen months of horizon ahead. */
+export function windowAround(todayDay: number): SpineWindow {
+  return { startDay: todayDay - 365, endDay: todayDay + 550 };
+}
+
+export function panned(window: SpineWindow, days: number): SpineWindow {
+  return { startDay: window.startDay + days, endDay: window.endDay + days };
+}
+
+const AVERAGE_MONTH_DAYS = 30.44;
+const AVERAGE_YEAR_DAYS = 365.25;
+
+export interface SpineInputs {
+  today: string;
+  ledger?: readonly LedgerEventOut[];
+  deadlines?: readonly DeadlineOut[];
+  leases?: readonly LeaseSummary[];
+  capex?: CapexForecastOut | null;
+  debts?: Financials['debts'];
+}
+
+const ledgerEvents = (rows: readonly LedgerEventOut[], todayDay: number): SpineEvent[] =>
+  rows.map((entry) => {
+    const day = dayOf(entry.occurred_on);
+    return {
+      id: entry.event_uuid,
+      day,
+      kind: 'ledger' as const,
+      label: entry.counterparty ?? titleCase(entry.category),
+      detail: entry.memo ?? titleCase(entry.category),
+      money: entry.amount,
+      projected: day > todayDay,
+      faint: entry.reversed,
+    };
+  });
+
+const deadlineEvents = (rows: readonly DeadlineOut[], todayDay: number): SpineEvent[] =>
+  rows
+    // A done or dismissed deadline is history the ledger already tells.
+    .filter((deadline) => deadline.status !== 'done' && deadline.status !== 'dismissed')
+    .map((deadline) => {
+      const day = dayOf(deadline.due_on);
+      return {
+        id: deadline.id,
+        day,
+        ...(deadline.window_opens_on == null ? {} : { spanStart: dayOf(deadline.window_opens_on) }),
+        kind: 'deadline' as const,
+        label: titleCase(deadline.kind),
+        detail: deadline.note ?? deadline.property_label ?? 'portfolio-wide',
+        ...(deadline.citation == null ? {} : { citation: deadline.citation }),
+        projected: day > todayDay,
+        faint: false,
+      };
+    });
+
+const leaseEvents = (rows: readonly LeaseSummary[], todayDay: number): SpineEvent[] =>
+  rows
+    .filter((lease) => lease.ends_on != null)
+    .map((lease) => {
+      const day = dayOf(lease.ends_on as string);
+      return {
+        id: `lease-${lease.id}`,
+        day,
+        kind: 'lease-end' as const,
+        label: `Lease ends · ${lease.unit_label ?? lease.property_label}`,
+        detail: lease.residents.join(', '),
+        money: lease.rent,
+        projected: day > todayDay,
+        faint: false,
+      };
+    });
+
+const capexEvents = (
+  forecast: CapexForecastOut | null | undefined,
+  todayDay: number,
+): SpineEvent[] =>
+  (forecast?.bands ?? [])
+    // A zero median is the simulation saying "probably nothing" — noise here.
+    .filter((band) => Number(band.p50) !== 0)
+    .map((band) => ({
+      id: `capex-${band.year}`,
+      day: todayDay + Math.round((band.year - 0.5) * AVERAGE_YEAR_DAYS),
+      kind: 'capex' as const,
+      label: `Capex median · year ${band.year}`,
+      detail: `p10 ${band.p10} · p90 ${band.p90}, Weibull over the component inventory`,
+      money: band.p50,
+      projected: true,
+      faint: false,
+    }));
+
+const debtEvents = (rows: Financials['debts'], todayDay: number): SpineEvent[] =>
+  rows.flatMap((debt, index) => {
+    const remaining = debt.term_months - debt.months_elapsed;
+    if (remaining <= 0) {
+      return [];
+    }
+    return [
+      {
+        id: `debt-${index}-${debt.lender}`,
+        day: todayDay + Math.round(remaining * AVERAGE_MONTH_DAYS),
+        kind: 'debt' as const,
+        label: `Note matures · ${debt.lender}`,
+        detail: `≈ ${remaining} payments remain on ${debt.original_principal}`,
+        projected: true,
+        faint: false,
+      },
+    ];
+  });
+
+export function buildSpine(inputs: SpineInputs): SpineEvent[] {
+  const todayDay = dayOf(inputs.today);
+  return [
+    ...ledgerEvents(inputs.ledger ?? [], todayDay),
+    ...deadlineEvents(inputs.deadlines ?? [], todayDay),
+    ...leaseEvents(inputs.leases ?? [], todayDay),
+    ...capexEvents(inputs.capex, todayDay),
+    ...debtEvents(inputs.debts ?? [], todayDay),
+  ].sort((a, b) => a.day - b.day || a.id.localeCompare(b.id));
+}
+
+/** Events whose mark or window touches the view. */
+export function visibleEvents(events: readonly SpineEvent[], window: SpineWindow): SpineEvent[] {
+  return events.filter(
+    (event) =>
+      (event.day >= window.startDay && event.day <= window.endDay) ||
+      (event.spanStart !== undefined &&
+        event.spanStart <= window.endDay &&
+        event.day >= window.startDay),
+  );
+}
+
+/**
+ * Greedy lane assignment: marks closer than `gapDays` climb to the next of
+ * three lanes rather than overprint — a ledger is legible or it is wrong.
+ */
+export function layoutSpine(
+  events: readonly SpineEvent[],
+  gapDays: number,
+): (SpineEvent & { lane: number })[] {
+  const lastDayPerLane: number[] = [];
+  return events.map((event) => {
+    let lane = 0;
+    while (lane < lastDayPerLane.length) {
+      const last = lastDayPerLane[lane] as number;
+      if (event.day - last >= gapDays) {
+        break;
+      }
+      lane += 1;
+    }
+    const bounded = lane % 3;
+    if (lane < 3) {
+      lastDayPerLane[lane] = event.day;
+    } else {
+      lastDayPerLane[bounded] = event.day;
+    }
+    return { ...event, lane: bounded };
+  });
+}

--- a/apps/web/tests/timeline-spine.test.tsx
+++ b/apps/web/tests/timeline-spine.test.tsx
@@ -1,0 +1,199 @@
+import { dayOf } from '@hestia/design';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TimelineSpine } from '../src/components/TimelineSpine';
+import type { SpineEvent } from '../src/lib/timeline';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// jsdom has no PointerEvent; without one, fired pointer events carry no
+// clientX and the drag math would see NaN instead of a coordinate.
+if (typeof window.PointerEvent === 'undefined') {
+  window.PointerEvent = class extends MouseEvent {} as typeof PointerEvent;
+}
+
+const TODAY = '2026-08-27';
+const TODAY_DAY = dayOf(TODAY);
+
+const EVENTS: readonly SpineEvent[] = [
+  {
+    id: 'rent',
+    day: TODAY_DAY - 30,
+    kind: 'ledger',
+    label: 'August rent',
+    detail: 'Unit 1 rent received',
+    money: '1450.00',
+    projected: false,
+    faint: false,
+  },
+  {
+    id: 'reversal',
+    day: TODAY_DAY - 20,
+    kind: 'ledger',
+    label: 'Reversed entry',
+    detail: 'entered twice',
+    money: '-90.00',
+    projected: false,
+    faint: true,
+  },
+  {
+    id: 'tax',
+    day: TODAY_DAY + 35,
+    spanStart: TODAY_DAY + 5,
+    kind: 'deadline',
+    label: 'Property Tax Due',
+    detail: '516 Overton St',
+    citation: 'KRS 134.015',
+    projected: true,
+    faint: false,
+  },
+  {
+    id: 'lease',
+    day: TODAY_DAY + 120,
+    kind: 'lease-end',
+    label: 'Lease ends · Unit 1',
+    detail: 'A. Renter',
+    money: '1450.00',
+    projected: true,
+    faint: false,
+  },
+  {
+    id: 'capex-1',
+    day: TODAY_DAY + 183,
+    kind: 'capex',
+    label: 'Capex median · year 1',
+    detail: 'p10 0.00 · p90 3200.00',
+    money: '850.00',
+    projected: true,
+    faint: false,
+  },
+  {
+    id: 'note',
+    day: TODAY_DAY + 400,
+    kind: 'debt',
+    label: 'Note matures · Heavy Lender',
+    detail: '≈ 330 payments remain',
+    projected: true,
+    faint: false,
+  },
+];
+
+const renderSpine = (props: Partial<Parameters<typeof TimelineSpine>[0]> = {}) =>
+  render(<TimelineSpine events={EVENTS} today={TODAY} ariaLabel="Test spine" {...props} />);
+
+const surface = () => screen.getByRole('application');
+
+describe('TimelineSpine', () => {
+  it('draws the datum, every kind of mark, spans, and honest stems', () => {
+    const { container } = renderSpine();
+    expect(container.querySelector('.chart__datum')).not.toBeNull();
+    expect(container.querySelector('.chart__plumb')).not.toBeNull();
+    expect(container.querySelectorAll('.chart__mark--deadline')).toHaveLength(1);
+    expect(container.querySelectorAll('.chart__mark--lease')).toHaveLength(1);
+    expect(container.querySelectorAll('.chart__mark--capex')).toHaveLength(1);
+    expect(container.querySelectorAll('.chart__mark--debt')).toHaveLength(1);
+    expect(container.querySelectorAll('.chart__mark--faint')).toHaveLength(1);
+    expect(container.querySelector('.chart__span')).not.toBeNull();
+    expect(container.querySelectorAll('.chart__stem--projected').length).toBeGreaterThan(0);
+    expect(screen.getByRole('img', { name: 'Test spine' }).getAttribute('viewBox')).toBe(
+      '0 0 680 158',
+    );
+  });
+
+  it('widens for full-page use', () => {
+    renderSpine({ wide: true });
+    expect(screen.getByRole('img', { name: 'Test spine' }).getAttribute('viewBox')).toBe(
+      '0 0 1080 158',
+    );
+  });
+
+  it('opens a mark into its detail, toggles it closed, and closes on demand', () => {
+    renderSpine();
+    const tax = screen.getByRole('button', { name: /deadline: Property Tax Due/ });
+    fireEvent.click(tax);
+    expect(screen.getByText('KRS 134.015').className).toBe('citation-chip');
+    expect(screen.getByText(/window opens/)).toBeDefined();
+    fireEvent.click(tax);
+    expect(screen.queryByText('KRS 134.015')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /ledger: August rent/ }));
+    expect(screen.getByText(/\$1,450\.00/)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByText(/Unit 1 rent received/)).toBeNull();
+
+    // A moneyless, citationless event renders its detail plainly.
+    fireEvent.click(screen.getByRole('button', { name: /note maturity: Note matures/ }));
+    expect(screen.getByText(/330 payments remain/)).toBeDefined();
+    expect(document.querySelector('.citation-chip')).toBeNull();
+  });
+
+  it('pans with the arrows, a year with shift, and returns home on T', () => {
+    renderSpine();
+    const before = screen.getByText('TODAY');
+    expect(before).toBeDefined();
+    fireEvent.keyDown(surface(), { key: 'ArrowRight', shiftKey: true });
+    fireEvent.keyDown(surface(), { key: 'ArrowRight', shiftKey: true });
+    // Two years right: today has left the window, the datum with it.
+    expect(screen.queryByText('TODAY')).toBeNull();
+    fireEvent.keyDown(surface(), { key: 't' });
+    expect(screen.getByText('TODAY')).toBeDefined();
+    fireEvent.keyDown(surface(), { key: 'ArrowLeft' });
+    expect(screen.getByText('TODAY')).toBeDefined();
+    fireEvent.keyDown(surface(), { key: 'x' });
+    expect(screen.getByText('TODAY')).toBeDefined();
+  });
+
+  it('pans by drag using the real surface width when the browser reports one', () => {
+    renderSpine();
+    const pane = surface();
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
+      width: 915,
+      height: 200,
+      top: 0,
+      left: 0,
+      right: 915,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    fireEvent.pointerDown(pane, { clientX: 500 });
+    fireEvent.pointerMove(pane, { clientX: 100 });
+    // 400px left over 915px of a 915-day window ≈ 400 days into the future.
+    expect(screen.queryByText('TODAY')).toBeNull();
+    fireEvent.pointerUp(pane);
+    fireEvent.pointerMove(pane, { clientX: 900 });
+    expect(screen.queryByText('TODAY')).toBeNull();
+  });
+
+  it('falls back to the view width for drag math when the rect is empty', () => {
+    renderSpine();
+    const pane = surface();
+    fireEvent.pointerDown(pane, { clientX: 400 });
+    fireEvent.pointerMove(pane, { clientX: 100 });
+    expect(screen.queryByText('TODAY')).toBeNull();
+    fireEvent.pointerLeave(pane);
+    fireEvent.pointerMove(pane, { clientX: 0 });
+  });
+
+  it('pans on horizontal wheel and shifted vertical wheel, ignoring plain scroll', () => {
+    renderSpine();
+    const pane = surface();
+    fireEvent.wheel(pane, { deltaX: 3000, deltaY: 0 });
+    expect(screen.queryByText('TODAY')).toBeNull();
+    fireEvent.keyDown(pane, { key: 'T' });
+    fireEvent.wheel(pane, { deltaY: 3000, shiftKey: true });
+    expect(screen.queryByText('TODAY')).toBeNull();
+    fireEvent.keyDown(pane, { key: 'T' });
+    fireEvent.wheel(pane, { deltaY: 3000 });
+    expect(screen.getByText('TODAY')).toBeDefined();
+  });
+
+  it('says so, honestly, when the window holds nothing', () => {
+    render(<TimelineSpine events={[]} today={TODAY} ariaLabel="Empty spine" />);
+    expect(screen.getByText(/Nothing recorded or due in this window/)).toBeDefined();
+  });
+});

--- a/apps/web/tests/timeline.test.ts
+++ b/apps/web/tests/timeline.test.ts
@@ -1,0 +1,260 @@
+import { dayOf } from '@hestia/design';
+import { describe, expect, it } from 'vitest';
+import type {
+  CapexForecastOut,
+  DeadlineOut,
+  Financials,
+  LeaseSummary,
+  LedgerEventOut,
+} from '../src/lib/api';
+import {
+  buildSpine,
+  layoutSpine,
+  panned,
+  type SpineEvent,
+  visibleEvents,
+  windowAround,
+} from '../src/lib/timeline';
+
+const TODAY = '2026-08-27';
+const TODAY_DAY = dayOf(TODAY);
+
+const ledger = (overrides: Partial<LedgerEventOut>): LedgerEventOut => ({
+  event_uuid: 'e1',
+  occurred_on: '2026-08-14',
+  recorded_at: '2026-08-14T12:00:00Z',
+  category: 'repairs',
+  amount: '-380.00',
+  memo: 'water heater relief valve',
+  counterparty: 'NKY Plumbing',
+  is_capital: null,
+  capitalisation_rationale: null,
+  property_id: 'p1',
+  unit_id: null,
+  lease_id: null,
+  entity_id: null,
+  reverses_event_uuid: null,
+  reversed: false,
+  ...overrides,
+});
+
+const deadline = (overrides: Partial<DeadlineOut>): DeadlineOut => ({
+  id: 'd1',
+  kind: 'property_tax_due',
+  due_on: '2026-10-01',
+  window_opens_on: null,
+  citation: 'KRS 134.015',
+  note: null,
+  property_label: '516 Overton St',
+  status: 'open',
+  ...overrides,
+});
+
+const lease = (overrides: Partial<LeaseSummary>): LeaseSummary => ({
+  id: 'l1',
+  property_label: '516 Overton St',
+  unit_label: 'Unit 1',
+  residents: ['A. Renter'],
+  rent: '1450.00',
+  starts_on: '2026-04-01',
+  ends_on: '2027-03-31',
+  status: 'active',
+  balance_due: '0.00',
+  open_credit: '0.00',
+  ...overrides,
+});
+
+const capex: CapexForecastOut = {
+  property_id: 'p1',
+  horizon_years: 2,
+  components_simulated: 4,
+  components_without_cost: [],
+  bands: [
+    { year: 1, expected: '900.00', p10: '0.00', p50: '0.00', p90: '3200.00' },
+    { year: 2, expected: '1400.00', p10: '0.00', p50: '850.00', p90: '4100.00' },
+  ],
+  total_expected: '2300.00',
+};
+
+const debts: Financials['debts'] = [
+  {
+    lender: 'Heavy Lender',
+    original_principal: '190000.00',
+    annual_rate: '0.0625',
+    term_months: 360,
+    months_elapsed: 30,
+  },
+  {
+    lender: 'Paid Off',
+    original_principal: '10000.00',
+    annual_rate: '0.05',
+    term_months: 60,
+    months_elapsed: 60,
+  },
+];
+
+describe('windowAround / panned', () => {
+  it('opens a year of record and eighteen months of horizon, and pans whole', () => {
+    const window = windowAround(TODAY_DAY);
+    expect(window).toEqual({ startDay: TODAY_DAY - 365, endDay: TODAY_DAY + 550 });
+    expect(panned(window, 31)).toEqual({
+      startDay: TODAY_DAY - 334,
+      endDay: TODAY_DAY + 581,
+    });
+  });
+});
+
+describe('buildSpine', () => {
+  it('is empty on empty inputs', () => {
+    expect(buildSpine({ today: TODAY })).toEqual([]);
+  });
+
+  it('turns ledger rows into past marks, keeping reversals at reduced ink', () => {
+    const events = buildSpine({
+      today: TODAY,
+      ledger: [
+        ledger({}),
+        ledger({ event_uuid: 'e2', counterparty: null, memo: null, reversed: true }),
+      ],
+    });
+    expect(events).toHaveLength(2);
+    const [named, anonymous] = events as [SpineEvent, SpineEvent];
+    expect(named.label).toBe('NKY Plumbing');
+    expect(named.detail).toBe('water heater relief valve');
+    expect(named.money).toBe('-380.00');
+    expect(named.projected).toBe(false);
+    expect(named.faint).toBe(false);
+    expect(anonymous.label).toBe('Repairs');
+    expect(anonymous.detail).toBe('Repairs');
+    expect(anonymous.faint).toBe(true);
+  });
+
+  it('marks deadlines with their windows and authorities, skipping the settled', () => {
+    const events = buildSpine({
+      today: TODAY,
+      deadlines: [
+        deadline({ window_opens_on: '2026-09-01' }),
+        deadline({ id: 'd2', status: 'done' }),
+        deadline({ id: 'd3', status: 'dismissed' }),
+        deadline({
+          id: 'd4',
+          citation: null,
+          note: 'inspection window',
+          property_label: null,
+          due_on: '2026-07-01',
+        }),
+      ],
+    });
+    expect(events).toHaveLength(2);
+    const [past, future] = events as [SpineEvent, SpineEvent];
+    expect(future.spanStart).toBe(dayOf('2026-09-01'));
+    expect(future.citation).toBe('KRS 134.015');
+    expect(future.detail).toBe('516 Overton St');
+    expect(future.projected).toBe(true);
+    expect(past.citation).toBeUndefined();
+    expect(past.detail).toBe('inspection window');
+    expect(past.projected).toBe(false);
+  });
+
+  it('falls back to portfolio-wide when a deadline names nothing', () => {
+    const events = buildSpine({
+      today: TODAY,
+      deadlines: [deadline({ note: null, property_label: null })],
+    });
+    expect((events[0] as SpineEvent).detail).toBe('portfolio-wide');
+  });
+
+  it('marks lease ends by unit, skipping leases without one', () => {
+    const events = buildSpine({
+      today: TODAY,
+      leases: [
+        lease({}),
+        lease({ id: 'l2', ends_on: null }),
+        lease({ id: 'l3', unit_label: null, residents: ['B', 'C'] }),
+      ],
+    });
+    expect(events).toHaveLength(2);
+    expect((events[0] as SpineEvent).label).toBe('Lease ends · Unit 1');
+    expect((events[0] as SpineEvent).money).toBe('1450.00');
+    expect((events[1] as SpineEvent).label).toBe('Lease ends · 516 Overton St');
+    expect((events[1] as SpineEvent).detail).toBe('B, C');
+  });
+
+  it('marks nonzero capex medians at each forward mid-year', () => {
+    const events = buildSpine({ today: TODAY, capex });
+    expect(events).toHaveLength(1);
+    const mark = events[0] as SpineEvent;
+    expect(mark.id).toBe('capex-2');
+    expect(mark.day).toBe(TODAY_DAY + Math.round(1.5 * 365.25));
+    expect(mark.money).toBe('850.00');
+    expect(mark.projected).toBe(true);
+    expect(buildSpine({ today: TODAY, capex: null })).toEqual([]);
+  });
+
+  it('projects note maturity from remaining term, skipping retired notes', () => {
+    const events = buildSpine({ today: TODAY, debts });
+    expect(events).toHaveLength(1);
+    const note = events[0] as SpineEvent;
+    expect(note.label).toBe('Note matures · Heavy Lender');
+    expect(note.day).toBe(TODAY_DAY + Math.round(330 * 30.44));
+    expect(note.detail).toContain('330 payments remain');
+  });
+
+  it('sorts by day with a stable id tiebreak', () => {
+    const events = buildSpine({
+      today: TODAY,
+      ledger: [
+        ledger({ event_uuid: 'z-later', occurred_on: '2026-08-14' }),
+        ledger({ event_uuid: 'a-first', occurred_on: '2026-08-14' }),
+        ledger({ event_uuid: 'm-early', occurred_on: '2026-01-02' }),
+      ],
+    });
+    expect(events.map((event) => event.id)).toEqual(['m-early', 'a-first', 'z-later']);
+  });
+});
+
+describe('visibleEvents', () => {
+  const window = { startDay: 100, endDay: 200 };
+  const at = (day: number, spanStart?: number): SpineEvent => ({
+    id: `at-${day}`,
+    day,
+    ...(spanStart === undefined ? {} : { spanStart }),
+    kind: 'deadline',
+    label: '',
+    detail: '',
+    projected: false,
+    faint: false,
+  });
+
+  it('keeps marks inside the window and windows that reach into it', () => {
+    expect(visibleEvents([at(150)], window)).toHaveLength(1);
+    expect(visibleEvents([at(99)], window)).toHaveLength(0);
+    expect(visibleEvents([at(201)], window)).toHaveLength(0);
+    // Due beyond the view, but its open window reaches in: visible.
+    expect(visibleEvents([at(250, 180)], window)).toHaveLength(1);
+    // Whole span before the view: not visible.
+    expect(visibleEvents([at(90, 60)], window)).toHaveLength(0);
+  });
+});
+
+describe('layoutSpine', () => {
+  const at = (day: number, id: string): SpineEvent => ({
+    id,
+    day,
+    kind: 'ledger',
+    label: '',
+    detail: '',
+    projected: false,
+    faint: false,
+  });
+
+  it('spreads crowded marks across three lanes and spills back to the first', () => {
+    const laid = layoutSpine([at(10, 'a'), at(11, 'b'), at(12, 'c'), at(13, 'd')], 5);
+    expect(laid.map((event) => event.lane)).toEqual([0, 1, 2, 0]);
+  });
+
+  it('returns to the ground lane once the gap clears', () => {
+    const laid = layoutSpine([at(10, 'a'), at(11, 'b'), at(40, 'c')], 5);
+    expect(laid.map((event) => event.lane)).toEqual([0, 1, 0]);
+  });
+});

--- a/docs/decisions/0002-equivalent-mutants.md
+++ b/docs/decisions/0002-equivalent-mutants.md
@@ -95,3 +95,9 @@ The chart geometry joins the engines' bar. Its survivors:
   `last + step/2`): accumulated tick values approximate multiples of the
   step; exact equality with a half-step offset cannot occur.
 - `contrast` — the sRGB linearization threshold, documented above.
+
+The time-axis day arithmetic (`days.ts`) joined at 100% after two redundant
+guards were removed rather than documented: the round-trip month check (a
+month-only drift cannot occur — month overflow rolls the year, day overflow
+rolls the day) and the January label slot (a January tick is major and says
+its year, so the month name was unreachable).

--- a/packages/design/src/charts/Datum.tsx
+++ b/packages/design/src/charts/Datum.tsx
@@ -1,0 +1,27 @@
+/**
+ * The datum: today as a fixed vertical rule with a plumb-bob diamond at its
+ * head. Everything left of it is fact in solid ink; everything right is
+ * projection, dashed — the one orientation mark every time surface shares.
+ */
+type DatumProps = {
+  x: number;
+  top: number;
+  bottom: number;
+  label?: string;
+};
+
+export function Datum({ x, top, bottom, label = 'TODAY' }: DatumProps) {
+  const head = top + 5;
+  return (
+    <g>
+      <line className="chart__datum" x1={x} x2={x} y1={top + 8} y2={bottom} />
+      <path
+        className="chart__plumb"
+        d={`M${x} ${head + 6} L${x - 4} ${head} L${x} ${head - 6} L${x + 4} ${head} Z`}
+      />
+      <text className="chart__datum-label" x={x + 7} y={head + 3}>
+        {label}
+      </text>
+    </g>
+  );
+}

--- a/packages/design/src/charts/TimeAxis.tsx
+++ b/packages/design/src/charts/TimeAxis.tsx
@@ -1,0 +1,38 @@
+import type { TimeTick } from './days.js';
+import type { Scale } from './scale.js';
+
+/**
+ * The horizontal time axis: one baseline, month ticks in the usual ink,
+ * year ticks heavier — the surveyor's ruled edge every time surface
+ * hangs its marks on.
+ */
+type TimeAxisProps = {
+  ticks: readonly TimeTick[];
+  x: Scale;
+  /** Baseline y in view units. */
+  y: number;
+  /** Left and right extent of the baseline. */
+  from: number;
+  to: number;
+};
+
+export function TimeAxis({ ticks, x, y, from, to }: TimeAxisProps) {
+  return (
+    <g>
+      <line className="chart__axis-line" x1={from} x2={to} y1={y} y2={y} />
+      {ticks.map((tick) => (
+        <g key={tick.day}>
+          <line className="chart__tick" x1={x(tick.day)} x2={x(tick.day)} y1={y} y2={y + 5} />
+          <text
+            className={tick.major ? 'chart__axis chart__axis--major' : 'chart__axis'}
+            x={x(tick.day)}
+            y={y + 16}
+            textAnchor="middle"
+          >
+            {tick.label}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+}

--- a/packages/design/src/charts/charts.test.tsx
+++ b/packages/design/src/charts/charts.test.tsx
@@ -2,8 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BalanceCurve } from './BalanceCurve.js';
 import { ChartFrame } from './ChartFrame.js';
+import { Datum } from './Datum.js';
 import { FanChart } from './FanChart.js';
 import { Sparkline } from './Sparkline.js';
+import { linearScale } from './scale.js';
+import { TimeAxis } from './TimeAxis.js';
 
 describe('ChartFrame', () => {
   it('is a named image with the chart class', () => {
@@ -119,5 +122,48 @@ describe('BalanceCurve', () => {
     );
     expect(screen.getByText('5')).toBeDefined();
     expect(container.querySelector('.chart__line.trace')).not.toBeNull();
+  });
+});
+
+describe('TimeAxis', () => {
+  it('draws the baseline and one tick per boundary, years heavier', () => {
+    const ticks = [
+      { day: 100, label: 'Feb', major: false },
+      { day: 130, label: '1971', major: true },
+    ];
+    const { container } = render(
+      <svg role="img" aria-label="axis under test">
+        <TimeAxis ticks={ticks} x={linearScale(90, 140, 0, 500)} y={80} from={0} to={500} />
+      </svg>,
+    );
+    expect(container.querySelector('.chart__axis-line')?.getAttribute('x2')).toBe('500');
+    expect(container.querySelectorAll('.chart__tick')).toHaveLength(2);
+    expect(screen.getByText('Feb').getAttribute('class')).toBe('chart__axis');
+    expect(screen.getByText('1971').getAttribute('class')).toBe('chart__axis chart__axis--major');
+    expect(screen.getByText('Feb').getAttribute('x')).toBe('100');
+  });
+});
+
+describe('Datum', () => {
+  it('drops the plumb line with its diamond and default label', () => {
+    const { container } = render(
+      <svg role="img" aria-label="datum under test">
+        <Datum x={250} top={10} bottom={120} />
+      </svg>,
+    );
+    const rule = container.querySelector('.chart__datum');
+    expect(rule?.getAttribute('x1')).toBe('250');
+    expect(rule?.getAttribute('y2')).toBe('120');
+    expect(container.querySelector('.chart__plumb')).not.toBeNull();
+    expect(screen.getByText('TODAY').getAttribute('class')).toBe('chart__datum-label');
+  });
+
+  it('takes a caller label', () => {
+    render(
+      <svg role="img" aria-label="datum labeled">
+        <Datum x={10} top={0} bottom={50} label="AS OF" />
+      </svg>,
+    );
+    expect(screen.getByText('AS OF')).toBeDefined();
   });
 });

--- a/packages/design/src/charts/days.test.ts
+++ b/packages/design/src/charts/days.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { dayOf, isoOf, timeTicks } from './days.js';
+
+const tickShape = (tick: { day: number; label: string; major: boolean }) =>
+  `${isoOf(tick.day)} ${tick.label}${tick.major ? ' *' : ''}`;
+
+describe('dayOf / isoOf', () => {
+  it('counts whole days from the epoch and round-trips', () => {
+    expect(dayOf('1970-01-01')).toBe(0);
+    expect(dayOf('1970-01-02')).toBe(1);
+    for (const iso of ['2026-08-27', '2024-02-29', '1999-12-31']) {
+      expect(isoOf(dayOf(iso))).toBe(iso);
+    }
+  });
+
+  it('knows a leap year from a common one', () => {
+    expect(dayOf('2024-03-01') - dayOf('2024-02-28')).toBe(2);
+    expect(dayOf('2026-03-01') - dayOf('2026-02-28')).toBe(1);
+  });
+
+  it('refuses malformed and impossible dates by name', () => {
+    expect(() => dayOf('2026-2-05')).toThrow('not a date-only ISO string: 2026-2-05');
+    // Day overflow (day drifts) and month overflow (year drifts) each refused.
+    expect(() => dayOf('2026-02-30')).toThrow('not a real calendar date: 2026-02-30');
+    expect(() => dayOf('2026-13-01')).toThrow(RangeError);
+    expect(() => dayOf('garbage')).toThrow(RangeError);
+    // The pattern is anchored at both ends: prefix and suffix junk is
+    // refused AS MALFORMED — never half-parsed into a calendar complaint.
+    expect(() => dayOf('x1970-01-01')).toThrow('not a date-only ISO string: x1970-01-01');
+    expect(() => dayOf('1970-01-011')).toThrow('not a date-only ISO string: 1970-01-011');
+    expect(() => isoOf(1.5)).toThrow('day numbers are whole days, got 1.5');
+  });
+});
+
+describe('timeTicks', () => {
+  it('marks every month across a short span, January as the year', () => {
+    const ticks = timeTicks(dayOf('2026-11-15'), dayOf('2027-02-10'));
+    expect(ticks.map(tickShape)).toEqual(['2026-12-01 Dec', '2027-01-01 2027 *', '2027-02-01 Feb']);
+  });
+
+  it('includes a boundary the span starts on, and none it merely grazes', () => {
+    const ticks = timeTicks(dayOf('2026-11-01'), dayOf('2026-12-02'));
+    expect(ticks.map(tickShape)).toEqual(['2026-11-01 Nov', '2026-12-01 Dec']);
+    // A start ONE day later must not claim the November boundary.
+    const later = timeTicks(dayOf('2026-11-02'), dayOf('2026-12-02'));
+    expect(later.map(tickShape)).toEqual(['2026-12-01 Dec']);
+    // A span ENDING exactly on a boundary keeps that tick.
+    const flush = timeTicks(dayOf('2026-11-15'), dayOf('2027-02-01'));
+    expect(flush.map(tickShape)).toEqual(['2026-12-01 Dec', '2027-01-01 2027 *', '2027-02-01 Feb']);
+  });
+
+  it('names every month of a spring-to-autumn walk', () => {
+    const ticks = timeTicks(dayOf('2027-02-15'), dayOf('2027-10-02'));
+    expect(ticks.map((tick) => tick.label)).toEqual([
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+    ]);
+  });
+
+  it('thins to aligned quarters on a multi-year span', () => {
+    const ticks = timeTicks(dayOf('2026-02-15'), dayOf('2028-08-01'));
+    expect(ticks.map(tickShape)).toEqual([
+      '2026-04-01 Apr',
+      '2026-07-01 Jul',
+      '2026-10-01 Oct',
+      '2027-01-01 2027 *',
+      '2027-04-01 Apr',
+      '2027-07-01 Jul',
+      '2027-10-01 Oct',
+      '2028-01-01 2028 *',
+      '2028-04-01 Apr',
+      '2028-07-01 Jul',
+    ]);
+  });
+
+  it('thins to Januaries alone on a decade', () => {
+    const ticks = timeTicks(dayOf('2026-06-01'), dayOf('2036-01-05'));
+    expect(ticks).toHaveLength(10);
+    expect(ticks.every((tick) => tick.major)).toBe(true);
+    expect(ticks.map((tick) => tick.label)).toEqual([
+      '2027',
+      '2028',
+      '2029',
+      '2030',
+      '2031',
+      '2032',
+      '2033',
+      '2034',
+      '2035',
+      '2036',
+    ]);
+  });
+
+  it('switches density exactly at the documented spans', () => {
+    // 800 days of months vs 801 of quarters, from an epoch January 1st.
+    expect(timeTicks(0, 800).length).toBe(27);
+    expect(timeTicks(0, 801).length).toBe(9);
+    // 2400 days of quarters vs 2401 of years.
+    expect(timeTicks(0, 2400).length).toBe(27);
+    expect(timeTicks(0, 2401).length).toBe(7);
+  });
+
+  it('refuses fractional and disordered bounds', () => {
+    expect(() => timeTicks(0.5, 10)).toThrow('tick bounds are whole days, got 0.5..10');
+    expect(() => timeTicks(10, 10)).toThrow('tick bounds must be ordered, got 10..10');
+    expect(() => timeTicks(11, 10)).toThrow(RangeError);
+  });
+});

--- a/packages/design/src/charts/days.ts
+++ b/packages/design/src/charts/days.ts
@@ -1,0 +1,89 @@
+/**
+ * Calendar-day arithmetic for time axes. Dates on the spine are date-only
+ * ISO strings; positioning math runs on whole days since the epoch (UTC),
+ * so no operator timezone can shift a mark. Rendering a date for a HUMAN
+ * is the app's business (its formatter is operator-local, deliberately).
+ */
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const MS_PER_DAY = 86_400_000;
+
+/** 'YYYY-MM-DD' → whole days since the epoch. Rejects malformed and
+ * impossible dates — 2026-02-30 is a lie, not a coordinate. */
+export function dayOf(iso: string): number {
+  if (!DATE_ONLY.test(iso)) {
+    throw new RangeError(`not a date-only ISO string: ${iso}`);
+  }
+  const year = Number(iso.slice(0, 4));
+  const month = Number(iso.slice(5, 7));
+  const day = Number(iso.slice(8, 10));
+  const ms = Date.UTC(year, month - 1, day);
+  const roundTrip = new Date(ms);
+  // Date.UTC normalizes lies instead of refusing them. Year and day drift
+  // between them catch every normalization: a month overflow rolls the
+  // year, and a day overflow rolls the day — a month-only drift cannot
+  // occur, so checking it would be a redundant guard.
+  if (roundTrip.getUTCFullYear() !== year || roundTrip.getUTCDate() !== day) {
+    throw new RangeError(`not a real calendar date: ${iso}`);
+  }
+  return ms / MS_PER_DAY;
+}
+
+/** Whole days since the epoch → 'YYYY-MM-DD'. */
+export function isoOf(day: number): string {
+  if (!Number.isInteger(day)) {
+    throw new RangeError(`day numbers are whole days, got ${day}`);
+  }
+  return new Date(day * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+export type TimeTick = {
+  day: number;
+  /** Month ticks say 'Feb'; January and year-mode ticks say the year. */
+  label: string;
+  /** True where the label is a year — the axis renders these heavier. */
+  major: boolean;
+};
+
+// January never appears here — a January tick is major and says its year.
+const MONTHS = ['Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * Month boundaries across [startDay, endDay], thinned by span: every month
+ * to ~2.2 years, quarters to ~6.5 years, then Januaries alone.
+ */
+export function timeTicks(startDay: number, endDay: number): TimeTick[] {
+  if (!Number.isInteger(startDay) || !Number.isInteger(endDay)) {
+    throw new RangeError(`tick bounds are whole days, got ${startDay}..${endDay}`);
+  }
+  if (endDay <= startDay) {
+    throw new RangeError(`tick bounds must be ordered, got ${startDay}..${endDay}`);
+  }
+  const span = endDay - startDay;
+  const stepMonths = span <= 800 ? 1 : span <= 2400 ? 3 : 12;
+  const start = new Date(startDay * MS_PER_DAY);
+  const firstMonth = start.getUTCFullYear() * 12 + start.getUTCMonth();
+  // The first boundary at or after the start, aligned to the step so
+  // quarter ticks land on Jan/Apr/Jul/Oct and year ticks on January.
+  let monthIndex = Math.ceil(firstMonth / stepMonths) * stepMonths;
+  if (monthIndex === firstMonth && start.getUTCDate() > 1) {
+    monthIndex += stepMonths;
+  }
+  const ticks: TimeTick[] = [];
+  for (;;) {
+    const year = Math.floor(monthIndex / 12);
+    const month = monthIndex % 12;
+    const day = Date.UTC(year, month, 1) / MS_PER_DAY;
+    if (day > endDay) {
+      break;
+    }
+    const major = month === 0;
+    ticks.push({
+      day,
+      label: major ? String(year) : (MONTHS[month - 1] as string),
+      major,
+    });
+    monthIndex += stepMonths;
+  }
+  return ticks;
+}

--- a/packages/design/src/css/charts.css
+++ b/packages/design/src/css/charts.css
@@ -52,6 +52,85 @@
     font-size: 9px;
   }
 
+  .chart__axis--major {
+    fill: var(--ink);
+    font-weight: 600;
+  }
+
+  /* ---- the time surface: axis, datum, marks ---- */
+
+  .chart__axis-line {
+    stroke: var(--graphite);
+    stroke-width: 1.5;
+  }
+
+  .chart__tick {
+    stroke: var(--line);
+    stroke-width: 1;
+  }
+
+  .chart__datum {
+    stroke: var(--ember);
+    stroke-width: 2;
+  }
+
+  .chart__plumb {
+    fill: var(--ember);
+  }
+
+  .chart__datum-label {
+    fill: var(--ember);
+    font-family: var(--mono);
+    font-size: 8px;
+    letter-spacing: var(--track-label);
+  }
+
+  /* Stems hang a mark from the axis; a projected stem is dashed —
+     the stroke-style law again. */
+  .chart__stem {
+    stroke: var(--line);
+    stroke-width: 1;
+  }
+
+  .chart__stem--projected {
+    stroke-dasharray: 3 3;
+  }
+
+  /* Marks: past facts in ink; the future wears its kind. */
+  .chart__mark {
+    fill: var(--ink);
+  }
+
+  .chart__mark--deadline {
+    fill: var(--ember);
+  }
+
+  .chart__mark--lease {
+    fill: var(--fern);
+  }
+
+  .chart__mark--capex {
+    fill: none;
+    stroke: var(--graphite);
+    stroke-width: 1.5;
+  }
+
+  .chart__mark--debt {
+    fill: var(--umber);
+  }
+
+  .chart__mark--faint {
+    opacity: 0.4;
+  }
+
+  /* A deadline's open window: the span you can aim at, drawn dashed. */
+  .chart__span {
+    stroke: var(--ember);
+    stroke-width: 3;
+    stroke-dasharray: 5 4;
+    opacity: 0.5;
+  }
+
   .chart__spark {
     fill: none;
     stroke: var(--ember);

--- a/packages/design/src/css/patterns.css
+++ b/packages/design/src/css/patterns.css
@@ -59,4 +59,87 @@
   .decision .disclosure {
     margin-top: var(--space-3);
   }
+
+  /* ---- the timeline spine ---- */
+
+  /* The plat: a whisper-faint survey grid under the marks. */
+  .spine__surface {
+    position: relative;
+    background:
+      repeating-linear-gradient(to right, transparent 0 23px, var(--line-soft) 23px 24px),
+      repeating-linear-gradient(to bottom, transparent 0 23px, var(--line-soft) 23px 24px),
+      var(--surface);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-lg);
+    cursor: grab;
+    touch-action: pan-y;
+  }
+
+  .spine__surface:active {
+    cursor: grabbing;
+  }
+
+  .spine__surface:focus-visible {
+    outline: var(--focus-outline);
+    outline-offset: 2px;
+  }
+
+  .spine__hit {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    transform: translate(-50%, 0);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .spine__hit:focus-visible {
+    outline: var(--focus-outline);
+    border-radius: var(--radius-full);
+  }
+
+  .spine__empty {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    margin: 0;
+  }
+
+  .spine__legend {
+    margin: var(--space-2) 0 0;
+    font-size: var(--type-label);
+  }
+
+  .spine__legend-ember {
+    color: var(--ember);
+  }
+
+  .spine__legend-fern {
+    color: var(--fern);
+  }
+
+  .spine__legend-graphite {
+    color: var(--graphite);
+  }
+
+  .spine__legend-umber {
+    color: var(--umber);
+  }
+
+  .spine__detail {
+    margin-top: var(--space-3);
+  }
+
+  .spine__detail-head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+  }
+
+  .spine__detail-head .button {
+    margin-left: auto;
+  }
 }

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -1,10 +1,13 @@
 export { BalanceCurve, type CurvePoint } from './charts/BalanceCurve.js';
 export { ChartFrame } from './charts/ChartFrame.js';
+export { Datum } from './charts/Datum.js';
+export { dayOf, isoOf, type TimeTick, timeTicks } from './charts/days.js';
 export { type FanBand, FanChart } from './charts/FanChart.js';
 export { type HatchKind, type HatchTile, hatchTile } from './charts/hatch.js';
 export { areaPath, linePath, type Point, stepPath } from './charts/path.js';
 export { Sparkline } from './charts/Sparkline.js';
 export { linearScale, type Scale } from './charts/scale.js';
+export { TimeAxis } from './charts/TimeAxis.js';
 export { niceTicks } from './charts/ticks.js';
 export { contrastRatio, relativeLuminance } from './contrast.js';
 export { cx } from './cx.js';


### PR DESCRIPTION
Closes #15.

Today is the datum — an ember rule with a plumb-bob diamond. Ledger left in solid ink, projections right in dashes: deadlines with their open windows drawn as aimable spans, lease ends, Weibull capex medians, note maturities. Every mark is a real button opening its grounded detail (date, figure, authority chip).

- `@hestia/design`: UTC day arithmetic + adaptive month/quarter/year ticks (`days.ts`, 100% mutation — two redundant guards removed rather than documented, ADR 0002), `TimeAxis`, `Datum`, the time-surface ink, and the plat-grid spine pattern.
- `apps/web`: pure `lib/timeline.ts` (five sources → positioned events, greedy three-lane collision layout) under `TimelineSpine` (drag/wheel/keyboard pan, T for today, role=application). The dossier carries the spine at its head; `/calendar` becomes it full-width.
- 259 package tests + 142 web tests, 100% line/branch, design mutation 98.54% (five argued equivalents). All six e2e smoke tests pass against the live stack, including new spine assertions; the mark→detail loop verified by hand in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)