### PR TITLE
E1: screening decisions, and the notice a denial owes

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -657,6 +657,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/screening": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Screening */
+        get: operations["list_screening_screening_get"];
+        put?: never;
+        /** Open Screening */
+        post: operations["open_screening_screening_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/screening/{screening_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Screening */
+        get: operations["read_screening_screening__screening_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/screening/{screening_id}/adverse-action": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record Adverse Action */
+        post: operations["record_adverse_action_screening__screening_id__adverse_action_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/screening/{screening_id}/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Decide Screening */
+        post: operations["decide_screening_screening__screening_id__decision_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sweep/deadlines": {
         parameters: {
             query?: never;
@@ -1336,6 +1405,23 @@ export interface components {
             /** Term Months */
             term_months: number;
         };
+        /** DecisionIn */
+        DecisionIn: {
+            /**
+             * Based On Consumer Report
+             * @default false
+             */
+            based_on_consumer_report: boolean;
+            /** Decided On */
+            decided_on?: string | null;
+            /**
+             * Decision
+             * @enum {string}
+             */
+            decision: "approved" | "conditional" | "denied" | "withdrawn";
+            /** Decision Basis */
+            decision_basis?: string | null;
+        };
         /** DefectOut */
         DefectOut: {
             /** Affects Financing */
@@ -1871,6 +1957,11 @@ export interface components {
             /** Reason */
             reason: string;
         };
+        /** NoticeIn */
+        NoticeIn: {
+            /** Sent On */
+            sent_on?: string | null;
+        };
         /** PolicyIn */
         PolicyIn: {
             /** Annual Premium */
@@ -2218,6 +2309,74 @@ export interface components {
             total_expenses: string;
             /** Total Income */
             total_income: string;
+        };
+        /** ScreeningIn */
+        ScreeningIn: {
+            /** Notes */
+            notes?: string | null;
+            /**
+             * Property Id
+             * Format: uuid
+             */
+            property_id: string;
+            /**
+             * Provider
+             * @default manual
+             */
+            provider: string;
+            /** Requested On */
+            requested_on?: string | null;
+            /**
+             * Resident Id
+             * Format: uuid
+             */
+            resident_id: string;
+            /** Unit Id */
+            unit_id?: string | null;
+        };
+        /** ScreeningOut */
+        ScreeningOut: {
+            /** Adverse Action Required */
+            adverse_action_required: boolean;
+            /** Adverse Action Sent On */
+            adverse_action_sent_on: string | null;
+            /** Based On Consumer Report */
+            based_on_consumer_report: boolean;
+            /** Citation */
+            citation: string | null;
+            /** Decided On */
+            decided_on: string | null;
+            /** Decision */
+            decision: string;
+            /** Decision Basis */
+            decision_basis: string | null;
+            /** Id */
+            id: string;
+            /** Notes */
+            notes: string | null;
+            /** Notice Contents */
+            notice_contents: {
+                [key: string]: string;
+            }[];
+            /** Property Id */
+            property_id: string;
+            /** Property Label */
+            property_label: string;
+            /** Provider */
+            provider: string;
+            /**
+             * Requested On
+             * Format: date
+             */
+            requested_on: string;
+            /** Resident Id */
+            resident_id: string;
+            /** Resident Name */
+            resident_name: string;
+            /** Unit Id */
+            unit_id: string | null;
+            /** Unit Label */
+            unit_label: string | null;
         };
         /** Signoff */
         Signoff: {
@@ -4016,6 +4175,179 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_screening_screening_get: {
+        parameters: {
+            query?: {
+                resident_id?: string | null;
+                property_id?: string | null;
+                notice_owed?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreeningOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    open_screening_screening_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ScreeningIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreeningOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_screening_screening__screening_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                screening_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreeningOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_adverse_action_screening__screening_id__adverse_action_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                screening_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NoticeIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreeningOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    decide_screening_screening__screening_id__decision_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                screening_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DecisionIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreeningOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -1471,6 +1471,53 @@
         "title": "DebtTerms",
         "type": "object"
       },
+      "DecisionIn": {
+        "properties": {
+          "based_on_consumer_report": {
+            "default": false,
+            "title": "Based On Consumer Report",
+            "type": "boolean"
+          },
+          "decided_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided On"
+          },
+          "decision": {
+            "enum": [
+              "approved",
+              "conditional",
+              "denied",
+              "withdrawn"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "decision_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decision Basis"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "title": "DecisionIn",
+        "type": "object"
+      },
       "DefectOut": {
         "properties": {
           "affects_financing": {
@@ -3217,6 +3264,24 @@
         "title": "NeedsClassification",
         "type": "object"
       },
+      "NoticeIn": {
+        "properties": {
+          "sent_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sent On"
+          }
+        },
+        "title": "NoticeIn",
+        "type": "object"
+      },
       "PolicyIn": {
         "properties": {
           "annual_premium": {
@@ -4350,6 +4415,224 @@
           "caveat"
         ],
         "title": "ScheduleEReport",
+        "type": "object"
+      },
+      "ScreeningIn": {
+        "properties": {
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "property_id": {
+            "format": "uuid",
+            "title": "Property Id",
+            "type": "string"
+          },
+          "provider": {
+            "default": "manual",
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Provider",
+            "type": "string"
+          },
+          "requested_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested On"
+          },
+          "resident_id": {
+            "format": "uuid",
+            "title": "Resident Id",
+            "type": "string"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          }
+        },
+        "required": [
+          "resident_id",
+          "property_id"
+        ],
+        "title": "ScreeningIn",
+        "type": "object"
+      },
+      "ScreeningOut": {
+        "properties": {
+          "adverse_action_required": {
+            "title": "Adverse Action Required",
+            "type": "boolean"
+          },
+          "adverse_action_sent_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adverse Action Sent On"
+          },
+          "based_on_consumer_report": {
+            "title": "Based On Consumer Report",
+            "type": "boolean"
+          },
+          "citation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Citation"
+          },
+          "decided_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided On"
+          },
+          "decision": {
+            "title": "Decision",
+            "type": "string"
+          },
+          "decision_basis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decision Basis"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "notice_contents": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Notice Contents",
+            "type": "array"
+          },
+          "property_id": {
+            "title": "Property Id",
+            "type": "string"
+          },
+          "property_label": {
+            "title": "Property Label",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "requested_on": {
+            "format": "date",
+            "title": "Requested On",
+            "type": "string"
+          },
+          "resident_id": {
+            "title": "Resident Id",
+            "type": "string"
+          },
+          "resident_name": {
+            "title": "Resident Name",
+            "type": "string"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "unit_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Label"
+          }
+        },
+        "required": [
+          "id",
+          "resident_id",
+          "resident_name",
+          "property_id",
+          "property_label",
+          "unit_id",
+          "unit_label",
+          "requested_on",
+          "provider",
+          "decision",
+          "decided_on",
+          "decision_basis",
+          "based_on_consumer_report",
+          "adverse_action_required",
+          "adverse_action_sent_on",
+          "notes",
+          "notice_contents",
+          "citation"
+        ],
+        "title": "ScreeningOut",
         "type": "object"
       },
       "Signoff": {
@@ -7825,6 +8108,292 @@
           }
         },
         "summary": "Create Resident"
+      }
+    },
+    "/screening": {
+      "get": {
+        "operationId": "list_screening_screening_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "resident_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Resident Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "property_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Property Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "notice_owed",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Notice Owed",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ScreeningOut"
+                  },
+                  "title": "Response List Screening Screening Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Screening"
+      },
+      "post": {
+        "operationId": "open_screening_screening_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScreeningIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScreeningOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Open Screening"
+      }
+    },
+    "/screening/{screening_id}": {
+      "get": {
+        "operationId": "read_screening_screening__screening_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "screening_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Screening Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScreeningOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Screening"
+      }
+    },
+    "/screening/{screening_id}/adverse-action": {
+      "post": {
+        "operationId": "record_adverse_action_screening__screening_id__adverse_action_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "screening_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Screening Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoticeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScreeningOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Record Adverse Action"
+      }
+    },
+    "/screening/{screening_id}/decision": {
+      "post": {
+        "operationId": "decide_screening_screening__screening_id__decision_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "screening_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Screening Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DecisionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScreeningOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Decide Screening"
       }
     },
     "/sweep/deadlines": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -16,3 +16,4 @@
 \ir 015_document_extraction.sql
 \ir 016_maintenance.sql
 \ir 017_replacement_history.sql
+\ir 018_screening.sql

--- a/packages/domain/schema/018_screening.sql
+++ b/packages/domain/schema/018_screening.sql
@@ -1,0 +1,123 @@
+-- ===========================================================================
+--  018 — Screening decisions, and the notice a denial owes.
+--
+--  `residents` has carried screened_on and adverse_action_sent_on since 003,
+--  with a comment explaining why no report contents are stored: the FCRA
+--  obliges a NOTICE when a consumer report drives a denial, it does not
+--  oblige anyone to warehouse the report, and holding one creates duties
+--  without benefit. This module builds the workflow around those dates and
+--  keeps that promise — there is nowhere here to put a score, a criminal
+--  record, or a reason code from a bureau.
+--
+--  The duty itself: FCRA s.615(a) (15 U.S.C. 1681m(a)). If adverse action is
+--  taken with respect to any consumer, BASED IN WHOLE OR IN PART on a
+--  consumer report, the user of that report must notify the consumer. Both
+--  halves matter, so both are recorded separately and the obligation is
+--  derived from them rather than asserted alongside them.
+-- ===========================================================================
+
+CREATE TYPE screening_decision AS ENUM (
+  'pending',
+  'approved',
+  -- Approval on worse terms — a larger deposit, a co-signer — is still
+  -- adverse action under 15 U.S.C. 1681a(k)(1)(B)(ii) when a report drove it.
+  'conditional',
+  'denied',
+  'withdrawn'   -- the applicant walked; no adverse action was taken
+);
+
+CREATE TABLE screening_requests (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  resident_id              UUID NOT NULL REFERENCES residents (id) ON DELETE CASCADE,
+  -- The application is to a property; the deadline this produces needs an
+  -- owner-side anchor (deadline_is_anchored, module 007).
+  property_id              UUID NOT NULL REFERENCES properties (id) ON DELETE CASCADE,
+  unit_id                  UUID,
+
+  requested_on             DATE NOT NULL DEFAULT CURRENT_DATE,
+  -- 'manual' until a bureau adapter exists. Named, never inferred.
+  provider                 TEXT NOT NULL DEFAULT 'manual',
+
+  decision                 screening_decision NOT NULL DEFAULT 'pending',
+  decided_on               DATE,
+  -- The owner's own words for why. NOT a reason code, NOT report contents:
+  -- what a person could defend in a fair-housing complaint.
+  decision_basis           TEXT,
+
+  -- The second half of the s.615(a) test, recorded as its own fact because it
+  -- is a different question from what the decision was.
+  based_on_consumer_report BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- GENERATED, so the obligation can never drift from the facts that create
+  -- it. A stored boolean somebody sets by hand is a claim; this is a
+  -- consequence.
+  adverse_action_required  BOOLEAN GENERATED ALWAYS AS (
+    based_on_consumer_report AND decision IN ('denied', 'conditional')
+  ) STORED,
+  adverse_action_sent_on   DATE,
+
+  notes                    TEXT,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  FOREIGN KEY (unit_id, property_id)
+    REFERENCES units (id, property_id) ON DELETE SET NULL (unit_id),
+
+  CONSTRAINT decided_requests_say_when
+    CHECK (decision = 'pending' OR decided_on IS NOT NULL),
+  CONSTRAINT pending_requests_are_undecided
+    CHECK (decision <> 'pending' OR decided_on IS NULL),
+  CONSTRAINT decided_after_requested
+    CHECK (decided_on IS NULL OR decided_on >= requested_on),
+  -- A notice cannot precede the decision it is about, and cannot be sent for
+  -- a decision that owes none. Written against the base columns rather than
+  -- the generated one so the rule reads as the statute does.
+  CONSTRAINT notice_follows_its_decision
+    CHECK (adverse_action_sent_on IS NULL OR adverse_action_sent_on >= decided_on),
+  CONSTRAINT notice_only_when_a_report_drove_an_adverse_decision
+    CHECK (
+      adverse_action_sent_on IS NULL
+      OR (based_on_consumer_report AND decision IN ('denied', 'conditional'))
+    )
+);
+
+CREATE INDEX screening_open_by_resident ON screening_requests (resident_id)
+  WHERE decision = 'pending';
+-- The queue the sweep reads: adverse action owed and not yet sent.
+CREATE INDEX screening_notice_owed ON screening_requests (property_id)
+  WHERE adverse_action_required AND adverse_action_sent_on IS NULL;
+
+CREATE TRIGGER screening_requests_set_updated_at
+  BEFORE UPDATE ON screening_requests
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+COMMENT ON TABLE screening_requests IS
+  'A decision and its dates. There is deliberately nowhere here to put a '
+  'score, a record, or a bureau reason code: the FCRA obliges a notice, not '
+  'a warehouse, and every stored attribute about an applicant is '
+  'fair-housing exposure that improves no decision this system makes.';
+
+COMMENT ON COLUMN screening_requests.adverse_action_required IS
+  'Derived, never asserted: s.615(a) attaches when adverse action is taken '
+  'AND a consumer report drove it in whole or in part. Conditional approval '
+  'counts as adverse action (15 U.S.C. 1681a(k)(1)(B)(ii)) — a bigger '
+  'deposit because of a report is exactly the case the statute is about.';
+
+-- ---------------------------------------------------------------------------
+-- The notice becomes a deadline
+-- ---------------------------------------------------------------------------
+
+ALTER TYPE deadline_kind ADD VALUE IF NOT EXISTS 'adverse_action_notice';
+
+-- Without its own anchor, two applicants denied on the same day at the same
+-- property would collapse into one deadline and the second notice would go
+-- unsent. The vendor anchor in 016 exists for the same reason.
+ALTER TABLE deadlines
+  ADD COLUMN screening_request_id UUID REFERENCES screening_requests (id) ON DELETE CASCADE;
+
+DROP INDEX deadlines_sweep_identity;
+CREATE UNIQUE INDEX deadlines_sweep_identity
+  ON deadlines (kind, due_on, property_id, entity_id, lease_id,
+                policy_id, debt_id, exchange_id, appeal_id, vendor_id,
+                screening_request_id)
+  NULLS NOT DISTINCT;

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -1018,6 +1018,101 @@ SELECT assert_rejected(
   'the same vendor expiry generated twice');
 
 \echo ''
+\echo 'screening and adverse action'
+INSERT INTO residents (id, full_name)
+  VALUES ('99999999-9999-4999-8999-999999999901', 'A. Applicant');
+SELECT assert_rejected(
+  $$INSERT INTO screening_requests (resident_id, property_id, decision)
+    VALUES ('99999999-9999-4999-8999-999999999901',
+            '33333333-3333-3333-3333-333333333333', 'denied')$$,
+  'decided_requests_say_when',
+  'a decision with no date');
+SELECT assert_rejected(
+  $$INSERT INTO screening_requests
+      (resident_id, property_id, requested_on, decision, decided_on)
+    VALUES ('99999999-9999-4999-8999-999999999901',
+            '33333333-3333-3333-3333-333333333333', '2026-08-01', 'pending',
+            '2026-08-05')$$,
+  'pending_requests_are_undecided',
+  'an undecided request carrying a decision date');
+SELECT assert_rejected(
+  $$INSERT INTO screening_requests
+      (resident_id, property_id, requested_on, decision, decided_on)
+    VALUES ('99999999-9999-4999-8999-999999999901',
+            '33333333-3333-3333-3333-333333333333', '2026-08-10', 'approved',
+            '2026-08-01')$$,
+  'decided_after_requested',
+  'a decision made before the application arrived');
+SELECT assert_rejected(
+  $$INSERT INTO screening_requests
+      (resident_id, property_id, requested_on, decision, decided_on,
+       based_on_consumer_report, adverse_action_sent_on)
+    VALUES ('99999999-9999-4999-8999-999999999901',
+            '33333333-3333-3333-3333-333333333333', '2026-08-01', 'denied',
+            '2026-08-05', TRUE, '2026-08-02')$$,
+  'notice_follows_its_decision',
+  'a notice sent before the decision it is about');
+SELECT assert_rejected(
+  $$INSERT INTO screening_requests
+      (resident_id, property_id, requested_on, decision, decided_on,
+       based_on_consumer_report, adverse_action_sent_on)
+    VALUES ('99999999-9999-4999-8999-999999999901',
+            '33333333-3333-3333-3333-333333333333', '2026-08-01', 'approved',
+            '2026-08-05', TRUE, '2026-08-06')$$,
+  'notice_only_when_a_report_drove_an_adverse_decision',
+  'an adverse-action notice for an approval');
+-- The obligation is DERIVED: both halves of s.615(a) or it does not attach.
+INSERT INTO screening_requests
+  (id, resident_id, property_id, requested_on, decision, decided_on,
+   based_on_consumer_report)
+VALUES ('99999999-9999-4999-8999-999999999902',
+        '99999999-9999-4999-8999-999999999901',
+        '33333333-3333-3333-3333-333333333333', '2026-08-01', 'denied',
+        '2026-08-05', TRUE);
+INSERT INTO screening_requests
+  (id, resident_id, property_id, requested_on, decision, decided_on,
+   based_on_consumer_report)
+VALUES ('99999999-9999-4999-8999-999999999903',
+        '99999999-9999-4999-8999-999999999901',
+        '33333333-3333-3333-3333-333333333333', '2026-08-01', 'denied',
+        '2026-08-05', FALSE);
+DO $$
+DECLARE
+  with_report BOOLEAN;
+  without_report BOOLEAN;
+BEGIN
+  SELECT adverse_action_required INTO with_report FROM screening_requests
+    WHERE id = '99999999-9999-4999-8999-999999999902';
+  SELECT adverse_action_required INTO without_report FROM screening_requests
+    WHERE id = '99999999-9999-4999-8999-999999999903';
+  IF NOT with_report OR without_report THEN
+    RAISE EXCEPTION 'DERIVATION WRONG: report-driven=%, owner-judgement=%',
+      with_report, without_report;
+  END IF;
+  RAISE NOTICE '  ok      s.615(a) attaches only when a report drove the denial';
+END $$;
+-- Two applicants denied the same day at one property are two notices.
+SELECT assert_accepted(
+  $$INSERT INTO deadlines (kind, due_on, property_id, screening_request_id, citation)
+    VALUES ('adverse_action_notice', '2026-08-05',
+            '33333333-3333-3333-3333-333333333333',
+            '99999999-9999-4999-8999-999999999902', 'FCRA s.615(a)')$$,
+  'an adverse-action notice as a deadline');
+SELECT assert_accepted(
+  $$INSERT INTO deadlines (kind, due_on, property_id, screening_request_id, citation)
+    VALUES ('adverse_action_notice', '2026-08-05',
+            '33333333-3333-3333-3333-333333333333',
+            '99999999-9999-4999-8999-999999999903', 'FCRA s.615(a)')$$,
+  'a second applicant denied the same day is its own notice');
+SELECT assert_rejected(
+  $$INSERT INTO deadlines (kind, due_on, property_id, screening_request_id, citation)
+    VALUES ('adverse_action_notice', '2026-08-05',
+            '33333333-3333-3333-3333-333333333333',
+            '99999999-9999-4999-8999-999999999902', 'FCRA s.615(a)')$$,
+  'deadlines_sweep_identity',
+  'the same notice generated twice');
+
+\echo ''
 \echo 'document extraction'
 -- The blob key is provably the sha256 of the bytes.
 INSERT INTO source_documents (id, kind, filename, content_hash, status)

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -44,6 +44,7 @@ from hestia_api import (
     payments,
     rent,
     reports,
+    screening,
     sweep,
     views,
 )
@@ -1692,3 +1693,134 @@ def add_work_order_cost(
         after_value={"net_cost": str(work_order.net_cost)},
     )
     return work_order
+
+
+# ---------------------------------------------------------------------------
+# Screening decisions and the notice a denial owes (FCRA s.615(a))
+# ---------------------------------------------------------------------------
+
+
+@app.post("/screening", response_model=screening.ScreeningOut, status_code=201)
+def open_screening(
+    body: screening.ScreeningIn, conn: Conn, request: Request, actor: Actor = "system"
+) -> screening.ScreeningOut:
+    try:
+        result = screening.create(conn, body)
+    except screening.UnknownResident as error:
+        raise HTTPException(status_code=404, detail="resident not found") from error
+    except screening.UnknownProperty as error:
+        raise HTTPException(status_code=404, detail="property not found") from error
+    except psycopg.errors.ForeignKeyViolation as error:
+        raise HTTPException(
+            status_code=422, detail="that unit does not belong to that property"
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="screening.open",
+        request_id=request.state.request_id,
+        table_name="screening_requests",
+        record_id=result.id,
+        after_value={"provider": result.provider},
+    )
+    return result
+
+
+@app.get("/screening", response_model=list[screening.ScreeningOut])
+def list_screening(
+    conn: Conn,
+    resident_id: Annotated[uuid.UUID | None, Query()] = None,
+    property_id: Annotated[uuid.UUID | None, Query()] = None,
+    notice_owed: Annotated[bool, Query()] = False,
+) -> list[screening.ScreeningOut]:
+    return screening.list_requests(
+        conn,
+        resident_id=str(resident_id) if resident_id else None,
+        property_id=str(property_id) if property_id else None,
+        notice_owed=notice_owed,
+    )
+
+
+@app.get("/screening/{screening_id}", response_model=screening.ScreeningOut)
+def read_screening(screening_id: uuid.UUID, conn: Conn) -> screening.ScreeningOut:
+    try:
+        return screening.read(conn, str(screening_id))
+    except screening.UnknownScreening as error:
+        raise HTTPException(status_code=404, detail="screening not found") from error
+
+
+@app.post("/screening/{screening_id}/decision", response_model=screening.ScreeningOut)
+def decide_screening(
+    screening_id: uuid.UUID,
+    body: screening.DecisionIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> screening.ScreeningOut:
+    try:
+        result = screening.decide(conn, str(screening_id), body)
+    except screening.UnknownScreening as error:
+        raise HTTPException(status_code=404, detail="screening not found") from error
+    except screening.AlreadyDecided as error:
+        raise HTTPException(
+            status_code=409,
+            detail=f"this application was already {error}; a decision is recorded once",
+        ) from error
+    except psycopg.errors.CheckViolation as error:
+        raise HTTPException(
+            status_code=422,
+            detail="a decision cannot precede the application it answers",
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="screening.decide",
+        request_id=request.state.request_id,
+        table_name="screening_requests",
+        record_id=str(screening_id),
+        after_value={
+            "decision": result.decision,
+            "adverse_action_required": result.adverse_action_required,
+        },
+    )
+    return result
+
+
+@app.post("/screening/{screening_id}/adverse-action", response_model=screening.ScreeningOut)
+def record_adverse_action(
+    screening_id: uuid.UUID,
+    body: screening.NoticeIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> screening.ScreeningOut:
+    try:
+        result = screening.record_notice(conn, str(screening_id), body)
+    except screening.UnknownScreening as error:
+        raise HTTPException(status_code=404, detail="screening not found") from error
+    except screening.NoticeNotOwed as error:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "no notice is owed: s.615(a) attaches only when a consumer "
+                "report drove an adverse decision"
+            ),
+        ) from error
+    except screening.NoticeAlreadySent as error:
+        raise HTTPException(
+            status_code=409, detail=f"the notice was already sent on {error}"
+        ) from error
+    except psycopg.errors.CheckViolation as error:
+        raise HTTPException(
+            status_code=422, detail="a notice cannot precede the decision it is about"
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="screening.adverse_action",
+        request_id=request.state.request_id,
+        table_name="screening_requests",
+        record_id=str(screening_id),
+        after_value={"sent_on": str(result.adverse_action_sent_on)},
+    )
+    return result

--- a/services/api/hestia_api/screening.py
+++ b/services/api/hestia_api/screening.py
@@ -1,0 +1,293 @@
+"""Screening decisions and the notice a denial owes.
+
+The FCRA obliges a notice, not a warehouse. Nothing here stores a score, a
+record, or a bureau reason code — only what was decided, when, whether a
+consumer report drove it, and when the notice went out. The obligation is
+derived in the database from those facts so it cannot drift from them.
+
+The authority is 15 U.S.C. 1681m(a) (FCRA s.615(a)): a user who takes adverse
+action with respect to a consumer, based in whole or in part on a consumer
+report, must notify that consumer. The statute sets no day count, so this
+module never invents one — the duty is dated to the decision, which is when it
+attaches, and the deadline says so.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any, Literal
+
+import psycopg
+from pydantic import BaseModel, Field
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+ADVERSE_ACTION_CITATION = (
+    "FCRA s.615(a), 15 U.S.C. 1681m(a) — a user taking adverse action based in "
+    "whole or in part on a consumer report must notify the consumer. The "
+    "statute sets no day count, so the duty is dated to the decision."
+)
+
+# What the letter must contain, from the statute itself. Enumerated server-side
+# because the browser displays what it is told; it does not know the law.
+NOTICE_CONTENTS: tuple[dict[str, str], ...] = (
+    {
+        "requirement": "State the adverse action taken",
+        "citation": "15 U.S.C. 1681m(a)",
+    },
+    {
+        "requirement": (
+            "Give the name, address and telephone number of the consumer "
+            "reporting agency that furnished the report, including a toll-free "
+            "number if the agency compiles nationwide files"
+        ),
+        "citation": "15 U.S.C. 1681m(a)(3)",
+    },
+    {
+        "requirement": (
+            "State that the reporting agency did not make the decision and "
+            "cannot give the specific reasons for it"
+        ),
+        "citation": "15 U.S.C. 1681m(a)(4)(A)",
+    },
+    {
+        "requirement": (
+            "Tell the consumer of their right to a free copy of the report "
+            "from that agency within sixty days"
+        ),
+        "citation": "15 U.S.C. 1681m(a)(4)(B), 1681j(b)",
+    },
+    {
+        "requirement": (
+            "Tell the consumer of their right to dispute the accuracy or "
+            "completeness of any information in the report"
+        ),
+        "citation": "15 U.S.C. 1681m(a)(4)(B), 1681i",
+    },
+)
+
+
+class UnknownResident(Exception):
+    pass
+
+
+class UnknownProperty(Exception):
+    pass
+
+
+class UnknownScreening(Exception):
+    pass
+
+
+class AlreadyDecided(Exception):
+    """A decision is made once; changing it would rewrite why someone was
+    refused a home."""
+
+
+class NoticeNotOwed(Exception):
+    """Only an adverse decision a report drove owes a notice."""
+
+
+class NoticeAlreadySent(Exception):
+    pass
+
+
+Decision = Literal["approved", "conditional", "denied", "withdrawn"]
+
+
+class ScreeningIn(BaseModel):
+    resident_id: uuid.UUID
+    property_id: uuid.UUID
+    unit_id: uuid.UUID | None = None
+    requested_on: dt.date | None = None
+    provider: str = Field(default="manual", min_length=1, max_length=80)
+    notes: str | None = None
+
+
+class DecisionIn(BaseModel):
+    decision: Decision
+    decided_on: dt.date | None = None
+    # The owner's own words. Never a bureau reason code.
+    decision_basis: str | None = None
+    based_on_consumer_report: bool = False
+
+
+class NoticeIn(BaseModel):
+    sent_on: dt.date | None = None
+
+
+class ScreeningOut(BaseModel):
+    id: str
+    resident_id: str
+    resident_name: str
+    property_id: str
+    property_label: str
+    unit_id: str | None
+    unit_label: str | None
+    requested_on: dt.date
+    provider: str
+    decision: str
+    decided_on: dt.date | None
+    decision_basis: str | None
+    based_on_consumer_report: bool
+    adverse_action_required: bool
+    adverse_action_sent_on: dt.date | None
+    notes: str | None
+    # Present exactly when a notice is owed and unsent — the checklist is the
+    # answer to "what do I have to say in the letter", not decoration.
+    notice_contents: list[dict[str, str]]
+    citation: str | None
+
+
+def _read(conn: Conn, screening_id: str) -> ScreeningOut:
+    row = conn.execute(
+        """
+        SELECT s.id::text, s.resident_id::text, r.full_name AS resident_name,
+               s.property_id::text, p.label AS property_label,
+               s.unit_id::text, u.label AS unit_label,
+               s.requested_on, s.provider, s.decision::text AS decision,
+               s.decided_on, s.decision_basis, s.based_on_consumer_report,
+               s.adverse_action_required, s.adverse_action_sent_on, s.notes
+        FROM screening_requests s
+        JOIN residents r ON r.id = s.resident_id
+        JOIN properties p ON p.id = s.property_id
+        LEFT JOIN units u ON u.id = s.unit_id
+        WHERE s.id = %s
+        """,
+        (screening_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownScreening(screening_id)
+    owed = row["adverse_action_required"] and row["adverse_action_sent_on"] is None
+    return ScreeningOut(
+        **row,
+        notice_contents=[dict(item) for item in NOTICE_CONTENTS] if owed else [],
+        citation=ADVERSE_ACTION_CITATION if row["adverse_action_required"] else None,
+    )
+
+
+def create(conn: Conn, body: ScreeningIn) -> ScreeningOut:
+    resident = conn.execute(
+        "SELECT id::text FROM residents WHERE id = %s", (body.resident_id,)
+    ).fetchone()
+    if resident is None:
+        raise UnknownResident(str(body.resident_id))
+    prop = conn.execute(
+        "SELECT id::text FROM properties WHERE id = %s", (body.property_id,)
+    ).fetchone()
+    if prop is None:
+        raise UnknownProperty(str(body.property_id))
+    row = conn.execute(
+        """
+        INSERT INTO screening_requests
+          (resident_id, property_id, unit_id, requested_on, provider, notes)
+        VALUES (%s, %s, %s, coalesce(%s, CURRENT_DATE), %s, %s)
+        RETURNING id::text
+        """,
+        (
+            body.resident_id,
+            body.property_id,
+            body.unit_id,
+            body.requested_on,
+            body.provider,
+            body.notes,
+        ),
+    ).fetchone()
+    return _read(conn, row["id"])
+
+
+def decide(conn: Conn, screening_id: str, body: DecisionIn) -> ScreeningOut:
+    """One decision, recorded once. A screening decision is the reason someone
+    did or did not get a home; re-deciding it would rewrite that record."""
+    current = conn.execute(
+        "SELECT decision::text AS decision FROM screening_requests WHERE id = %s FOR UPDATE",
+        (screening_id,),
+    ).fetchone()
+    if current is None:
+        raise UnknownScreening(screening_id)
+    if current["decision"] != "pending":
+        raise AlreadyDecided(current["decision"])
+    conn.execute(
+        """
+        UPDATE screening_requests
+        SET decision = %s, decided_on = coalesce(%s, CURRENT_DATE),
+            decision_basis = %s, based_on_consumer_report = %s
+        WHERE id = %s
+        """,
+        (
+            body.decision,
+            body.decided_on,
+            body.decision_basis,
+            body.based_on_consumer_report,
+            screening_id,
+        ),
+    )
+    return _read(conn, screening_id)
+
+
+def record_notice(conn: Conn, screening_id: str, body: NoticeIn) -> ScreeningOut:
+    """Recording the notice resolves the deadline that demanded it."""
+    row = conn.execute(
+        """
+        SELECT adverse_action_required, adverse_action_sent_on, decided_on
+        FROM screening_requests WHERE id = %s FOR UPDATE
+        """,
+        (screening_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownScreening(screening_id)
+    if not row["adverse_action_required"]:
+        raise NoticeNotOwed(screening_id)
+    if row["adverse_action_sent_on"] is not None:
+        raise NoticeAlreadySent(str(row["adverse_action_sent_on"]))
+    sent_on = body.sent_on or dt.date.today()
+    conn.execute(
+        "UPDATE screening_requests SET adverse_action_sent_on = %s WHERE id = %s",
+        (sent_on, screening_id),
+    )
+    # The resident's own summary field, which 003 has carried all along.
+    conn.execute(
+        """
+        UPDATE residents SET adverse_action_sent_on = %s
+        WHERE id = (SELECT resident_id FROM screening_requests WHERE id = %s)
+        """,
+        (sent_on, screening_id),
+    )
+    conn.execute(
+        """
+        UPDATE deadlines SET status = 'done', completed_on = %s
+        WHERE screening_request_id = %s AND status = 'upcoming'
+        """,
+        (sent_on, screening_id),
+    )
+    return _read(conn, screening_id)
+
+
+def read(conn: Conn, screening_id: str) -> ScreeningOut:
+    return _read(conn, screening_id)
+
+
+def list_requests(
+    conn: Conn,
+    *,
+    resident_id: str | None = None,
+    property_id: str | None = None,
+    notice_owed: bool = False,
+) -> list[ScreeningOut]:
+    rows = conn.execute(
+        """
+        SELECT id::text FROM screening_requests
+        WHERE (%(resident_id)s::uuid IS NULL OR resident_id = %(resident_id)s::uuid)
+          AND (%(property_id)s::uuid IS NULL OR property_id = %(property_id)s::uuid)
+          AND (NOT %(notice_owed)s
+               OR (adverse_action_required AND adverse_action_sent_on IS NULL))
+        ORDER BY requested_on DESC, id
+        """,
+        {
+            "resident_id": resident_id,
+            "property_id": property_id,
+            "notice_owed": notice_owed,
+        },
+    ).fetchall()
+    return [_read(conn, row["id"]) for row in rows]

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -22,18 +22,21 @@ from typing import Any
 import psycopg
 
 from hestia_api import calendar
+from hestia_api.screening import ADVERSE_ACTION_CITATION
 
 Conn = psycopg.Connection[dict[str, Any]]
 
 INSERT = """
 INSERT INTO deadlines
   (kind, due_on, window_opens_on, property_id, entity_id, lease_id,
-   policy_id, debt_id, exchange_id, vendor_id, citation, note)
+   policy_id, debt_id, exchange_id, vendor_id, screening_request_id,
+   citation, note)
 VALUES (%(kind)s, %(due_on)s, %(window_opens_on)s, %(property_id)s, %(entity_id)s,
         %(lease_id)s, %(policy_id)s, %(debt_id)s, %(exchange_id)s, %(vendor_id)s,
-        %(citation)s, %(note)s)
+        %(screening_request_id)s, %(citation)s, %(note)s)
 ON CONFLICT (kind, due_on, property_id, entity_id, lease_id,
-             policy_id, debt_id, exchange_id, appeal_id, vendor_id)
+             policy_id, debt_id, exchange_id, appeal_id, vendor_id,
+             screening_request_id)
 DO NOTHING
 """
 
@@ -71,6 +74,7 @@ def _row(kind: str, due_on: dt.date, citation: str, **anchors: Any) -> dict[str,
         "debt_id": None,
         "exchange_id": None,
         "vendor_id": None,
+        "screening_request_id": None,
         "citation": citation,
         "note": None,
     }
@@ -342,6 +346,37 @@ def _vendor_credentials(conn: Conn, as_of: dt.date) -> list[dict[str, Any]]:
     return out
 
 
+def _adverse_action_notices(conn: Conn, as_of: dt.date) -> list[dict[str, Any]]:
+    """A denial a consumer report drove owes the applicant a notice.
+
+    FCRA s.615(a) sets no day count, so none is invented: the duty is dated to
+    the decision, which is when it attaches. Anchored on the request, so two
+    applicants refused on one day at one property are two notices (module 018
+    added the anchor for exactly that).
+    """
+    rows = conn.execute(
+        """
+        SELECT s.id, s.property_id, s.decided_on, s.decision::text AS decision,
+               r.full_name
+        FROM screening_requests s JOIN residents r ON r.id = s.resident_id
+        WHERE s.adverse_action_required
+          AND s.adverse_action_sent_on IS NULL
+          AND s.decided_on IS NOT NULL
+        """,
+    ).fetchall()
+    return [
+        _row(
+            "adverse_action_notice",
+            record["decided_on"],
+            ADVERSE_ACTION_CITATION,
+            property_id=record["property_id"],
+            screening_request_id=record["id"],
+            note=f"{record['full_name']} — {record['decision']}",
+        )
+        for record in rows
+    ]
+
+
 GENERATORS = (
     _lease_expirations,
     _policy_expirations,
@@ -349,6 +384,7 @@ GENERATORS = (
     _exchange_clocks,
     _entity_tax_dates,
     _vendor_credentials,
+    _adverse_action_notices,
 )
 
 

--- a/services/api/tests/test_screening.py
+++ b/services/api/tests/test_screening.py
@@ -1,0 +1,361 @@
+"""Screening decisions and the notice a denial owes.
+
+The acceptance criteria of issue #3, made executable: record a denial and the
+deadline appears with its citation; record the sent date and it resolves. The
+whole workflow is FCRA-complete with no provider at all.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from hestia_api import screening
+
+
+@pytest.fixture
+def applicant(newport_property: str, client: TestClient) -> dict[str, str]:
+    resident = client.post("/residents", json={"full_name": "A. Applicant"}).json()
+    return {"property": newport_property, "resident": resident["id"]}
+
+
+def open_request(client: TestClient, world: dict[str, str], **overrides: Any) -> dict[str, Any]:
+    body = {
+        "resident_id": world["resident"],
+        "property_id": world["property"],
+        "requested_on": "2026-08-01",
+        **overrides,
+    }
+    response = client.post("/screening", json=body)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+class TestTheAcceptanceWalk:
+    def test_a_denial_raises_the_notice_and_sending_it_resolves(
+        self, applicant: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        request = open_request(client, applicant)
+        assert request["decision"] == "pending"
+        assert request["adverse_action_required"] is False
+        assert request["notice_contents"] == []
+
+        decided = client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "denied",
+                "decided_on": "2026-08-05",
+                "decision_basis": "income below the posted standard",
+                "based_on_consumer_report": True,
+            },
+        ).json()
+        assert decided["adverse_action_required"] is True
+        # The letter's required contents come from the server, cited.
+        assert len(decided["notice_contents"]) == len(screening.NOTICE_CONTENTS)
+        assert any("free copy" in item["requirement"] for item in decided["notice_contents"])
+        assert all("1681m" in item["citation"] for item in decided["notice_contents"])
+        assert "1681m(a)" in decided["citation"]
+
+        client.post("/sweep/deadlines?as_of=2026-08-06")
+        deadline = conn.execute(
+            """
+            SELECT kind::text AS kind, due_on, status::text AS status, citation, note
+            FROM deadlines WHERE screening_request_id = %s
+            """,
+            (request["id"],),
+        ).fetchone()
+        assert deadline is not None
+        assert deadline["kind"] == "adverse_action_notice"
+        # Dated to the decision: the statute sets no day count, so none is invented.
+        assert deadline["due_on"] == dt.date(2026, 8, 5)
+        assert deadline["status"] == "upcoming"
+        assert "1681m(a)" in deadline["citation"]
+        assert "A. Applicant" in deadline["note"]
+
+        sent = client.post(
+            f"/screening/{request['id']}/adverse-action", json={"sent_on": "2026-08-07"}
+        ).json()
+        assert sent["adverse_action_sent_on"] == "2026-08-07"
+        assert sent["notice_contents"] == []  # nothing left owed
+
+        resolved = conn.execute(
+            "SELECT status::text AS status, completed_on FROM deadlines"
+            " WHERE screening_request_id = %s",
+            (request["id"],),
+        ).fetchone()
+        assert resolved["status"] == "done"
+        assert resolved["completed_on"] == dt.date(2026, 8, 7)
+        # The resident's own summary field, carried since module 003.
+        assert conn.execute(
+            "SELECT adverse_action_sent_on FROM residents WHERE id = %s",
+            (applicant["resident"],),
+        ).fetchone()["adverse_action_sent_on"] == dt.date(2026, 8, 7)
+
+        # Re-sweeping raises nothing new: the duty is discharged.
+        client.post("/sweep/deadlines?as_of=2026-08-08")
+        assert (
+            conn.execute(
+                "SELECT count(*) AS n FROM deadlines WHERE screening_request_id = %s",
+                (request["id"],),
+            ).fetchone()["n"]
+            == 1
+        )
+
+    def test_two_applicants_refused_on_one_day_are_two_notices(
+        self, applicant: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """Without its own anchor the second notice would collapse into the
+        first and go unsent."""
+        second = client.post("/residents", json={"full_name": "B. Applicant"}).json()
+        ids = []
+        for resident in (applicant["resident"], second["id"]):
+            request = open_request(client, applicant, resident_id=resident)
+            client.post(
+                f"/screening/{request['id']}/decision",
+                json={
+                    "decision": "denied",
+                    "decided_on": "2026-08-05",
+                    "based_on_consumer_report": True,
+                },
+            )
+            ids.append(request["id"])
+        client.post("/sweep/deadlines?as_of=2026-08-06")
+        rows = conn.execute(
+            "SELECT screening_request_id::text AS sid FROM deadlines"
+            " WHERE kind::text = 'adverse_action_notice' AND due_on = '2026-08-05'"
+        ).fetchall()
+        assert sorted(r["sid"] for r in rows) == sorted(ids)
+
+
+class TestWhenTheDutyAttaches:
+    def test_a_conditional_approval_on_a_report_is_adverse_action(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        """A larger deposit because of a report is exactly what
+        15 U.S.C. 1681a(k)(1)(B)(ii) is about."""
+        request = open_request(client, applicant)
+        decided = client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "conditional",
+                "decided_on": "2026-08-05",
+                "decision_basis": "approved with a double deposit",
+                "based_on_consumer_report": True,
+            },
+        ).json()
+        assert decided["adverse_action_required"] is True
+
+    def test_a_denial_on_the_owner_s_own_judgement_owes_nothing(
+        self, applicant: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """Both halves of s.615(a) or it does not attach: no report, no notice."""
+        request = open_request(client, applicant)
+        decided = client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "denied",
+                "decided_on": "2026-08-05",
+                "decision_basis": "the unit was let to an earlier applicant",
+                "based_on_consumer_report": False,
+            },
+        ).json()
+        assert decided["adverse_action_required"] is False
+        assert decided["citation"] is None
+        client.post("/sweep/deadlines?as_of=2026-08-06")
+        assert (
+            conn.execute(
+                "SELECT count(*) AS n FROM deadlines WHERE screening_request_id = %s",
+                (request["id"],),
+            ).fetchone()["n"]
+            == 0
+        )
+
+    def test_an_approval_owes_nothing_and_cannot_send_one(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        request = open_request(client, applicant)
+        client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "approved",
+                "decided_on": "2026-08-05",
+                "based_on_consumer_report": True,
+            },
+        )
+        response = client.post(f"/screening/{request['id']}/adverse-action", json={})
+        assert response.status_code == 422
+        assert "s.615(a) attaches only when" in response.json()["detail"]
+
+    def test_a_withdrawal_is_not_adverse_action(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        request = open_request(client, applicant)
+        decided = client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "withdrawn",
+                "decided_on": "2026-08-05",
+                "based_on_consumer_report": True,
+            },
+        ).json()
+        assert decided["adverse_action_required"] is False
+
+
+class TestRefusals:
+    def test_a_decision_is_recorded_once(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        request = open_request(client, applicant)
+        assert (
+            client.post(
+                f"/screening/{request['id']}/decision",
+                json={"decision": "approved", "decided_on": "2026-08-05"},
+            ).status_code
+            == 200
+        )
+        again = client.post(
+            f"/screening/{request['id']}/decision",
+            json={"decision": "denied", "decided_on": "2026-08-06"},
+        )
+        assert again.status_code == 409
+        assert "already approved" in again.json()["detail"]
+
+    def test_a_notice_is_sent_once(self, applicant: dict[str, str], client: TestClient) -> None:
+        request = open_request(client, applicant)
+        client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "denied",
+                "decided_on": "2026-08-05",
+                "based_on_consumer_report": True,
+            },
+        )
+        assert (
+            client.post(
+                f"/screening/{request['id']}/adverse-action", json={"sent_on": "2026-08-07"}
+            ).status_code
+            == 200
+        )
+        again = client.post(
+            f"/screening/{request['id']}/adverse-action", json={"sent_on": "2026-08-08"}
+        )
+        assert again.status_code == 409
+        assert "already sent on 2026-08-07" in again.json()["detail"]
+
+    def test_a_decision_cannot_precede_the_application(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        request = open_request(client, applicant)
+        response = client.post(
+            f"/screening/{request['id']}/decision",
+            json={"decision": "approved", "decided_on": "2026-07-01"},
+        )
+        assert response.status_code == 422
+        assert "cannot precede the application" in response.json()["detail"]
+
+    def test_a_notice_cannot_precede_its_decision(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        request = open_request(client, applicant)
+        client.post(
+            f"/screening/{request['id']}/decision",
+            json={
+                "decision": "denied",
+                "decided_on": "2026-08-05",
+                "based_on_consumer_report": True,
+            },
+        )
+        response = client.post(
+            f"/screening/{request['id']}/adverse-action", json={"sent_on": "2026-08-01"}
+        )
+        assert response.status_code == 422
+        assert "cannot precede the decision" in response.json()["detail"]
+
+    def test_unknown_things_are_404_and_a_foreign_unit_is_422(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        ghost = "00000000-0000-4000-8000-000000000000"
+        assert client.get(f"/screening/{ghost}").status_code == 404
+        assert (
+            client.post(f"/screening/{ghost}/decision", json={"decision": "approved"}).status_code
+            == 404
+        )
+        assert client.post(f"/screening/{ghost}/adverse-action", json={}).status_code == 404
+        assert (
+            client.post(
+                "/screening", json={"resident_id": ghost, "property_id": applicant["property"]}
+            ).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                "/screening", json={"resident_id": applicant["resident"], "property_id": ghost}
+            ).status_code
+            == 404
+        )
+        entity = client.post("/entities", json={"name": "Elsewhere", "kind": "llc"}).json()
+        other = client.post(
+            "/properties",
+            json={
+                "entity_id": entity["id"],
+                "label": "Elsewhere",
+                "street_1": "9 Elsewhere Ave",
+                "city": "Newport",
+                "state": "KY",
+                "postal_code": "41071",
+                "kind": "single_family",
+            },
+        ).json()
+        unit = client.post("/units", json={"property_id": other["id"], "label": "Z"}).json()
+        response = client.post(
+            "/screening",
+            json={
+                "resident_id": applicant["resident"],
+                "property_id": applicant["property"],
+                "unit_id": unit["id"],
+            },
+        )
+        assert response.status_code == 422
+
+
+class TestQueue:
+    def test_the_queue_answers_who_is_still_owed_a_letter(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        owed = open_request(client, applicant)
+        client.post(
+            f"/screening/{owed['id']}/decision",
+            json={
+                "decision": "denied",
+                "decided_on": "2026-08-05",
+                "based_on_consumer_report": True,
+            },
+        )
+        settled = open_request(client, applicant)
+        client.post(
+            f"/screening/{settled['id']}/decision",
+            json={"decision": "approved", "decided_on": "2026-08-05"},
+        )
+        queue = client.get("/screening?notice_owed=true").json()
+        assert [row["id"] for row in queue] == [owed["id"]]
+        by_resident = client.get(f"/screening?resident_id={applicant['resident']}").json()
+        assert len(by_resident) == 2
+        by_property = client.get(f"/screening?property_id={applicant['property']}").json()
+        assert len(by_property) == 2
+        assert client.get(f"/screening/{owed['id']}").json()["resident_name"] == "A. Applicant"
+
+    def test_a_request_can_name_its_unit_and_provider(
+        self, applicant: dict[str, str], client: TestClient
+    ) -> None:
+        unit = client.post(
+            "/units", json={"property_id": applicant["property"], "label": "B"}
+        ).json()
+        request = open_request(
+            client, applicant, unit_id=unit["id"], provider="transunion_shareable", notes="walk-in"
+        )
+        assert request["unit_label"] == "B"
+        assert request["provider"] == "transunion_shareable"
+        assert request["notes"] == "walk-in"


### PR DESCRIPTION
Closes #3.

**The FCRA obliges a notice, not a warehouse.** Module 018 keeps the promise `residents` has carried since 003: there is nowhere here to put a score, a record, or a bureau reason code — only what was decided, when, whether a consumer report drove it, and when the letter went out.

**The obligation is derived, never asserted.** s.615(a) attaches when adverse action is taken *and* a report drove it in whole or in part, so both halves are recorded separately and `adverse_action_required` is a `GENERATED` column over them. A boolean somebody sets by hand is a claim; this is a consequence. A conditional approval counts — a bigger deposit because of a report is exactly what 15 U.S.C. 1681a(k)(1)(B)(ii) is about — and a denial on the owner's own judgement owes nothing.

**No invented deadline.** The statute sets no day count, so the duty is dated to the decision, which is when it attaches, and the citation says exactly that. `deadlines` gained a screening anchor and the sweep identity index was rebuilt around it: without one, two applicants refused on the same day at the same property collapse into a single row and the second letter never gets sent — the same trap the vendor anchor closed in 016. Recording the sent date resolves the deadline and writes the resident's own summary field.

**The letter's contents are enumerated server-side**, each requirement with the subsection that demands it (1681m(a), (a)(3), (a)(4)(A), (a)(4)(B) with 1681j(b) and 1681i). The browser displays what it is told; it does not know the law.

**Recorded once.** A decision is made once and a notice sent once — re-deciding would rewrite why someone was refused a home.

### Acceptance
- [x] Record a denial → the deadline appears with its citation (test asserts kind, due date, `upcoming`, the 1681m(a) citation and the applicant's name in the note).
- [x] Record the sent date → it resolves (`done` + `completed_on`), and a re-sweep raises nothing new.
- [x] FCRA-complete with no provider at all; `provider` defaults to `manual` and TransUnion ShareAble remains a follow-on adapter.
- [x] Constraint proofs by name: `decided_requests_say_when`, `pending_requests_are_undecided`, `decided_after_requested`, `notice_follows_its_decision`, `notice_only_when_a_report_drove_an_adverse_decision`, plus the derivation itself and the two-applicants-one-day case.

245 API tests at 100% line+branch · 136 schema assertions · contract regenerated · web typechecks · lint, state-literal ratchet, config audit and actionlint clean.

**Handed over:** the screening panel and adverse-action checklist UI live in `apps/web`, the other agent's surface. The API returns the checklist ready to render — noted in the shared log rather than edited across the boundary.