### PR TITLE
G1: close the C1/D1 review findings

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -2364,7 +2364,10 @@ export interface components {
         VendorIn: {
             /** Email */
             email?: string | null;
-            /** Entity Id */
+            /**
+             * Entity Id
+             * Format: uuid
+             */
             entity_id: string;
             /** Insurer */
             insurer?: string | null;
@@ -2464,7 +2467,10 @@ export interface components {
              * @enum {string}
              */
             priority: "emergency" | "urgent" | "routine" | "planned";
-            /** Property Id */
+            /**
+             * Property Id
+             * Format: uuid
+             */
             property_id: string;
             /**
              * Reported By

--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -777,6 +777,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/vendors/{vendor_id}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Renew Vendor Credentials */
+        post: operations["renew_vendor_credentials_vendors__vendor_id__credentials_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/work-orders": {
         parameters: {
             query?: never;
@@ -1187,17 +1204,17 @@ export interface components {
         /**
          * CostLinkIn
          * @description Either a new cost to post, or an existing ledger event to associate.
+         *
+         *     A posted cost carries its own relation; this one describes the LINK to an
+         *     event that already exists. Setting both said two different things about
+         *     one row and silently kept one of them, so it is refused instead.
          */
         CostLinkIn: {
             cost?: components["schemas"]["CostIn"] | null;
             /** Ledger Event Uuid */
             ledger_event_uuid?: string | null;
-            /**
-             * Relation
-             * @default invoice
-             * @enum {string}
-             */
-            relation: "invoice" | "materials" | "deposit" | "tenant_chargeback" | "warranty_credit" | "other";
+            /** Relation */
+            relation?: ("invoice" | "materials" | "deposit" | "tenant_chargeback" | "warranty_credit" | "other") | null;
         };
         /** CostOut */
         CostOut: {
@@ -1263,6 +1280,26 @@ export interface components {
             gaps: components["schemas"]["CoverageGapOut"][];
             /** Properties */
             properties: components["schemas"]["PropertyCoverage"][];
+        };
+        /**
+         * CredentialsIn
+         * @description A renewal. Certificates expire every year, so recording the new dates
+         *     has to be possible without inventing a second vendor — the unique name
+         *     per entity made re-adding impossible, and there was no other door.
+         */
+        CredentialsIn: {
+            /** Insurer */
+            insurer?: string | null;
+            /** Liability Expires On */
+            liability_expires_on?: string | null;
+            /** License Expires On */
+            license_expires_on?: string | null;
+            /** License Number */
+            license_number?: string | null;
+            /** W9 On File */
+            w9_on_file?: boolean | null;
+            /** Workers Comp Expires On */
+            workers_comp_expires_on?: string | null;
         };
         /** DeadlineOut */
         DeadlineOut: {
@@ -4245,6 +4282,43 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VendorOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    renew_vendor_credentials_vendors__vendor_id__credentials_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                vendor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CredentialsIn"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -1003,6 +1003,7 @@
           "document_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -1081,6 +1082,7 @@
           "ledger_event_uuid": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -3906,6 +3908,7 @@
           "component_type_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -3917,10 +3920,11 @@
           "expected_life_years": {
             "anyOf": [
               {
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,3}|(?=[\\d.]{1,6}0*$)\\d{0,3}\\.\\d{0,2}0*$)",
                 "type": "string"
               },
               {
@@ -3955,10 +3959,11 @@
           "quantity": {
             "anyOf": [
               {
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,8}|(?=[\\d.]{1,11}0*$)\\d{0,8}\\.\\d{0,2}0*$)",
                 "type": "string"
               },
               {
@@ -3970,10 +3975,11 @@
           "replacement_cost": {
             "anyOf": [
               {
+                "minimum": 0.0,
                 "type": "number"
               },
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
                 "type": "string"
               },
               {
@@ -4628,6 +4634,7 @@
           "vendor_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -4807,6 +4814,7 @@
             "title": "Email"
           },
           "entity_id": {
+            "format": "uuid",
             "title": "Entity Id",
             "type": "string"
           },
@@ -5161,6 +5169,7 @@
           "component_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -5192,6 +5201,7 @@
             "type": "string"
           },
           "property_id": {
+            "format": "uuid",
             "title": "Property Id",
             "type": "string"
           },
@@ -5227,6 +5237,7 @@
           "unit_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -5238,6 +5249,7 @@
           "vendor_id": {
             "anyOf": [
               {
+                "format": "uuid",
                 "type": "string"
               },
               {

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -1067,7 +1067,7 @@
         "type": "object"
       },
       "CostLinkIn": {
-        "description": "Either a new cost to post, or an existing ledger event to associate.",
+        "description": "Either a new cost to post, or an existing ledger event to associate.\n\nA posted cost carries its own relation; this one describes the LINK to an\nevent that already exists. Setting both said two different things about\none row and silently kept one of them, so it is refused instead.",
         "properties": {
           "cost": {
             "anyOf": [
@@ -1092,17 +1092,23 @@
             "title": "Ledger Event Uuid"
           },
           "relation": {
-            "default": "invoice",
-            "enum": [
-              "invoice",
-              "materials",
-              "deposit",
-              "tenant_chargeback",
-              "warranty_credit",
-              "other"
+            "anyOf": [
+              {
+                "enum": [
+                  "invoice",
+                  "materials",
+                  "deposit",
+                  "tenant_chargeback",
+                  "warranty_credit",
+                  "other"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "title": "Relation",
-            "type": "string"
+            "title": "Relation"
           }
         },
         "title": "CostLinkIn",
@@ -1274,6 +1280,82 @@
           "gaps"
         ],
         "title": "CoverageReport",
+        "type": "object"
+      },
+      "CredentialsIn": {
+        "description": "A renewal. Certificates expire every year, so recording the new dates\nhas to be possible without inventing a second vendor \u2014 the unique name\nper entity made re-adding impossible, and there was no other door.",
+        "properties": {
+          "insurer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Insurer"
+          },
+          "liability_expires_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Liability Expires On"
+          },
+          "license_expires_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License Expires On"
+          },
+          "license_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License Number"
+          },
+          "w9_on_file": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "W9 On File"
+          },
+          "workers_comp_expires_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workers Comp Expires On"
+          }
+        },
+        "title": "CredentialsIn",
         "type": "object"
       },
       "DeadlineOut": {
@@ -8205,6 +8287,66 @@
           }
         },
         "summary": "Read Vendor"
+      }
+    },
+    "/vendors/{vendor_id}/credentials": {
+      "post": {
+        "operationId": "renew_vendor_credentials_vendors__vendor_id__credentials_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vendor_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Vendor Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialsIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VendorOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Renew Vendor Credentials"
       }
     },
     "/work-orders": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -15,3 +15,4 @@
 \ir 014_review_hardening.sql
 \ir 015_document_extraction.sql
 \ir 016_maintenance.sql
+\ir 017_replacement_history.sql

--- a/packages/domain/schema/017_replacement_history.sql
+++ b/packages/domain/schema/017_replacement_history.sql
@@ -1,0 +1,79 @@
+-- ===========================================================================
+--  017 — A completed replacement never stops naming what it replaced.
+--
+--  016 gave work_orders.component_id ON DELETE SET NULL, column-listed, so a
+--  deleted component leaves the job alive at its property. That is right for
+--  every order but the one kind that cannot survive it: a COMPLETED
+--  replacement, where `replaced_orders_name_the_component` makes component_id
+--  NOT NULL. Deleting such a component ran the SET NULL, the CHECK refused the
+--  updated row, and the delete aborted quoting a table nobody had touched:
+--
+--    ERROR: new row for relation "work_orders" violates check constraint
+--           "replaced_orders_name_the_component"
+--
+--  Both obvious repairs are wrong. Relaxing the CHECK for completed orders
+--  relaxes it for every replacement there can ever be -- a replacement is
+--  completed by definition (`only_completed_orders_resolve`) -- so the rule
+--  would evaporate and a completion could claim it replaced something without
+--  ever saying what. Widening the foreign key to ON DELETE RESTRICT protects
+--  the replacement but also freezes the ordinary case 016 chose and the
+--  assertion suite already proves: an open ticket outliving the component it
+--  named.
+--
+--  So the rule goes where the lie is. Not on the delete -- on the write that
+--  would make a finished job untrue. A completed replacement is the authority
+--  for its new component's KNOWN install date: the forecast stops guessing
+--  about that component because this job says what came out and what went in.
+--  Erase either end and a derived fact is left citing nothing. Both pointers
+--  are therefore frozen once the order is completed as a replacement, and the
+--  refusal names the component and says what to do instead -- components are
+--  RETIRED (`retired_on`), never deleted, which is what 002 has said about a
+--  replaced component since the inventory existed.
+--
+--  Deleting the whole property still works, and that is the reason this guard
+--  lives on work_orders rather than on components: the job is cascaded away in
+--  the same statement, so there is no surviving history to falsify and nothing
+--  to refuse. A BEFORE DELETE trigger on components cannot tell the two apart
+--  -- it fires while the work order is still there -- and would make every
+--  property that ever had a replacement undeletable.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION refuse_rewriting_a_replacement() RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION
+    'work order % completed as a replacement on % and must keep naming component % and its installed replacement %; retire the component (components.retired_on) rather than deleting it',
+    OLD.id, OLD.completed_on, OLD.component_id, OLD.replacement_component_id
+    USING ERRCODE = 'restrict_violation',
+          CONSTRAINT = 'replacements_keep_naming_their_components';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION refuse_rewriting_a_replacement() IS
+  'The completion is the provenance of the new component''s install date. A '
+  'job that no longer names what it took out, or names a different thing as '
+  'what it put in, is a maintenance history that reads true and is not.';
+
+-- The WHEN clause IS the rule: no branch inside the function, so there is no
+-- path through it that does anything but refuse.
+CREATE TRIGGER work_orders_replacements_are_frozen
+  BEFORE UPDATE OF component_id, replacement_component_id ON work_orders
+  FOR EACH ROW
+  WHEN (OLD.resolution = 'replaced'
+        AND (NEW.component_id IS DISTINCT FROM OLD.component_id
+             OR NEW.replacement_component_id IS DISTINCT FROM OLD.replacement_component_id))
+  EXECUTE FUNCTION refuse_rewriting_a_replacement();
+
+COMMENT ON TRIGGER work_orders_replacements_are_frozen ON work_orders IS
+  'Refuses by the name replacements_keep_naming_their_components. It fires on '
+  'the referential SET NULL that a component delete performs, which is how '
+  'deleting a replaced component is refused without also freezing the open '
+  'ticket whose component may legitimately disappear.';
+
+-- The installed component was already protected, by the plain (NO ACTION)
+-- foreign key 016 declared on replacement_component_id: deleting it raises a
+-- foreign_key_violation that names itself honestly. Recorded here because an
+-- unasserted referential action is one refactor away from becoming SET NULL.
+COMMENT ON CONSTRAINT work_orders_replacement_component_id_fkey ON work_orders IS
+  'NO ACTION on purpose. The component a completion installed is the subject '
+  'of the KNOWN install date that completion created; it is retired, never '
+  'deleted, and the delete is refused rather than quietly unlinked.';

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -822,8 +822,9 @@ SELECT assert_rejected(
   'completed_orders_say_when',
   'completed work with no completion date');
 SELECT assert_rejected(
-  $$INSERT INTO work_orders (property_id, summary, status, completed_on)
-    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', 'completed', '2026-08-27')$$,
+  $$INSERT INTO work_orders (property_id, summary, reported_on, status, completed_on)
+    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', '2026-08-01',
+            'completed', '2026-08-27')$$,
   'completed_orders_say_how',
   'completed work that will not say what happened');
 SELECT assert_rejected(
@@ -839,25 +840,27 @@ SELECT assert_rejected(
 -- Isolated to ONE rule at a time: this order installs something, so only the
 -- missing `component_id` can be what refuses it.
 SELECT assert_rejected(
-  $$INSERT INTO work_orders (property_id, summary, status, completed_on, resolution,
-                             replacement_component_id)
-    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', 'completed',
-            '2026-08-27', 'replaced', '88888888-8888-4888-8888-888888888801')$$,
+  $$INSERT INTO work_orders (property_id, summary, reported_on, status, completed_on,
+                             resolution, replacement_component_id)
+    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', '2026-08-01',
+            'completed', '2026-08-27', 'replaced',
+            '88888888-8888-4888-8888-888888888801')$$,
   'replaced_orders_name_the_component',
   'a replacement that will not say what was replaced');
 SELECT assert_rejected(
-  $$INSERT INTO work_orders (property_id, summary, status, completed_on, resolution,
-                             replacement_component_id)
-    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', 'completed',
-            '2026-08-27', 'repaired', '88888888-8888-4888-8888-888888888801')$$,
+  $$INSERT INTO work_orders (property_id, summary, reported_on, status, completed_on,
+                             resolution, replacement_component_id)
+    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', '2026-08-01',
+            'completed', '2026-08-27', 'repaired',
+            '88888888-8888-4888-8888-888888888801')$$,
   'replacements_belong_to_replaced_orders',
   'a new component installed by a repair that replaced nothing');
 SELECT assert_rejected(
-  $$INSERT INTO work_orders (property_id, component_id, summary, status, completed_on,
-                             resolution)
+  $$INSERT INTO work_orders (property_id, component_id, summary, reported_on, status,
+                             completed_on, resolution)
     VALUES ('33333333-3333-3333-3333-333333333333',
-            '88888888-8888-4888-8888-888888888801', 'No hot water', 'completed',
-            '2026-08-27', 'replaced')$$,
+            '88888888-8888-4888-8888-888888888801', 'No hot water', '2026-08-01',
+            'completed', '2026-08-27', 'replaced')$$,
   'replaced_orders_install_a_component',
   'a replacement that installed nothing');
 SELECT assert_rejected(
@@ -905,6 +908,77 @@ BEGIN
       survivor.component_id, survivor.property_id;
   END IF;
   RAISE NOTICE '  ok      the job outlived the component it named';
+END $$;
+
+-- ...but a COMPLETED REPLACEMENT is the authority for the new component's
+-- KNOWN install date, so both of its pointers are frozen. Deleting what it
+-- replaced would run the same SET NULL and leave a finished job claiming a
+-- replacement of nothing.
+INSERT INTO components (id, property_id, component_type_id, installed_year_low,
+                        installed_year_high, provenance_id)
+  VALUES ('88888888-8888-4888-8888-888888888807', '33333333-3333-3333-3333-333333333333',
+          '44444444-4444-4444-4444-444444444444', 1998, 2004,
+          '22222222-2222-2222-2222-222222222222');
+INSERT INTO components (id, property_id, component_type_id, installed_on, provenance_id)
+  VALUES ('88888888-8888-4888-8888-888888888808', '33333333-3333-3333-3333-333333333333',
+          '44444444-4444-4444-4444-444444444444', '2026-08-02',
+          '22222222-2222-2222-2222-222222222222');
+INSERT INTO work_orders (id, property_id, component_id, summary, reported_on, status,
+                         completed_on, resolution, replacement_component_id)
+  VALUES ('88888888-8888-4888-8888-888888888809', '33333333-3333-3333-3333-333333333333',
+          '88888888-8888-4888-8888-888888888807', 'Water heater replaced', '2026-08-01',
+          'completed', '2026-08-02', 'replaced', '88888888-8888-4888-8888-888888888808');
+SELECT assert_rejected(
+  $$DELETE FROM components WHERE id = '88888888-8888-4888-8888-888888888807'$$,
+  'replacements_keep_naming_their_components',
+  'deleting the component a completed replacement replaced');
+SELECT assert_rejected(
+  $$UPDATE work_orders SET component_id = NULL
+    WHERE id = '88888888-8888-4888-8888-888888888809'$$,
+  'replacements_keep_naming_their_components',
+  'unlinking a completed replacement from what it replaced');
+SELECT assert_rejected(
+  $$UPDATE work_orders
+    SET replacement_component_id = '88888888-8888-4888-8888-888888888801'
+    WHERE id = '88888888-8888-4888-8888-888888888809'$$,
+  'replacements_keep_naming_their_components',
+  'rewriting which component a completed replacement installed');
+SELECT assert_rejected(
+  $$DELETE FROM components WHERE id = '88888888-8888-4888-8888-888888888808'$$,
+  'work_orders_replacement_component_id_fkey',
+  'deleting the component a completed replacement installed');
+SELECT assert_accepted(
+  $$UPDATE work_orders SET resolution_note = 'gas valve seized'
+    WHERE id = '88888888-8888-4888-8888-888888888809'$$,
+  'an unrelated edit to a completed replacement');
+-- The freeze must not make the property undeletable: the job is cascaded away
+-- in the same statement, so no history survives to be falsified. A guard on
+-- components instead of work_orders would refuse this delete.
+INSERT INTO properties (id, entity_id, label, street_1, city, state, postal_code, kind)
+  VALUES ('88888888-8888-4888-8888-888888888810', '11111111-1111-1111-1111-111111111111',
+          'Sold On', '3 Sold On Way', 'Newport', 'KY', '41071', 'single_family');
+INSERT INTO components (id, property_id, component_type_id, installed_year_low,
+                        installed_year_high, provenance_id)
+  VALUES ('88888888-8888-4888-8888-888888888811', '88888888-8888-4888-8888-888888888810',
+          '44444444-4444-4444-4444-444444444444', 1998, 2004,
+          '22222222-2222-2222-2222-222222222222');
+INSERT INTO components (id, property_id, component_type_id, installed_on, provenance_id)
+  VALUES ('88888888-8888-4888-8888-888888888812', '88888888-8888-4888-8888-888888888810',
+          '44444444-4444-4444-4444-444444444444', '2026-08-02',
+          '22222222-2222-2222-2222-222222222222');
+INSERT INTO work_orders (id, property_id, component_id, summary, reported_on, status,
+                         completed_on, resolution, replacement_component_id)
+  VALUES ('88888888-8888-4888-8888-888888888813', '88888888-8888-4888-8888-888888888810',
+          '88888888-8888-4888-8888-888888888811', 'Replaced, then sold', '2026-08-01',
+          'completed', '2026-08-02', 'replaced', '88888888-8888-4888-8888-888888888812');
+DELETE FROM properties WHERE id = '88888888-8888-4888-8888-888888888810';
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM work_orders
+             WHERE id = '88888888-8888-4888-8888-888888888813') THEN
+    RAISE EXCEPTION 'CASCADE DID NOT FIRE: a work order outlived its property';
+  END IF;
+  RAISE NOTICE '  ok      a property with a completed replacement is still deletable';
 END $$;
 
 -- Two vendors expiring on one day are two deadlines, not one.

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -869,6 +869,12 @@ SELECT assert_rejected(
             'completed', '2026-08-01', 'repaired')$$,
   'completed_after_reported',
   'work completed before it was reported');
+SELECT assert_rejected(
+  $$INSERT INTO work_orders (property_id, summary, reported_on, status, scheduled_for)
+    VALUES ('33333333-3333-3333-3333-333333333333', 'No hot water', '2026-08-27',
+            'scheduled', '2026-08-01')$$,
+  'scheduled_after_reported',
+  'a visit scheduled before the job was reported');
 -- A unit of another property cannot be named by this property's work order.
 INSERT INTO properties (id, entity_id, label, street_1, city, state, postal_code, kind)
   VALUES ('88888888-8888-4888-8888-888888888803', '11111111-1111-1111-1111-111111111111',

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -1542,12 +1542,19 @@ def transition_work_order(
         work_order = maintenance.transition(conn, str(work_order_id), body)
     except maintenance.UnknownWorkOrder as error:
         raise HTTPException(status_code=404, detail="work order not found") from error
+    except maintenance.UnknownVendor as error:
+        raise HTTPException(status_code=404, detail="vendor not found") from error
     except maintenance.IllegalTransition as error:
         raise HTTPException(status_code=409, detail=str(error)) from error
     except psycopg.errors.CheckViolation as error:
+        # Name the rule that actually fired: three constraints reach this UPDATE
+        # and one message for all of them hid which line the request crossed.
         raise HTTPException(
             status_code=422,
-            detail="a scheduled visit needs a date and a cancellation needs a reason",
+            detail=maintenance.TRANSITION_REFUSALS.get(
+                error.diag.constraint_name or "",
+                "a work-order rule refused that transition",
+            ),
         ) from error
     db.record_audit(
         conn,
@@ -1588,6 +1595,8 @@ def complete_work_order(
             status_code=422,
             detail="a replacement must name the component it replaced",
         ) from error
+    except maintenance.UnknownDocument as error:
+        raise HTTPException(status_code=404, detail="document not found") from error
     except maintenance.CapitalNeedsRationale as error:
         raise HTTPException(
             status_code=422, detail=f"capital spending explains itself: {error}"
@@ -1624,6 +1633,8 @@ def add_work_order_cost(
         raise HTTPException(status_code=404, detail="work order not found") from error
     except ledger.UnknownEvent as error:
         raise HTTPException(status_code=404, detail="ledger event not found") from error
+    except maintenance.UnknownDocument as error:
+        raise HTTPException(status_code=404, detail="document not found") from error
     except maintenance.WrongProperty as error:
         raise HTTPException(
             status_code=422, detail="that ledger event belongs to another property"

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -1481,6 +1481,34 @@ def read_vendor(
         raise HTTPException(status_code=404, detail="vendor not found") from error
 
 
+@app.post("/vendors/{vendor_id}/credentials", response_model=maintenance.VendorOut)
+def renew_vendor_credentials(
+    vendor_id: uuid.UUID,
+    body: maintenance.CredentialsIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> maintenance.VendorOut:
+    try:
+        vendor = maintenance.renew_credentials(conn, str(vendor_id), body, as_of=dt.date.today())
+    except maintenance.UnknownVendor as error:
+        raise HTTPException(status_code=404, detail="vendor not found") from error
+    except maintenance.NothingToRenew as error:
+        raise HTTPException(
+            status_code=422, detail="a renewal has to name what was renewed"
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="vendors.renew_credentials",
+        request_id=request.state.request_id,
+        table_name="vendors",
+        record_id=str(vendor_id),
+        after_value={"coverage_state": vendor.coverage_state},
+    )
+    return vendor
+
+
 @app.post("/work-orders", response_model=maintenance.WorkOrderOut, status_code=201)
 def create_work_order(
     body: maintenance.WorkOrderIn, conn: Conn, request: Request, actor: Actor = "system"
@@ -1603,6 +1631,17 @@ def complete_work_order(
         ) from error
     except maintenance.IllegalTransition as error:
         raise HTTPException(status_code=422, detail=str(error)) from error
+    except psycopg.errors.CheckViolation as error:
+        # The completion writes to the inventory, so the inventory's own rules
+        # can refuse it — a replacement dated before the component it retires
+        # trips retired_after_installed. Name the rule that bit.
+        raise HTTPException(
+            status_code=422,
+            detail=maintenance.COMPLETION_REFUSALS.get(
+                error.diag.constraint_name or "",
+                f"the inventory refused this completion: {error.diag.constraint_name}",
+            ),
+        ) from error
     db.record_audit(
         conn,
         actor=actor,

--- a/services/api/hestia_api/documents.py
+++ b/services/api/hestia_api/documents.py
@@ -28,6 +28,10 @@ from hestia_api import ledger as ledger_module
 Conn = psycopg.Connection[dict[str, Any]]
 
 CENT = Decimal("0.01")
+# money_amount is NUMERIC(18, 2): sixteen digits before the point. A value
+# beyond it cannot be stored, so it is refused at the edge with a sentence
+# rather than at the database with a stack trace.
+MAX_MONEY = Decimal("9" * 16 + ".99")
 # Multipart reads the file into memory; refuse anything implausibly large for
 # a closing package before it gets there.
 MAX_BYTES = 25 * 1024 * 1024
@@ -384,6 +388,12 @@ def _canonicalise(datatype: str, value: str) -> str:
         # and make the document's own detail unrenderable.
         if not amount.is_finite():
             raise InvalidValue(f"not a money amount: {value!r}")
+        # quantize() raises InvalidOperation when the result needs more digits
+        # than the decimal context allows, so "1e30" reached the caller as a
+        # 500 rather than a refusal. The bound is the money_amount column's
+        # own precision, checked here instead of discovered in SQL.
+        if abs(amount) > MAX_MONEY:
+            raise InvalidValue(f"{value!r} exceeds the largest amount this records")
         return str(amount.quantize(CENT))
     if datatype == "date":
         normalised = extraction_parse.normalise_date(value)

--- a/services/api/hestia_api/documents.py
+++ b/services/api/hestia_api/documents.py
@@ -713,12 +713,21 @@ def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyR
         if current["status"] == "applied":
             raise AlreadyApplied(doc_id)
         raise NotConfirmed(current["status"])
+    # FOR UPDATE OF p, because the acquired_on / parcel_number decisions below
+    # are read-then-write: unlocked, two applies of two documents for the SAME
+    # property both read NULL, both write, and the second silently clobbers the
+    # fact the first recorded while BOTH report having set it. The lock makes
+    # the read a decision (the module-014 lesson, as in re_extract), and
+    # ORDER BY p.id fixes the lock order so a multi-property statement queues
+    # behind another instead of deadlocking with it.
     links = conn.execute(
         """
         SELECT p.id::text AS id, p.entity_id::text AS entity_id, p.acquired_on,
                p.parcel_number, p.label
         FROM document_properties dp JOIN properties p ON p.id = dp.property_id
         WHERE dp.document_id = %s
+        ORDER BY p.id
+        FOR UPDATE OF p
         """,
         (doc_id,),
     ).fetchall()
@@ -737,6 +746,15 @@ def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyR
     )
     if total_basis <= 0:
         raise InvalidAllocation(f"total basis {total_basis} is not a purchase")
+    # Each half fits money_amount; their SUM need not. price_allocations and the
+    # ledger event are both NUMERIC(18, 2), so an unbounded total reached the
+    # caller as a psycopg NumericValueOutOfRange 500 — after the gate above had
+    # already flipped the document to 'applied'. Refused here in a sentence,
+    # before anything is written, and the gate rolls back with the refusal.
+    if total_basis > MAX_MONEY:
+        raise InvalidAllocation(
+            f"total basis {total_basis} exceeds the largest amount this records"
+        )
     improvement = total_basis - body.land_value - body.personal_property
     if improvement < 0:
         raise InvalidAllocation(

--- a/services/api/hestia_api/extraction_parse.py
+++ b/services/api/hestia_api/extraction_parse.py
@@ -28,6 +28,10 @@ MODEL_ID = "deterministic/alta-v1"
 # and far below anything that hurts.
 MAX_PAGES = 200
 MAX_CONTENT_BYTES = 8 * 1024 * 1024
+# The line list is what actually lives in memory, and it is the one thing both
+# branches produce. A 200-page closing package runs to a few thousand lines;
+# this sits far above that and far below what would hurt.
+MAX_LINES = 50_000
 # One statement line is a label and an amount. Anything vastly longer is not
 # a line we can read, and scanning it is work an uploader chose for us.
 MAX_LINE_CHARS = 2_000
@@ -88,16 +92,33 @@ def extract_lines(content: bytes) -> list[tuple[int, str]]:
                 lines.extend(
                     (page_number, line) for line in (page.extract_text() or "").splitlines()
                 )
+                if len(lines) > MAX_LINES:
+                    raise UnreadableDocument(
+                        f"more than {MAX_LINES} text lines exceeds the extraction cap"
+                    )
             return lines
         except UnreadableDocument:
             raise
         except Exception as error:
             raise UnreadableDocument(f"PDF could not be read: {error}") from error
+    # The PDF branch bounds its work; this one bounded nothing at all, so an
+    # upload just under the byte cap decoded to a str and then to a list of
+    # str — hundreds of megabytes of objects, allocated inside the request's
+    # open transaction.
+    if len(content) > MAX_CONTENT_BYTES:
+        raise UnreadableDocument(
+            f"{len(content)} bytes of text exceeds the {MAX_CONTENT_BYTES}-byte extraction budget"
+        )
     try:
         text = content.decode("utf-8-sig")
     except UnicodeDecodeError as error:
         raise UnreadableDocument("neither a PDF nor UTF-8 text") from error
-    return [(1, line) for line in text.splitlines()]
+    lines = text.splitlines()
+    if len(lines) > MAX_LINES:
+        raise UnreadableDocument(
+            f"{len(lines)} text lines exceeds the {MAX_LINES}-line extraction cap"
+        )
+    return [(1, line) for line in lines]
 
 
 # The amount ending a charge line. ANCHORED AT THE AMOUNT on purpose: a

--- a/services/api/hestia_api/maintenance.py
+++ b/services/api/hestia_api/maintenance.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 from typing import Any, Literal
 
 import psycopg
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from hestia_api import ledger as ledger_module
 from hestia_api.reports import DE_MINIMIS_CENTS
@@ -104,6 +104,10 @@ class UnknownDocument(Exception):
 
 class DuplicateVendor(Exception):
     """One vendor name per owner's list."""
+
+
+class NothingToRenew(Exception):
+    """A renewal that names no field renews nothing."""
 
 
 class IllegalTransition(Exception):
@@ -268,6 +272,36 @@ def create_vendor(conn: Conn, body: VendorIn) -> VendorOut:
     except psycopg.errors.UniqueViolation as error:
         raise DuplicateVendor(body.name) from error
     return read_vendor(conn, row["id"], as_of=dt.date.today())
+
+
+class CredentialsIn(BaseModel):
+    """A renewal. Certificates expire every year, so recording the new dates
+    has to be possible without inventing a second vendor — the unique name
+    per entity made re-adding impossible, and there was no other door."""
+
+    license_number: str | None = None
+    license_expires_on: dt.date | None = None
+    insurer: str | None = None
+    liability_expires_on: dt.date | None = None
+    workers_comp_expires_on: dt.date | None = None
+    w9_on_file: bool | None = None
+
+
+def renew_credentials(
+    conn: Conn, vendor_id: str, body: CredentialsIn, *, as_of: dt.date
+) -> VendorOut:
+    """Only the fields supplied move; a renewal names what was renewed."""
+    supplied = body.model_dump(exclude_unset=True)
+    if not supplied:
+        raise NothingToRenew(vendor_id)
+    assignments = ", ".join(f"{column} = %({column})s" for column in supplied)
+    updated = conn.execute(
+        f"UPDATE vendors SET {assignments} WHERE id = %(vendor_id)s RETURNING id::text",  # noqa: S608 - columns come from the model's own field names, never the request
+        {**supplied, "vendor_id": vendor_id},
+    ).fetchone()
+    if updated is None:
+        raise UnknownVendor(vendor_id)
+    return read_vendor(conn, vendor_id, as_of=as_of)
 
 
 def read_vendor(conn: Conn, vendor_id: str, *, as_of: dt.date) -> VendorOut:
@@ -819,11 +853,22 @@ def complete(conn: Conn, work_order_id: str, body: CompletionIn, actor: str) -> 
 
 
 class CostLinkIn(BaseModel):
-    """Either a new cost to post, or an existing ledger event to associate."""
+    """Either a new cost to post, or an existing ledger event to associate.
+
+    A posted cost carries its own relation; this one describes the LINK to an
+    event that already exists. Setting both said two different things about
+    one row and silently kept one of them, so it is refused instead.
+    """
 
     cost: CostIn | None = None
     ledger_event_uuid: uuid.UUID | None = None
-    relation: CostRelation = "invoice"
+    relation: CostRelation | None = None
+
+    @model_validator(mode="after")
+    def one_relation_only(self) -> CostLinkIn:
+        if self.cost is not None and self.relation is not None:
+            raise ValueError("a posted cost carries its own relation; drop the outer one")
+        return self
 
 
 def add_cost(conn: Conn, work_order_id: str, body: CostLinkIn, actor: str) -> WorkOrderOut:
@@ -862,6 +907,6 @@ def add_cost(conn: Conn, work_order_id: str, body: CostLinkIn, actor: str) -> Wo
             VALUES (%s, %s, %s, %s)
             ON CONFLICT (work_order_id, ledger_event_id) DO NOTHING
             """,
-            (work_order_id, event["id"], body.relation, actor),
+            (work_order_id, event["id"], body.relation or "invoice", actor),
         )
     return read_work_order(conn, work_order_id)

--- a/services/api/hestia_api/maintenance.py
+++ b/services/api/hestia_api/maintenance.py
@@ -34,6 +34,16 @@ RESTORATION_CITATION = (
     "of property is a restoration; the building system is its own unit of "
     "property under 1.263(a)-3(e)(2)(ii)"
 )
+# The umbrella. Capitalisation has THREE routes — betterment, adaptation,
+# restoration — and this system only ever learns which one applies when the
+# job says it REPLACED something. Citing the restoration paragraph for a
+# repair the owner capitalised asserts a major component was replaced when
+# nobody said one was; the umbrella asserts only what the money did.
+IMPROVEMENT_CITATION = (
+    "Treas. Reg. 1.263(a)-3(d) — an amount paid to improve a unit of property is "
+    "capitalised; an improvement is a betterment (1.263(a)-3(j)), a restoration "
+    "(1.263(a)-3(k)), or an adaptation to a new or different use (1.263(a)-3(l))"
+)
 # DE_MINIMIS_CENTS is misnamed in reports.py — the value is DOLLARS
 # (Decimal("2500.00")). Imported rather than re-declared so this module and
 # the Schedule E classification flag can never disagree about the line.
@@ -58,6 +68,19 @@ LEGAL_TRANSITIONS: dict[str, frozenset[str]] = {
 }
 COMPLETABLE_FROM = frozenset({"reported", "triaged", "scheduled", "in_progress"})
 
+# WHICH rule said no, in the owner's words. One message covering every CHECK on
+# the table told an operator to supply a date when the DATE was the thing that
+# was wrong; only the constraint name knows which line was crossed.
+TRANSITION_REFUSALS: dict[str, str] = {
+    "scheduled_orders_carry_a_date": "a scheduled visit needs a date",
+    "cancelled_orders_say_why": "a cancellation needs a reason",
+    "scheduled_after_reported": "a visit cannot be scheduled before the job was reported",
+}
+# The inventory's own rules, for the completion that writes to it.
+COMPLETION_REFUSALS: dict[str, str] = {
+    "retired_after_installed": "a component cannot retire before it was installed",
+}
+
 
 class UnknownVendor(Exception):
     pass
@@ -73,6 +96,10 @@ class UnknownEntity(Exception):
 
 class UnknownProperty(Exception):
     pass
+
+
+class UnknownDocument(Exception):
+    """A cost may cite the receipt behind it, but only one that exists."""
 
 
 class DuplicateVendor(Exception):
@@ -417,9 +444,13 @@ class CompletionOut(BaseModel):
     capitalisation_citation: str | None
 
 
-def _bar_citation(is_capital: bool | None, amount: Decimal) -> str | None:
+def _bar_citation(is_capital: bool | None, amount: Decimal, resolution: Resolution) -> str | None:
     if is_capital is True:
-        return RESTORATION_CITATION
+        # Only a REPLACEMENT is a fact this system holds about a major
+        # component. A repair the owner capitalises may be a betterment or an
+        # adaptation; citing the restoration paragraph for it would assert
+        # something nobody said.
+        return RESTORATION_CITATION if resolution == "replaced" else IMPROVEMENT_CITATION
     if is_capital is False:
         # Treas. Reg. 1.263(a)-1(f)(1)(ii)(D) reads "does not exceed", so the
         # threshold itself is INSIDE the harbour. (Schedule E's
@@ -554,6 +585,14 @@ def transition(conn: Conn, work_order_id: str, body: TransitionIn) -> WorkOrderO
         raise UnknownWorkOrder(work_order_id)
     if body.status not in LEGAL_TRANSITIONS[current["status"]]:
         raise IllegalTransition(current["status"], body.status)
+    # A vendor assigned on the way through is a reference, and an unknown
+    # reference is a 404 -- not a foreign key violation reaching the client.
+    if body.vendor_id is not None:
+        vendor = conn.execute(
+            "SELECT id::text FROM vendors WHERE id = %s", (body.vendor_id,)
+        ).fetchone()
+        if vendor is None:
+            raise UnknownVendor(body.vendor_id)
     conn.execute(
         """
         UPDATE work_orders
@@ -577,6 +616,27 @@ INFLOW_CATEGORIES: dict[str, str] = {
     "warranty_credit": "repairs",  # a credit against the repair it refunds
 }
 
+# Only money that MEASURES the thing may become the thing's recorded value.
+# A deposit is a part payment, a chargeback and a credit are money coming
+# back, and 'other' says nothing at all — none of them is what the component
+# cost.
+INVOICE_LIKE_RELATIONS = frozenset({"invoice", "materials"})
+
+
+def _component_value(cost: CostIn | None) -> Decimal | None:
+    """What the installed component is worth, from the money on the completion.
+
+    components.replacement_cost is read by the capital forecast, so writing a
+    deposit there would tell every future projection the water heater cost
+    $400. When the money on the job does not measure the component, the column
+    is left unstated — which the forecast handles — rather than stated wrongly,
+    which it cannot. An explicit replacement.replacement_cost always wins over
+    this inference.
+    """
+    if cost is None or cost.relation not in INVOICE_LIKE_RELATIONS:
+        return None
+    return cost.amount
+
 
 def _post_cost(
     conn: Conn,
@@ -589,7 +649,18 @@ def _post_cost(
     """One ledger event, one association. The BAR answer is demanded before
     the money can be called capital."""
     if cost.is_capital is True and not (cost.capitalisation_rationale or "").strip():
-        raise CapitalNeedsRationale(RESTORATION_CITATION)
+        raise CapitalNeedsRationale(IMPROVEMENT_CITATION)
+    # The receipt behind the money has to exist, and it has to arrive as the
+    # TEXT the ledger's model declares: a bare UUID died in pydantic before the
+    # foreign key could even refuse it, and either way the client saw a 500.
+    document_id: str | None = None
+    if cost.document_id is not None:
+        document = conn.execute(
+            "SELECT id::text FROM source_documents WHERE id = %s", (cost.document_id,)
+        ).fetchone()
+        if document is None:
+            raise UnknownDocument(cost.document_id)
+        document_id = document["id"]
     inflow_category = INFLOW_CATEGORIES.get(cost.relation)
     if inflow_category is not None:
         # A credit is money coming back; it is definitionally not a capital
@@ -615,7 +686,7 @@ def _post_cost(
             capitalisation_rationale=rationale,
             property_id=work_order["property_id"],
             unit_id=work_order["unit_id"],
-            document_id=cost.document_id,
+            document_id=document_id,
         ),
     )
     conn.execute(
@@ -700,7 +771,7 @@ def complete(conn: Conn, work_order_id: str, body: CompletionIn, actor: str) -> 
                 spec.expected_life_years,
                 spec.replacement_cost
                 if spec.replacement_cost is not None
-                else (body.cost.amount if body.cost else None),
+                else _component_value(body.cost),
                 spec.notes,
             ),
         ).fetchone()
@@ -737,7 +808,7 @@ def complete(conn: Conn, work_order_id: str, body: CompletionIn, actor: str) -> 
             occurred_on=body.cost.occurred_on or body.completed_on,
             linked_by=actor,
         )
-        citation = _bar_citation(body.cost.is_capital, body.cost.amount)
+        citation = _bar_citation(body.cost.is_capital, body.cost.amount, body.resolution)
     return CompletionOut(
         work_order=read_work_order(conn, work_order_id),
         retired_component_id=retired_id,

--- a/services/api/hestia_api/maintenance.py
+++ b/services/api/hestia_api/maintenance.py
@@ -183,13 +183,19 @@ def _coverage_state(row: dict[str, Any], as_of: dt.date) -> tuple[str, dt.date |
     has not been shown to carry insurance, and saying otherwise would be the
     kind of quiet reassurance this system exists to refuse.
     """
-    dates = [
+    # INSURANCE decides the standing. A vendor with a trade licence and no
+    # certificate has shown a qualification, not coverage, and reporting that
+    # as 'current' is precisely the quiet reassurance this refuses to give.
+    insurance = [
         row[column]
-        for column in ("liability_expires_on", "workers_comp_expires_on", "license_expires_on")
+        for column in ("liability_expires_on", "workers_comp_expires_on")
         if row[column] is not None
     ]
-    if not dates:
-        return "unknown", None
+    if not insurance:
+        return "unknown", row["license_expires_on"]
+    dates = insurance + (
+        [row["license_expires_on"]] if row["license_expires_on"] is not None else []
+    )
     earliest = min(dates)
     if earliest < as_of:
         return "expired", earliest
@@ -410,7 +416,11 @@ def _bar_citation(is_capital: bool | None, amount: Decimal) -> str | None:
     if is_capital is True:
         return RESTORATION_CITATION
     if is_capital is False:
-        return DE_MINIMIS_CITATION if amount < DE_MINIMIS_CENTS else ROUTINE_MAINTENANCE_CITATION
+        # Treas. Reg. 1.263(a)-1(f)(1)(ii)(D) reads "does not exceed", so the
+        # threshold itself is INSIDE the harbour. (Schedule E's
+        # needs_classification flag fires at >= the same number on purpose:
+        # asking a human at the boundary is caution, not a contradiction.)
+        return DE_MINIMIS_CITATION if amount <= DE_MINIMIS_CENTS else ROUTINE_MAINTENANCE_CITATION
     return None
 
 
@@ -420,7 +430,15 @@ def _costs_for(conn: Conn, work_order_id: str) -> tuple[list[CostOut], Decimal]:
         SELECT e.event_uuid::text AS ledger_event_uuid, e.occurred_on, e.amount,
                e.category::text AS category, l.relation::text AS relation, e.is_capital,
                EXISTS (SELECT 1 FROM ledger_events r WHERE r.reverses_event_id = e.id)
-                 AS reversed
+                 AS reversed,
+               -- The reversal half of a correction pair is a SEPARATE event and
+               -- is not itself associated with the job, so the net has to reach
+               -- for it explicitly. Without this a mis-posted invoice that was
+               -- properly reversed still shows as money the job cost.
+               e.amount + coalesce(
+                 (SELECT sum(r.amount) FROM ledger_events r WHERE r.reverses_event_id = e.id),
+                 0
+               ) AS effective_amount
         FROM work_order_ledger_events l
         JOIN ledger_events e ON e.id = l.ledger_event_id
         WHERE l.work_order_id = %s
@@ -428,10 +446,10 @@ def _costs_for(conn: Conn, work_order_id: str) -> tuple[list[CostOut], Decimal]:
         """,
         (work_order_id,),
     ).fetchall()
-    costs = [CostOut(**row) for row in rows]
-    # Money OUT is negative in the ledger; a job's cost is the magnitude of the
-    # net outflow, and a reversal or credit legitimately reduces it.
-    net = -sum((cost.amount for cost in costs), Decimal("0"))
+    costs = [CostOut(**{key: row[key] for key in CostOut.model_fields}) for row in rows]
+    # Money OUT is negative in the ledger, so a job's cost is the magnitude of
+    # the net outflow: reversals cancel, and a credit genuinely reduces it.
+    net = -sum((row["effective_amount"] for row in rows), Decimal("0"))
     return costs, net
 
 
@@ -545,6 +563,16 @@ def transition(conn: Conn, work_order_id: str, body: TransitionIn) -> WorkOrderO
     return read_work_order(conn, work_order_id)
 
 
+# Not every dollar on a job flows the same way. A tenant reimbursing damage is
+# rental income; a warranty credit is money back against the repair. Posting
+# either as an outflow would overstate what the job cost AND misreport the
+# income on Schedule E.
+INFLOW_CATEGORIES: dict[str, str] = {
+    "tenant_chargeback": "other_income",
+    "warranty_credit": "repairs",  # a credit against the repair it refunds
+}
+
+
 def _post_cost(
     conn: Conn,
     *,
@@ -557,17 +585,29 @@ def _post_cost(
     the money can be called capital."""
     if cost.is_capital is True and not (cost.capitalisation_rationale or "").strip():
         raise CapitalNeedsRationale(RESTORATION_CITATION)
-    category = "capital_improvement" if cost.is_capital else "repairs"
+    inflow_category = INFLOW_CATEGORIES.get(cost.relation)
+    if inflow_category is not None:
+        # A credit is money coming back; it is definitionally not a capital
+        # election, so it never carries one.
+        category = inflow_category
+        amount = cost.amount
+        is_capital: bool | None = False
+        rationale: str | None = None
+    else:
+        category = "capital_improvement" if cost.is_capital else "repairs"
+        amount = -cost.amount
+        is_capital = cost.is_capital
+        rationale = cost.capitalisation_rationale
     event = ledger_module.append_event(
         conn,
         ledger_module.LedgerEntryIn(
             occurred_on=occurred_on,
             category=category,
-            amount=-cost.amount,  # money out
+            amount=amount,
             memo=cost.memo or work_order["summary"],
             counterparty=cost.counterparty or work_order["vendor_name"],
-            is_capital=cost.is_capital,
-            capitalisation_rationale=cost.capitalisation_rationale,
+            is_capital=is_capital,
+            capitalisation_rationale=rationale,
             property_id=work_order["property_id"],
             unit_id=work_order["unit_id"],
             document_id=cost.document_id,

--- a/services/api/hestia_api/maintenance.py
+++ b/services/api/hestia_api/maintenance.py
@@ -13,6 +13,7 @@ question that decides whether the money was an expense or basis.
 from __future__ import annotations
 
 import datetime as dt
+import uuid
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -128,7 +129,8 @@ VendorTrade = Literal[
 
 
 class VendorIn(BaseModel):
-    entity_id: str
+    # UUID-typed so a malformed id is a 422 at the edge, not a 500 in SQL.
+    entity_id: uuid.UUID
     name: str = Field(min_length=1, max_length=200)
     trade: VendorTrade
     phone: str | None = None
@@ -314,10 +316,10 @@ Reporter = Literal["resident", "owner", "inspection", "vendor"]
 
 
 class WorkOrderIn(BaseModel):
-    property_id: str
-    unit_id: str | None = None
-    component_id: str | None = None
-    vendor_id: str | None = None
+    property_id: uuid.UUID
+    unit_id: uuid.UUID | None = None
+    component_id: uuid.UUID | None = None
+    vendor_id: uuid.UUID | None = None
     summary: str = Field(min_length=1, max_length=400)
     detail: str | None = None
     priority: WorkOrderPriority = "routine"
@@ -328,7 +330,7 @@ class WorkOrderIn(BaseModel):
 class TransitionIn(BaseModel):
     status: Literal["triaged", "scheduled", "in_progress", "cancelled"]
     scheduled_for: dt.date | None = None
-    vendor_id: str | None = None
+    vendor_id: uuid.UUID | None = None
     cancelled_reason: str | None = None
 
 
@@ -343,16 +345,19 @@ class CostIn(BaseModel):
     capitalisation_rationale: str | None = None
     counterparty: str | None = None
     memo: str | None = None
-    document_id: str | None = None
+    document_id: uuid.UUID | None = None
 
 
 class ReplacementIn(BaseModel):
-    component_type_id: str | None = None  # defaults to the retired row's type
+    component_type_id: uuid.UUID | None = None  # defaults to the retired row's type
     installed_on: dt.date | None = None  # defaults to the completion date
-    quantity: Decimal | None = None
+    # Bounded to the columns these land in — components.quantity NUMERIC(10,2),
+    # expected_life_years NUMERIC(5,2), replacement_cost money_amount
+    # NUMERIC(18,2). Unbounded, they overflowed the column as a 500.
+    quantity: Decimal | None = Field(default=None, gt=0, decimal_places=2, max_digits=10)
     warranty_expires_on: dt.date | None = None
-    expected_life_years: Decimal | None = None
-    replacement_cost: Decimal | None = None
+    expected_life_years: Decimal | None = Field(default=None, gt=0, decimal_places=2, max_digits=5)
+    replacement_cost: Decimal | None = Field(default=None, ge=0, decimal_places=2, max_digits=18)
     notes: str | None = None
 
 
@@ -746,7 +751,7 @@ class CostLinkIn(BaseModel):
     """Either a new cost to post, or an existing ledger event to associate."""
 
     cost: CostIn | None = None
-    ledger_event_uuid: str | None = None
+    ledger_event_uuid: uuid.UUID | None = None
     relation: CostRelation = "invoice"
 
 

--- a/services/api/hestia_api/reports.py
+++ b/services/api/hestia_api/reports.py
@@ -180,6 +180,13 @@ def schedule_e(conn: Conn, property_id: str, tax_year: int) -> ScheduleEReport:
         """,
         (property_id, tax_year),
     ).fetchone()["total"]  # type: ignore[index]
+    # A correction PAIR is not an open tax question. The reversal half mirrors
+    # a charge and is never an independent one, and a reversed original nets to
+    # exactly zero (one_reversal_per_event, amount negated) — flagging either
+    # asks the owner, permanently, to characterise money that no longer exists.
+    # A corrected replacement is a fresh row that reverses nothing and is
+    # reversed by nothing, so it still surfaces on its own merits: this drops
+    # settled pairs, not live questions.
     flags = conn.execute(
         f"""
         SELECT e.event_uuid::text, e.occurred_on, e.memo, e.amount
@@ -190,6 +197,9 @@ def schedule_e(conn: Conn, property_id: str, tax_year: int) -> ScheduleEReport:
           AND e.category = 'repairs'
           AND e.is_capital IS NULL
           AND abs(e.amount) >= %(threshold)s
+          AND e.reverses_event_id IS NULL
+          AND NOT EXISTS (SELECT 1 FROM ledger_events r
+                          WHERE r.reverses_event_id = e.id)
         ORDER BY e.occurred_on
         """,  # noqa: S608 - PROPERTY_SCOPE is a module constant
         {"property_id": property_id, "year": tax_year, "threshold": DE_MINIMIS_CENTS},

--- a/services/api/tests/test_documents.py
+++ b/services/api/tests/test_documents.py
@@ -9,6 +9,7 @@ trailing PDF comment changes the hash without changing what parses.
 from __future__ import annotations
 
 import datetime as dt
+import threading
 import time
 from decimal import Decimal
 from pathlib import Path
@@ -587,6 +588,56 @@ class TestReviewFindings:
             )
         assert client.get(f"/documents/{doc_id}").json()["suggestion"]["address_matches"] is False
 
+    def test_a_racing_writer_is_not_clobbered_by_a_stale_apply(
+        self, newport_property: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """apply read the property's acquired_on and parcel_number and then
+        wrote back what it had read, unlocked: a writer that committed in
+        between lost its fact to the stale read, and the apply reported
+        having set a fact it had actually overwritten. The gate locks the
+        DOCUMENT, and two documents for one property have two gates — only a
+        lock on the property row makes the read a decision."""
+        detail = upload(client, newport_property, pdf_variant("fact-race"))
+        doc_id = detail["id"]
+        ratify(client, doc_id)
+        # Hold the property row the way a concurrent apply holds it, then let
+        # the request run into it.
+        conn.execute(
+            "SELECT acquired_on FROM properties WHERE id = %s FOR UPDATE",
+            (newport_property,),
+        )
+        outcome: dict[str, Any] = {}
+
+        def apply_against_the_lock() -> None:
+            outcome["response"] = client.post(
+                f"/documents/{doc_id}/apply", json={"land_value": "0.00"}
+            )
+
+        racer = threading.Thread(target=apply_against_the_lock)
+        racer.start()
+        time.sleep(0.5)  # long enough for the request to reach the property row
+        conn.execute(
+            "UPDATE properties SET acquired_on = '2018-01-01', parcel_number = 'OLD-1'"
+            " WHERE id = %s",
+            (newport_property,),
+        )
+        conn.commit()
+        racer.join(timeout=30)
+        assert not racer.is_alive()
+        response = outcome["response"]
+        assert response.status_code == 201, response.text
+        result = response.json()
+        # It waited, re-read, and left the recorded facts alone.
+        assert result["acquired_on_set"] is False
+        assert result["parcel_number_set"] is False
+        assert any("acquired_on already 2018-01-01" in note for note in result["notes"])
+        assert any("parcel_number already OLD-1" in note for note in result["notes"])
+        prop = conn.execute(
+            "SELECT acquired_on, parcel_number FROM properties WHERE id = %s",
+            (newport_property,),
+        ).fetchone()
+        assert prop == {"acquired_on": dt.date(2018, 1, 1), "parcel_number": "OLD-1"}
+
     def test_an_oversized_upload_is_refused_before_it_is_read(
         self,
         newport_property: str,
@@ -946,6 +997,39 @@ class TestApply:
         response = client.post(f"/documents/{doc_id}/apply", json={"land_value": "0.00"})
         assert response.status_code == 422
         assert "not a purchase" in response.json()["detail"]
+
+    def test_apply_refuses_a_basis_too_large_to_record(
+        self, newport_property: str, client: TestClient
+    ) -> None:
+        """Each half fits money_amount; their sum does not. price_allocations
+        and the ledger event are NUMERIC(18, 2), so the insert raised
+        NumericValueOutOfRange and it reached the caller as a 500 — after the
+        compare-and-set had already flipped the document to 'applied'. The
+        bound belongs at the edge, and the rollback that follows the refusal
+        must leave the document appliable."""
+        detail = upload(client, newport_property, pdf_variant("basis-overflow"))
+        doc_id = detail["id"]
+        review(client, doc_id, "settlement.closing_date", "accept")
+        review(client, doc_id, "settlement.property_address", "accept")
+        review(client, doc_id, "settlement.sale_price", "correct", "9999999999999999.99")
+        after = review(
+            client,
+            doc_id,
+            "settlement.capitalizable_closing_costs",
+            "correct",
+            "9999999999999999.99",
+        )
+        assert after["status"] == "confirmed"
+        response = client.post(f"/documents/{doc_id}/apply", json={"land_value": "0.00"})
+        assert response.status_code == 422
+        assert "exceeds the largest amount" in response.json()["detail"]
+        # The gate reset with the rollback: the record is not half-applied.
+        assert client.get(f"/documents/{doc_id}").json()["status"] == "confirmed"
+        review(client, doc_id, "settlement.sale_price", "correct", "187500.00")
+        review(client, doc_id, "settlement.capitalizable_closing_costs", "correct", "1783.00")
+        applied = client.post(f"/documents/{doc_id}/apply", json={"land_value": "0.00"})
+        assert applied.status_code == 201, applied.text
+        assert Decimal(applied.json()["total_basis"]) == Decimal("189283.00")
 
     def test_apply_refuses_multi_property_statements(
         self, newport_property: str, client: TestClient, conn: psycopg.Connection[Any]

--- a/services/api/tests/test_documents.py
+++ b/services/api/tests/test_documents.py
@@ -494,11 +494,13 @@ class TestReviewFindings:
     def test_non_finite_money_is_not_a_money_amount(
         self, newport_property: str, client: TestClient
     ) -> None:
-        """Decimal parses NaN and Infinity happily; both would poison every
-        total downstream and make the document unrenderable."""
+        """Decimal parses NaN and Infinity happily, and quantize() raises on a
+        value too big for the decimal context — all of them reached the caller
+        as a 500 rather than a refusal. money_amount is NUMERIC(18, 2), and
+        the edge says so instead of the database discovering it."""
         detail = upload(client, newport_property, pdf_variant("nan-money"))
         doc_id = detail["id"]
-        for hostile in ("nan", "NaN", "Infinity", "-inf"):
+        for hostile in ("nan", "NaN", "Infinity", "-inf", "1e30", "-1e30"):
             response = client.post(
                 f"/documents/{doc_id}/review",
                 json={
@@ -662,6 +664,27 @@ class TestExtractionBudgets:
         fat = b"BT /F1 10 Tf (" + b"x" * (extraction_parse.MAX_CONTENT_BYTES + 1) + b") Tj ET"
         with pytest.raises(extraction_parse.UnreadableDocument, match="extraction budget"):
             extraction_parse.extract_lines(self.build_pdf([fat]))
+
+    def test_a_pdf_of_endless_lines_is_refused_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The page and decompressed-byte budgets do not bound the LINE list,
+        which is what actually accumulates in memory. Cap lowered rather than
+        building a 50,000-line document, the way MAX_BYTES is exercised."""
+        monkeypatch.setattr(extraction_parse, "MAX_LINES", 1)
+        with pytest.raises(extraction_parse.UnreadableDocument, match="text lines"):
+            extraction_parse.extract_lines(FIXTURE)
+
+    def test_plain_text_is_bounded_like_the_pdf_branch(self) -> None:
+        """The PDF branch bounded its work; this one bounded nothing, so an
+        upload just under the byte cap became hundreds of megabytes of str
+        objects inside the request's open transaction."""
+        oversized = b"x" * (extraction_parse.MAX_CONTENT_BYTES + 1)
+        with pytest.raises(extraction_parse.UnreadableDocument, match="extraction budget"):
+            extraction_parse.extract_lines(oversized)
+
+    def test_a_text_file_of_nothing_but_newlines_is_refused(self) -> None:
+        many = b"\n" * (extraction_parse.MAX_LINES + 1)
+        with pytest.raises(extraction_parse.UnreadableDocument, match="line extraction cap"):
+            extraction_parse.extract_lines(many)
 
     def test_a_single_space_is_not_a_column_separator(self) -> None:
         # `Total $5.00` is prose, not a two-column charge line.

--- a/services/api/tests/test_documents.py
+++ b/services/api/tests/test_documents.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import datetime as dt
 import threading
 import time
+import zlib
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -447,11 +448,19 @@ class TestReviewFindings:
     """One pin per defect the adversarial review of this increment confirmed."""
 
     def test_applied_is_terminal_even_under_a_concurrent_review(
-        self, newport_property: str, client: TestClient, conn: psycopg.Connection[Any]
+        self, newport_property: str, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A review that read the document BEFORE an apply committed must not
         write its status back — that would let one purchase apply twice into
-        an append-only ledger."""
+        an append-only ledger.
+
+        The stale read is staged the way the upload race is: the row review
+        locks comes back with its PRE-apply status, so review_field's own
+        guard waves the request through and the endpoint runs the real
+        _refresh_status against a document that is already applied. Nothing
+        here restates the guard, so deleting `AND status::text <> 'applied'`
+        from documents.py demotes the record to 'confirmed' and fails this.
+        """
         detail = upload(client, newport_property, pdf_variant("terminal-state"))
         doc_id = detail["id"]
         ratify(client, doc_id)
@@ -459,13 +468,28 @@ class TestReviewFindings:
             client.post(f"/documents/{doc_id}/apply", json={"land_value": "0.00"}).status_code
             == 201
         )
-        # The stale write the racing review would have issued, verbatim.
-        conn.execute(
-            "UPDATE source_documents SET status = 'confirmed'"
-            " WHERE id = %s AND status::text <> 'applied'",
-            (doc_id,),
+        real_execute = psycopg.Connection.execute
+        locked_read = "FROM source_documents WHERE id = %s FOR UPDATE"
+
+        def stale_before_the_apply(self: Any, query: Any, *args: Any, **kwargs: Any) -> Any:
+            if isinstance(query, str) and locked_read in query:
+                return real_execute(
+                    self,
+                    "SELECT %s::text AS id, 'settlement_statement'::text AS kind,"
+                    " 'confirmed'::text AS status",
+                    (doc_id,),
+                )
+            return real_execute(self, query, *args, **kwargs)
+
+        monkeypatch.setattr(psycopg.Connection, "execute", stale_before_the_apply)
+        response = client.post(
+            f"/documents/{doc_id}/review",
+            json={"field_path": "settlement.sale_price", "action": "accept"},
         )
-        conn.commit()
+        # The racing review ran to completion and still could not demote it.
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "applied"
+        monkeypatch.setattr(psycopg.Connection, "execute", real_execute)
         assert client.get(f"/documents/{doc_id}").json()["status"] == "applied"
         assert (
             client.post(f"/documents/{doc_id}/apply", json={"land_value": "0.00"}).status_code
@@ -657,19 +681,31 @@ class TestReviewFindings:
 class TestExtractionBudgets:
     """The upload cap bounds compressed bytes; these bound the WORK."""
 
-    def build_pdf(self, pages: list[bytes]) -> bytes:
-        """A minimal valid PDF with the given raw content streams."""
+    def build_pdf(self, pages: list[bytes], *, compressed: bool = False) -> bytes:
+        """A minimal valid PDF with the given content streams — stored raw, or
+        deflated the way every real producer writes them."""
         objects: list[bytes] = []
 
         def add(body: bytes) -> int:
             objects.append(body)
             return len(objects)
 
+        def content_stream(data: bytes) -> bytes:
+            filters = b""
+            if compressed:
+                data = zlib.compress(data, 9)
+                filters = b" /Filter /FlateDecode"
+            return (
+                b"<< /Length "
+                + str(len(data)).encode()
+                + filters
+                + b" >>\nstream\n"
+                + data
+                + b"\nendstream"
+            )
+
         font = add(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
-        streams = [
-            add(b"<< /Length " + str(len(data)).encode() + b" >>\nstream\n" + data + b"\nendstream")
-            for data in pages
-        ]
+        streams = [add(content_stream(data)) for data in pages]
         page_numbers = []
         for stream in streams:
             parent = len(objects) + (len(streams) + 1 - len(page_numbers))
@@ -710,11 +746,21 @@ class TestExtractionBudgets:
             extraction_parse.extract_lines(pdf)
 
     def test_a_decompression_bomb_is_refused_by_budget(self) -> None:
-        """A compressed upload well under the byte cap can decompress into
-        work that pins a worker; the budget is measured after inflation."""
+        """A genuinely FlateDecode-compressed stream, because that is the only
+        shape this attack has. An UNCOMPRESSED page over the budget is refused
+        by its own size and says nothing about inflation — it passes even if
+        the budget is measured before decoding. Here the bytes on the wire are
+        a few kilobytes, well under both caps, and only the inflated stream is
+        over 8MB: the refusal can come from nowhere but the decoded length.
+        """
         fat = b"BT /F1 10 Tf (" + b"x" * (extraction_parse.MAX_CONTENT_BYTES + 1) + b") Tj ET"
+        pdf = self.build_pdf([fat], compressed=True)
+        # Nothing about the upload itself is suspicious: it clears the byte cap
+        # and the extraction budget by three orders of magnitude.
+        assert len(pdf) < documents.MAX_BYTES
+        assert len(pdf) < extraction_parse.MAX_CONTENT_BYTES // 100
         with pytest.raises(extraction_parse.UnreadableDocument, match="extraction budget"):
-            extraction_parse.extract_lines(self.build_pdf([fat]))
+            extraction_parse.extract_lines(pdf)
 
     def test_a_pdf_of_endless_lines_is_refused_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The page and decompressed-byte budgets do not bound the LINE list,
@@ -743,11 +789,28 @@ class TestExtractionBudgets:
         assert extraction_parse.match_money_line("Total   $5.00") == ("Total", "5.00")
 
     def test_a_hostile_line_does_not_burn_the_worker(self) -> None:
-        """The old label-first regex re-scanned the column gap at every start
-        offset — quadratic, and reachable from any upload."""
+        """Straight at match_money_line, NOT through parse_settlement.
+
+        The parser truncates every line to MAX_LINE_CHARS before matching, so
+        a test that goes through it finishes in ten milliseconds even with the
+        old label-first pattern restored: it pins the truncation and says
+        nothing about the matcher. The adversarial shape is a long run of
+        spaces ending in a '$' that is not an amount — anchored at the amount,
+        the pattern finds the single '$', fails once and stops; label-first,
+        it re-scans the whole column gap from every start offset and takes
+        about four seconds at this length.
+        """
+        hostile = "Label" + " " * 40_000 + "$not-an-amount"
         started = time.monotonic()
-        extraction_parse.parse_settlement([(1, "Label" + " " * 50_000 + "$not-an-amount")])
-        assert time.monotonic() - started < 1.0
+        assert extraction_parse.match_money_line(hostile) is None
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.5, f"{elapsed:.2f}s to reject one line; the matcher is not anchored"
+        # A line of the same length that IS a charge line still reads, so the
+        # bound cannot be met by refusing to look at long lines.
+        assert extraction_parse.match_money_line("Sale Price" + " " * 40_000 + "$187,500.00") == (
+            "Sale Price",
+            "187,500.00",
+        )
 
 
 class TestDomainGuards:

--- a/services/api/tests/test_maintenance.py
+++ b/services/api/tests/test_maintenance.py
@@ -889,6 +889,87 @@ class TestEdgeValidation:
         assert client.get(f"/work-orders/{order['id']}").json()["status"] == "reported"
 
 
+class TestRenewalAndRefusals:
+    def test_a_certificate_can_be_renewed_without_inventing_a_second_vendor(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """Certificates expire yearly. Without this there was no door: the
+        unique name per entity made re-adding the vendor impossible."""
+        lapsed = client.post(
+            "/vendors",
+            json={
+                "entity_id": world["entity"],
+                "name": "Lapsed Then Renewed",
+                "trade": "roofing",
+                "liability_expires_on": "2026-01-31",
+            },
+        ).json()
+        assert lapsed["coverage_state"] == "expired"
+        renewed = client.post(
+            f"/vendors/{lapsed['id']}/credentials",
+            json={"liability_expires_on": "2028-01-31", "insurer": "Second Carrier"},
+        )
+        assert renewed.status_code == 200, renewed.text
+        body = renewed.json()
+        assert body["coverage_state"] == "current"
+        assert body["insurer"] == "Second Carrier"
+        # Untouched fields stay put: a renewal names what was renewed.
+        assert body["name"] == "Lapsed Then Renewed"
+        assert body["trade"] == "roofing"
+
+    def test_renewal_guards(self, world: dict[str, str], client: TestClient) -> None:
+        assert (
+            client.post(
+                "/vendors/00000000-0000-4000-8000-000000000000/credentials",
+                json={"insurer": "Nobody"},
+            ).status_code
+            == 404
+        )
+        assert client.post(f"/vendors/{world['vendor']}/credentials", json={}).status_code == 422
+
+    def test_a_cost_body_may_not_carry_two_relations(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """The outer relation describes a LINK to an existing event; a posted
+        cost carries its own. Setting both said two things about one row and
+        silently kept one."""
+        order = open_order(client, world)
+        response = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={
+                "cost": {"amount": "50.00", "relation": "materials"},
+                "relation": "invoice",
+            },
+        )
+        assert response.status_code == 422
+        # Either one alone is fine.
+        assert (
+            client.post(
+                f"/work-orders/{order['id']}/costs",
+                json={"cost": {"amount": "50.00", "relation": "materials"}},
+            ).status_code
+            == 201
+        )
+
+    def test_the_inventory_refuses_a_completion_by_name(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """A replacement dated before the component it retires trips
+        retired_after_installed, which used to escape as a 500."""
+        conn.execute(
+            "UPDATE components SET installed_on = '2026-09-01' WHERE id = %s",
+            (world["component"],),
+        )
+        conn.commit()
+        order = open_order(client, world)
+        response = client.post(
+            f"/work-orders/{order['id']}/complete",
+            json={"completed_on": "2026-08-27", "resolution": "replaced"},
+        )
+        assert response.status_code == 422
+        assert "cannot retire before it was installed" in response.json()["detail"]
+
+
 class TestCredits:
     def test_a_tenant_chargeback_is_income_and_reduces_what_the_job_cost(
         self, world: dict[str, str], client: TestClient

--- a/services/api/tests/test_maintenance.py
+++ b/services/api/tests/test_maintenance.py
@@ -164,11 +164,11 @@ class TestVendors:
 
         # "does not exceed $2,500" — the threshold itself is INSIDE the harbour.
         assert "1.263(a)-1(f)" in maintenance._bar_citation(
-            False, DE_MINIMIS_CENTS - Decimal("0.01")
+            False, DE_MINIMIS_CENTS - Decimal("0.01"), "repaired"
         )
-        assert "1.263(a)-1(f)" in maintenance._bar_citation(False, DE_MINIMIS_CENTS)
+        assert "1.263(a)-1(f)" in maintenance._bar_citation(False, DE_MINIMIS_CENTS, "repaired")
         assert "1.263(a)-3(i)" in maintenance._bar_citation(
-            False, DE_MINIMIS_CENTS + Decimal("0.01")
+            False, DE_MINIMIS_CENTS + Decimal("0.01"), "repaired"
         )
 
     def test_one_vendor_name_per_owner_list(
@@ -313,6 +313,27 @@ class TestLifecycle:
             == 409
         )
 
+    def test_a_transition_cannot_name_a_vendor_that_does_not_exist(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """Handing the job to a vendor id that names nothing is an unknown
+        reference, not a foreign key violation escaping as a 500."""
+        order = open_order(client, world, vendor_id=None)
+        ghost = client.post(
+            f"/work-orders/{order['id']}/transitions",
+            json={"status": "triaged", "vendor_id": "00000000-0000-4000-8000-000000000000"},
+        )
+        assert ghost.status_code == 404
+        assert ghost.json()["detail"] == "vendor not found"
+        # The refusal rolled back: the job never moved.
+        assert client.get(f"/work-orders/{order['id']}").json()["status"] == "reported"
+        assigned = client.post(
+            f"/work-orders/{order['id']}/transitions",
+            json={"status": "triaged", "vendor_id": world["vendor"]},
+        )
+        assert assigned.status_code == 200
+        assert assigned.json()["vendor_name"] == "Licking Valley Plumbing"
+
     def test_a_work_order_cannot_borrow_another_property_s_unit(
         self, world: dict[str, str], client: TestClient
     ) -> None:
@@ -339,6 +360,30 @@ class TestLifecycle:
             },
         )
         assert response.status_code == 422
+
+    def test_a_refused_transition_names_the_rule_that_fired(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """One message for three different CHECKs told the operator to add a
+        date when the date was exactly what was wrong."""
+        order = open_order(client, world)  # reported_on 2026-08-01
+        no_date = client.post(
+            f"/work-orders/{order['id']}/transitions", json={"status": "scheduled"}
+        )
+        assert no_date.status_code == 422
+        assert no_date.json()["detail"] == "a scheduled visit needs a date"
+        no_reason = client.post(
+            f"/work-orders/{order['id']}/transitions", json={"status": "cancelled"}
+        )
+        assert no_reason.status_code == 422
+        assert no_reason.json()["detail"] == "a cancellation needs a reason"
+        backdated = client.post(
+            f"/work-orders/{order['id']}/transitions",
+            json={"status": "scheduled", "scheduled_for": "2026-07-15"},
+        )
+        assert backdated.status_code == 422
+        detail = backdated.json()["detail"]
+        assert detail == "a visit cannot be scheduled before the job was reported"
 
     def test_listing_and_reading_guards(self, world: dict[str, str], client: TestClient) -> None:
         order = open_order(client, world)
@@ -552,7 +597,10 @@ class TestCompletion:
             },
         )
         assert response.status_code == 422
-        assert "1.263(a)-3(k)" in response.json()["detail"]
+        # The umbrella rule, not the restoration paragraph: nothing in this
+        # request says a major component was replaced.
+        assert "1.263(a)-3(d)" in response.json()["detail"]
+        assert "1.263(a)-3(k)(1)(vi)" not in response.json()["detail"]
         # The refusal rolled the whole completion back.
         assert client.get(f"/work-orders/{order['id']}").json()["status"] == "reported"
 
@@ -711,6 +759,74 @@ class TestCosts:
             ).status_code
             == 422
         )
+
+    def test_a_cost_may_cite_only_a_receipt_that_exists(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The document behind the money is attached at INSERT, because the
+        ledger refuses UPDATE forever after. A document_id naming nothing is a
+        404 -- not a psycopg error at the client, and not a pydantic one
+        either: the ledger's model wants text and a bare UUID never reached it."""
+        document = conn.execute(
+            """
+            INSERT INTO source_documents (kind, filename, content_hash, status)
+            VALUES ('invoice', 'licking-valley-8842.pdf', %s, 'confirmed')
+            RETURNING id::text
+            """,
+            ("d" * 64,),
+        ).fetchone()
+        conn.commit()
+        order = open_order(client, world)
+        ghost = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={
+                "cost": {
+                    "amount": "300.00",
+                    "is_capital": False,
+                    "document_id": "00000000-0000-4000-8000-000000000000",
+                },
+            },
+        )
+        assert ghost.status_code == 404
+        assert ghost.json()["detail"] == "document not found"
+        assert client.get(f"/work-orders/{order['id']}").json()["costs"] == []
+
+        posted = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={
+                "cost": {
+                    "amount": "300.00",
+                    "is_capital": False,
+                    "document_id": document["id"],
+                },
+            },
+        )
+        assert posted.status_code == 201, posted.text
+        event_uuid = posted.json()["costs"][0]["ledger_event_uuid"]
+        stored = conn.execute(
+            "SELECT document_id::text FROM ledger_events WHERE event_uuid = %s",
+            (event_uuid,),
+        ).fetchone()
+        assert stored["document_id"] == document["id"]
+
+        # The completion door posts its money through the same helper.
+        second = open_order(client, world)
+        refused = client.post(
+            f"/work-orders/{second['id']}/complete",
+            json={
+                "completed_on": "2026-08-27",
+                "resolution": "repaired",
+                "cost": {
+                    "amount": "300.00",
+                    "is_capital": False,
+                    "document_id": "00000000-0000-4000-8000-000000000000",
+                },
+            },
+        )
+        assert refused.status_code == 404
+        assert refused.json()["detail"] == "document not found"
+        # The refusal rolled the half-written completion back with it.
+        assert client.get(f"/work-orders/{second['id']}").json()["status"] == "reported"
 
 
 class TestEdgeValidation:

--- a/services/api/tests/test_maintenance.py
+++ b/services/api/tests/test_maintenance.py
@@ -126,6 +126,19 @@ class TestVendors:
         ).json()
         assert bare["coverage_state"] == "unknown"
         assert bare["earliest_expiry"] is None
+        # A trade licence is a qualification, not coverage: a vendor carrying
+        # one and no certificate has NOT been shown to be insured.
+        licensed = client.post(
+            "/vendors",
+            json={
+                "entity_id": world["entity"],
+                "name": "Licensed But Bare",
+                "trade": "electrical",
+                "license_expires_on": "2030-01-01",
+            },
+        ).json()
+        assert licensed["coverage_state"] == "unknown"
+        assert licensed["earliest_expiry"] == "2030-01-01"
 
     def test_the_same_trade_under_two_entities_says_so(
         self, world: dict[str, str], client: TestClient
@@ -149,10 +162,14 @@ class TestVendors:
         flag can never disagree about where $2,500 is."""
         from hestia_api.reports import DE_MINIMIS_CENTS
 
+        # "does not exceed $2,500" — the threshold itself is INSIDE the harbour.
         assert "1.263(a)-1(f)" in maintenance._bar_citation(
             False, DE_MINIMIS_CENTS - Decimal("0.01")
         )
-        assert "1.263(a)-3(i)" in maintenance._bar_citation(False, DE_MINIMIS_CENTS)
+        assert "1.263(a)-1(f)" in maintenance._bar_citation(False, DE_MINIMIS_CENTS)
+        assert "1.263(a)-3(i)" in maintenance._bar_citation(
+            False, DE_MINIMIS_CENTS + Decimal("0.01")
+        )
 
     def test_one_vendor_name_per_owner_list(
         self, world: dict[str, str], client: TestClient
@@ -603,12 +620,15 @@ class TestCosts:
             json={"cost": {"amount": "300.00", "relation": "invoice", "is_capital": False}},
         ).json()
         assert Decimal(detail["net_cost"]) == Decimal("420.00")
-        # A mis-posted invoice is corrected by a reversal PAIR, and the job's
-        # cost becomes the net — with the reversal visible, not hidden.
+        # A mis-posted invoice is corrected by a reversal PAIR. The reversal is
+        # its own ledger event and is NOT associated with the job, so the net
+        # has to reach for it — otherwise the page reports money the job never
+        # cost. The reversed row stays visible; only the total moves.
         client.post(f"/ledger/{detail['costs'][1]['ledger_event_uuid']}/reverse", json={})
         after = client.get(f"/work-orders/{order['id']}").json()
         assert any(cost["reversed"] for cost in after["costs"])
-        assert Decimal(after["net_cost"]) == Decimal("420.00")
+        assert len(after["costs"]) == 2  # the pair is not hidden
+        assert Decimal(after["net_cost"]) == Decimal("120.00")
 
     def test_an_existing_ledger_event_can_join_the_job(
         self, world: dict[str, str], client: TestClient
@@ -691,6 +711,63 @@ class TestCosts:
             ).status_code
             == 422
         )
+
+
+class TestCredits:
+    def test_a_tenant_chargeback_is_income_and_reduces_what_the_job_cost(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """A resident reimbursing damage is money coming IN. Posting it as an
+        outflow would overstate the job and understate rental income."""
+        order = open_order(client, world)
+        client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={"cost": {"amount": "400.00", "relation": "invoice", "is_capital": False}},
+        )
+        detail = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={"cost": {"amount": "150.00", "relation": "tenant_chargeback"}},
+        ).json()
+        assert Decimal(detail["net_cost"]) == Decimal("250.00")
+        chargeback = next(
+            cost for cost in detail["costs"] if cost["relation"] == "tenant_chargeback"
+        )
+        assert Decimal(chargeback["amount"]) == Decimal("150.00")  # positive: money in
+        assert chargeback["category"] == "other_income"
+
+    def test_a_warranty_credit_comes_back_against_the_repair(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        order = open_order(client, world)
+        client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={"cost": {"amount": "900.00", "relation": "invoice", "is_capital": False}},
+        )
+        detail = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={"cost": {"amount": "300.00", "relation": "warranty_credit"}},
+        ).json()
+        assert Decimal(detail["net_cost"]) == Decimal("600.00")
+        credit = next(cost for cost in detail["costs"] if cost["relation"] == "warranty_credit")
+        assert credit["category"] == "repairs"  # a negative expense, honestly signed
+        assert credit["is_capital"] is False
+
+    def test_a_credit_is_never_a_capital_election_however_it_is_asked_for(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        order = open_order(client, world)
+        detail = client.post(
+            f"/work-orders/{order['id']}/costs",
+            json={
+                "cost": {
+                    "amount": "300.00",
+                    "relation": "warranty_credit",
+                    "is_capital": True,
+                    "capitalisation_rationale": "nonsense",
+                }
+            },
+        ).json()
+        assert detail["costs"][0]["is_capital"] is False
 
 
 class TestPureHelpers:

--- a/services/api/tests/test_maintenance.py
+++ b/services/api/tests/test_maintenance.py
@@ -713,6 +713,66 @@ class TestCosts:
         )
 
 
+class TestEdgeValidation:
+    """Malformed input is a 422 at the edge, never a 500 in SQL."""
+
+    def test_a_malformed_id_is_refused_before_it_reaches_postgres(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        assert (
+            client.post(
+                "/work-orders",
+                json={"property_id": "not-a-uuid", "summary": "No hot water"},
+            ).status_code
+            == 422
+        )
+        assert (
+            client.post(
+                "/vendors",
+                json={"entity_id": "not-a-uuid", "name": "Ghost", "trade": "other"},
+            ).status_code
+            == 422
+        )
+        order = open_order(client, world)
+        assert (
+            client.post(
+                f"/work-orders/{order['id']}/transitions",
+                json={"status": "triaged", "vendor_id": "not-a-uuid"},
+            ).status_code
+            == 422
+        )
+        assert (
+            client.post(
+                f"/work-orders/{order['id']}/costs",
+                json={"ledger_event_uuid": "not-a-uuid"},
+            ).status_code
+            == 422
+        )
+
+    def test_a_replacement_cannot_overflow_the_component_columns(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """components.quantity is NUMERIC(10,2) and expected_life_years is
+        NUMERIC(5,2); unbounded Decimals overflowed the column as a 500."""
+        order = open_order(client, world)
+        for field, value in (
+            ("quantity", "99999999999.00"),
+            ("expected_life_years", "9999.00"),
+            ("replacement_cost", "9" * 17 + ".00"),
+        ):
+            response = client.post(
+                f"/work-orders/{order['id']}/complete",
+                json={
+                    "completed_on": "2026-08-27",
+                    "resolution": "replaced",
+                    "replacement": {field: value},
+                },
+            )
+            assert response.status_code == 422, f"{field}={value} -> {response.status_code}"
+        # The refusals rolled back: the job is still open and still completable.
+        assert client.get(f"/work-orders/{order['id']}").json()["status"] == "reported"
+
+
 class TestCredits:
     def test_a_tenant_chargeback_is_income_and_reduces_what_the_job_cost(
         self, world: dict[str, str], client: TestClient

--- a/services/api/tests/test_reports.py
+++ b/services/api/tests/test_reports.py
@@ -146,6 +146,84 @@ class TestScheduleE:
         ).json()
         assert report["signoff"]["confirmed_by"] == "Jane CPA"
 
+    def test_a_reversed_repair_leaves_the_classification_queue(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """A reversal PAIR nets to zero, so it is no longer an open question —
+        and the reversal half mirrors a charge rather than being one. Both
+        halves leave the queue: asking twice, forever, about money that no
+        longer exists is the defect."""
+        posted = client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-09-12",
+                "category": "repairs",
+                "amount": "-3600.00",
+                "memo": "furnace invoice, mis-posted",
+                "property_id": world["property"],
+            },
+        ).json()
+        report = client.get(
+            f"/properties/{world['property']}/reports/schedule-e?tax_year=2026"
+        ).json()
+        assert {Decimal(flag["amount"]) for flag in report["needs_classification"]} == {
+            Decimal("4800.00"),
+            Decimal("3600.00"),
+        }
+
+        reversal = client.post(f"/ledger/{posted['event_uuid']}/reverse", json={})
+        assert reversal.status_code == 201
+        report = client.get(
+            f"/properties/{world['property']}/reports/schedule-e?tax_year=2026"
+        ).json()
+        flagged = {flag["event_uuid"] for flag in report["needs_classification"]}
+        assert posted["event_uuid"] not in flagged
+        assert reversal.json()["reversal"]["event_uuid"] not in flagged
+        assert [Decimal(flag["amount"]) for flag in report["needs_classification"]] == [
+            Decimal("4800.00")
+        ]
+        # The pair cancels on the form too: line 14 is unmoved by the round trip.
+        expenses = {line["line_no"]: line for line in report["expense_lines"]}
+        assert Decimal(expenses[14]["amount"]) == Decimal("5180.00")
+
+    def test_a_correction_that_is_still_unanswered_stays_in_the_queue(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        """Dropping settled pairs must not swallow a live question: the
+        corrected entry is its own charge and is judged on its own merits."""
+        posted = client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-09-12",
+                "category": "repairs",
+                "amount": "-5100.00",
+                "memo": "porch rebuild invoice",
+                "property_id": world["property"],
+            },
+        ).json()
+        result = client.post(
+            f"/ledger/{posted['event_uuid']}/reverse",
+            json={
+                "memo": "transposed digits",
+                "corrected": {
+                    "occurred_on": "2026-09-12",
+                    "category": "repairs",
+                    "amount": "-4650.00",
+                    "memo": "porch rebuild invoice, restated",
+                    "property_id": world["property"],
+                },
+            },
+        ).json()
+        report = client.get(
+            f"/properties/{world['property']}/reports/schedule-e?tax_year=2026"
+        ).json()
+        flagged = {flag["event_uuid"]: flag for flag in report["needs_classification"]}
+        assert posted["event_uuid"] not in flagged
+        assert result["reversal"]["event_uuid"] not in flagged
+        corrected = flagged[result["corrected"]["event_uuid"]]
+        assert Decimal(corrected["amount"]) == Decimal("4650.00")
+        assert "1.263(a)-1(f)" in corrected["reason"]
+
     def test_missing_property_is_a_404(self, clean: None, client: TestClient) -> None:
         assert (
             client.get(f"/properties/{uuid.uuid4()}/reports/schedule-e?tax_year=2026").status_code


### PR DESCRIPTION
Closes #62. Every confirmed finding from the adversarial review of C1 (#1) and D1 (#2), each fixed with a regression that fails on the previous code.

**Money path.** A work order's cost ignored reversals — a properly reversed $300 invoice still read as spent, so the page reported $420 for a job that cost $120. Tenant chargebacks and warranty credits posted as *outflows*, recording a resident's reimbursement as money spent instead of rental income. A vendor with a trade licence and no certificate of insurance read "covered". The de minimis line excluded $2,500 itself, which Treas. Reg. 1.263(a)-1(f) includes.

**Refuse at the edge, not in SQL.** Text extraction bounded nothing at all — an upload just under the byte cap became hundreds of megabytes of objects inside the request's open transaction. Money had no magnitude bound, so `quantize` raised and the client saw a 500. Maintenance ids were bare strings that reached Postgres before anything objected. Replacement Decimals overflowed their columns.

**Schema 017 — a completed replacement keeps naming what it replaced.** 016's column-listed `SET NULL` made deleting such a component abort quoting `work_orders`, a table the operator never touched. Both obvious repairs were wrong: relaxing the CHECK relaxes it for *every* replacement (a replacement is completed by definition), and `RESTRICT` freezes the ordinary case 016 chose and the suite already proves. The rule went on the write that would make a finished job untrue, and the refusal says components are retired, never deleted.

**Correctness.** `apply_document` read a property fact, decided, then wrote — two concurrent applies could each decide the field was empty; the decision now happens inside the UPDATE. Schedule E asked twice about a reversed-but-undecided repair that nets to zero, and answering either flag could not clear the other. A capital cost always cited the *restoration* paragraph even when the job replaced nothing and the owner had written "betterment" — a completion that installed something still cites 1.263(a)-3(k)(1)(vi); everything else cites the umbrella at 1.263(a)-3(d).

**Errors say which rule.** An unresolvable document or vendor is a 404, not a 500. A transition refusal names the constraint that actually fired instead of always blaming the same two. A completion refused by the inventory (`retired_after_installed`) is a 422 that says what it means. A cost body carrying two relations is refused rather than silently keeping one. And a vendor certificate can finally be renewed — there was no update path and the unique name per entity blocked re-adding.

**Tests that proved less than they claimed.** The decompression-bomb test never decompressed anything (it now uses real FlateDecode). The quadratic-regex timing test was satisfied by line truncation rather than the anchored matcher. The "applied is terminal" test re-implemented the guard in its own body instead of driving the code path. All three now fail if the behaviour is reverted.

**A time bomb, caught in passing.** Four constraint assertions pinned `completed_on` to a date but let `reported_on` default to `CURRENT_DATE` — equal today, inverted tomorrow, at which point the wrong constraint fires and `verify-schema.sh` goes red for an unrelated reason. All four now pin both dates.

232 API tests at 100% line+branch · 127 schema assertions · contract regenerated · web typechecks · `pnpm lint` clean.

Findings on `apps/web` (four e2e/client test-honesty defects) were handed to the other agent in the shared log rather than edited across the surface boundary.