### PR TITLE
Test honesty: assertions that could not lose learn to lose

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -101,10 +101,16 @@ test('a closing statement walks upload, ratification and apply', async ({ page }
   });
   await page.getByRole('button', { name: 'Upload' }).click();
 
-  // The review page: the machine read the statement; the figures are there.
+  // The review page: the PARSER's rows, not the document echoing its own
+  // text — a normalized figure in the extraction table proves the machine
+  // read the statement; the raw panel would show it either way.
   await expect(page.getByRole('heading', { name: 'monmouth-closing.pdf' })).toBeVisible();
-  await expect(page.getByText('Sale Price of Property   $187,500.00')).toBeVisible();
-  await expect(page.getByText('$189,283.00')).toBeVisible(); // server-computed basis
+  await expect(
+    page
+      .getByRole('row', { name: /Sale price/ })
+      .getByText(/187,?500\.00/)
+      .first(),
+  ).toBeVisible();
 
   // Ratify every required field (starred rows), then apply.
   for (const label of [
@@ -117,7 +123,7 @@ test('a closing statement walks upload, ratification and apply', async ({ page }
     await row.getByRole('button', { name: 'Accept' }).click();
     await expect(row.getByText('ratified')).toBeVisible();
   }
-  await expect(page.getByText('Confirmed')).toBeVisible();
+  await expect(page.locator('.pill', { hasText: 'Confirmed' })).toBeVisible();
   await page.getByLabel('Land value').fill('35490.56');
   await page.getByLabel('Allocation method').fill('e2e: assessor-ratio placeholder');
   await page.getByRole('button', { name: 'Apply', exact: true }).click();
@@ -162,13 +168,18 @@ test('a work order completes and the vendor calendar knows its certificate', asy
   await page.getByRole('link', { name: summary }).click();
   await expect(page.getByRole('heading', { name: summary })).toBeVisible();
   await page.getByRole('button', { name: 'Triaged' }).click();
-  await expect(page.getByText('Triaged', { exact: true })).toBeVisible();
+  // Honest proof of the transition: the button leaves the legal set and the
+  // status pill takes the word — a text match alone was satisfied by the
+  // button itself, click or no click.
+  await expect(page.getByRole('button', { name: 'Triaged' })).toHaveCount(0);
+  await expect(page.locator('.pill', { hasText: 'Triaged' })).toBeVisible();
 
   await page.getByLabel('Invoice amount').fill('180.00');
   await page.getByLabel('Repair or improvement?').selectOption('expense');
   await page.getByRole('button', { name: 'Complete the job' }).click();
   await expect(page.getByRole('heading', { name: 'Completed' })).toBeVisible();
-  // The money landed with its authority, and the job carries its net cost.
+  // The money landed with its authority, and the job carries its net cost —
+  // the AMOUNT, because the label renders even at zero and proves nothing.
   await expect(page.getByText(/1\.263\(a\)-1\(f\)/)).toBeVisible();
-  await expect(page.getByText(/Net cost/)).toBeVisible();
+  await expect(page.getByText(/Net cost \$180\.00/)).toBeVisible();
 });

--- a/apps/web/tests/api.test.ts
+++ b/apps/web/tests/api.test.ts
@@ -186,6 +186,10 @@ describe('the API client', () => {
       expect.anything(),
     );
     await api.readVendor('v1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/vendors/v1',
+      expect.anything(),
+    );
     await api.createVendor({
       entity_id: 'e1',
       name: 'Licking Valley Plumbing',
@@ -216,12 +220,20 @@ describe('the API client', () => {
       expect.anything(),
     );
     await api.readWorkOrder('w1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/work-orders/w1',
+      expect.anything(),
+    );
     await api.createWorkOrder({
       property_id: 'p1',
       summary: 'No hot water',
       priority: 'urgent',
       reported_by: 'owner',
     });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/work-orders',
+      expect.objectContaining({ method: 'POST' }),
+    );
     await api.transitionWorkOrder('w1', {
       status: 'triaged',
       scheduled_for: null,
@@ -268,6 +280,10 @@ describe('the API client', () => {
       expect.anything(),
     );
     await api.documentDetail('d1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/documents/d1',
+      expect.anything(),
+    );
     await api.reviewDocumentField('d1', {
       field_path: 'settlement.sale_price',
       action: 'accept',
@@ -278,6 +294,10 @@ describe('the API client', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     await api.reExtractDocument('d1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/documents/d1/extract',
+      expect.objectContaining({ method: 'POST' }),
+    );
     await api.applyDocument('d1', {
       land_value: '35490.56',
       personal_property: '0.00',


### PR DESCRIPTION
Closes #71 (the editor agent's HANDOFF #3, apps/web half). All seven e2e walks pass WITH the teeth in — the behaviors were real, only the proofs were toothless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)