### PR TITLE
Debt: an owner can finally record their own mortgage

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -141,6 +141,92 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/debts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Debts */
+        get: operations["list_debts_debts_get"];
+        put?: never;
+        /** Create Debt */
+        post: operations["create_debt_debts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debts/{debt_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Debt */
+        get: operations["read_debt_debts__debt_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debts/{debt_id}/payments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record Debt Payment */
+        post: operations["record_debt_payment_debts__debt_id__payments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debts/{debt_id}/payoff": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pay Off Debt */
+        post: operations["pay_off_debt_debts__debt_id__payoff_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debts/{debt_id}/schedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Debt Schedule */
+        get: operations["read_debt_schedule_debts__debt_id__schedule_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/documents": {
         parameters: {
             query?: never;
@@ -1392,6 +1478,156 @@ export interface components {
             /** Window Opens On */
             window_opens_on: string | null;
         };
+        /** DebtIn */
+        DebtIn: {
+            /**
+             * Amortization
+             * @default fully_amortizing
+             * @enum {string}
+             */
+            amortization: "fully_amortizing" | "interest_only" | "balloon" | "arm" | "negative_amortizing";
+            /** Amortization Months */
+            amortization_months?: number | null;
+            /** Document Id */
+            document_id?: string | null;
+            /** Entity Id */
+            entity_id?: string | null;
+            /**
+             * Escrows Insurance
+             * @default false
+             */
+            escrows_insurance: boolean;
+            /**
+             * Escrows Taxes
+             * @default false
+             */
+            escrows_taxes: boolean;
+            /** First Payment On */
+            first_payment_on?: string | null;
+            /**
+             * Has Due On Sale
+             * @default true
+             */
+            has_due_on_sale: boolean;
+            /** Interest Rate */
+            interest_rate: number | string;
+            /**
+             * Is Recourse
+             * @default true
+             */
+            is_recourse: boolean;
+            /**
+             * Kind
+             * @default conventional_mortgage
+             * @enum {string}
+             */
+            kind: "conventional_mortgage" | "portfolio_loan" | "dscr_loan" | "agency_multifamily" | "bridge" | "hard_money" | "heloc" | "seller_financing" | "private_note";
+            /** Lender */
+            lender?: string | null;
+            /**
+             * Lien Position
+             * @default 1
+             */
+            lien_position: number;
+            /** Matures On */
+            matures_on?: string | null;
+            /** Original Principal */
+            original_principal: number | string;
+            /**
+             * Originated On
+             * Format: date
+             */
+            originated_on: string;
+            /**
+             * Prepayment
+             * @default none
+             * @enum {string}
+             */
+            prepayment: "none" | "step_down" | "flat_percent" | "yield_maintenance" | "defeasance" | "lockout";
+            /** Prepayment Terms */
+            prepayment_terms?: string | null;
+            /**
+             * Property Id
+             * Format: uuid
+             */
+            property_id: string;
+            /** Rate Adjusts On */
+            rate_adjusts_on?: string | null;
+            /** Rate Cap Lifetime */
+            rate_cap_lifetime?: number | string | null;
+            /** Rate Cap Periodic */
+            rate_cap_periodic?: number | string | null;
+            /** Rate Index */
+            rate_index?: string | null;
+            /** Rate Margin */
+            rate_margin?: number | string | null;
+            /** Term Months */
+            term_months: number;
+        };
+        /** DebtOut */
+        DebtOut: {
+            /** Amortization */
+            amortization: string;
+            /** Amortization Months */
+            amortization_months: number | null;
+            /** Document Id */
+            document_id: string | null;
+            /** Entity Id */
+            entity_id: string | null;
+            /** Escrows Insurance */
+            escrows_insurance: boolean;
+            /** Escrows Taxes */
+            escrows_taxes: boolean;
+            /** First Payment On */
+            first_payment_on: string | null;
+            /** Has Due On Sale */
+            has_due_on_sale: boolean;
+            /** Id */
+            id: string;
+            /** Interest Paid */
+            interest_paid: string;
+            /** Interest Rate */
+            interest_rate: string;
+            /** Is Recourse */
+            is_recourse: boolean;
+            /** Kind */
+            kind: string;
+            /** Lender */
+            lender: string | null;
+            /** Lien Position */
+            lien_position: number;
+            /** Matures On */
+            matures_on: string | null;
+            /** Original Principal */
+            original_principal: string;
+            /**
+             * Originated On
+             * Format: date
+             */
+            originated_on: string;
+            /** Paid Off On */
+            paid_off_on: string | null;
+            /** Payments Recorded */
+            payments_recorded: number;
+            /** Prepayment */
+            prepayment: string;
+            /** Prepayment Terms */
+            prepayment_terms: string | null;
+            /** Principal Paid */
+            principal_paid: string;
+            /** Property Id */
+            property_id: string;
+            /** Property Label */
+            property_label: string;
+            /** Rate Adjusts On */
+            rate_adjusts_on: string | null;
+            /** Rate Index */
+            rate_index: string | null;
+            /** Scheduled Payment */
+            scheduled_payment: string | null;
+            /** Term Months */
+            term_months: number;
+        };
         /** DebtTerms */
         DebtTerms: {
             /** Annual Rate */
@@ -1962,6 +2198,65 @@ export interface components {
             /** Sent On */
             sent_on?: string | null;
         };
+        /** PaymentIn */
+        PaymentIn: {
+            /**
+             * Escrow
+             * @default 0
+             */
+            escrow: number | string;
+            /**
+             * Extra Principal
+             * @default 0
+             */
+            extra_principal: number | string;
+            /** Interest */
+            interest?: number | string | null;
+            /**
+             * Paid On
+             * Format: date
+             */
+            paid_on: string;
+            /**
+             * Post To Ledger
+             * @default true
+             */
+            post_to_ledger: boolean;
+            /** Principal */
+            principal?: number | string | null;
+        };
+        /** PaymentOut */
+        PaymentOut: {
+            /** Balance After */
+            balance_after: string | null;
+            /** Debt Id */
+            debt_id: string;
+            /** Escrow */
+            escrow: string;
+            /** Extra Principal */
+            extra_principal: string;
+            /** From Schedule Month */
+            from_schedule_month: number | null;
+            /** Interest */
+            interest: string;
+            /** Ledger Event Uuids */
+            ledger_event_uuids: string[];
+            /**
+             * Paid On
+             * Format: date
+             */
+            paid_on: string;
+            /** Principal */
+            principal: string;
+        };
+        /** PayoffIn */
+        PayoffIn: {
+            /**
+             * Paid Off On
+             * Format: date
+             */
+            paid_off_on: string;
+        };
         /** PolicyIn */
         PolicyIn: {
             /** Annual Premium */
@@ -2309,6 +2604,38 @@ export interface components {
             total_expenses: string;
             /** Total Income */
             total_income: string;
+        };
+        /** ScheduleOut */
+        ScheduleOut: {
+            /** Citation */
+            citation: string;
+            /** Debt Id */
+            debt_id: string;
+            /** Next Interest */
+            next_interest: string | null;
+            /** Next Month */
+            next_month: number | null;
+            /** Next Principal */
+            next_principal: string | null;
+            /** Rows */
+            rows: components["schemas"]["ScheduleRow"][];
+            /** Scheduled Payment */
+            scheduled_payment: string;
+            /** Total Interest */
+            total_interest: string;
+        };
+        /** ScheduleRow */
+        ScheduleRow: {
+            /** Balance */
+            balance: string;
+            /** Interest */
+            interest: string;
+            /** Month */
+            month: number;
+            /** Payment */
+            payment: string;
+            /** Principal */
+            principal: string;
         };
         /** ScreeningIn */
         ScreeningIn: {
@@ -3033,6 +3360,211 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeadlineOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_debts_debts_get: {
+        parameters: {
+            query?: {
+                property_id?: string | null;
+                include_paid_off?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebtOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_debt_debts_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DebtIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebtOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_debt_debts__debt_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                debt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebtOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_debt_payment_debts__debt_id__payments_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                debt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PaymentIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pay_off_debt_debts__debt_id__payoff_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                debt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PayoffIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebtOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_debt_schedule_debts__debt_id__schedule_get: {
+        parameters: {
+            query?: {
+                as_of?: string | null;
+            };
+            header?: never;
+            path: {
+                debt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScheduleOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -1429,6 +1429,528 @@
         "title": "DeadlineOut",
         "type": "object"
       },
+      "DebtIn": {
+        "properties": {
+          "amortization": {
+            "default": "fully_amortizing",
+            "enum": [
+              "fully_amortizing",
+              "interest_only",
+              "balloon",
+              "arm",
+              "negative_amortizing"
+            ],
+            "title": "Amortization",
+            "type": "string"
+          },
+          "amortization_months": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "maximum": 600.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amortization Months"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Id"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Id"
+          },
+          "escrows_insurance": {
+            "default": false,
+            "title": "Escrows Insurance",
+            "type": "boolean"
+          },
+          "escrows_taxes": {
+            "default": false,
+            "title": "Escrows Taxes",
+            "type": "boolean"
+          },
+          "first_payment_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Payment On"
+          },
+          "has_due_on_sale": {
+            "default": true,
+            "title": "Has Due On Sale",
+            "type": "boolean"
+          },
+          "interest_rate": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,1}|(?=[\\d.]{1,10}0*$)\\d{0,1}\\.\\d{0,8}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Interest Rate"
+          },
+          "is_recourse": {
+            "default": true,
+            "title": "Is Recourse",
+            "type": "boolean"
+          },
+          "kind": {
+            "default": "conventional_mortgage",
+            "enum": [
+              "conventional_mortgage",
+              "portfolio_loan",
+              "dscr_loan",
+              "agency_multifamily",
+              "bridge",
+              "hard_money",
+              "heloc",
+              "seller_financing",
+              "private_note"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "lender": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lender"
+          },
+          "lien_position": {
+            "default": 1,
+            "maximum": 9.0,
+            "minimum": 1.0,
+            "title": "Lien Position",
+            "type": "integer"
+          },
+          "matures_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matures On"
+          },
+          "original_principal": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Original Principal"
+          },
+          "originated_on": {
+            "format": "date",
+            "title": "Originated On",
+            "type": "string"
+          },
+          "prepayment": {
+            "default": "none",
+            "enum": [
+              "none",
+              "step_down",
+              "flat_percent",
+              "yield_maintenance",
+              "defeasance",
+              "lockout"
+            ],
+            "title": "Prepayment",
+            "type": "string"
+          },
+          "prepayment_terms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prepayment Terms"
+          },
+          "property_id": {
+            "format": "uuid",
+            "title": "Property Id",
+            "type": "string"
+          },
+          "rate_adjusts_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Adjusts On"
+          },
+          "rate_cap_lifetime": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,1}|(?=[\\d.]{1,10}0*$)\\d{0,1}\\.\\d{0,8}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Cap Lifetime"
+          },
+          "rate_cap_periodic": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,1}|(?=[\\d.]{1,10}0*$)\\d{0,1}\\.\\d{0,8}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Cap Periodic"
+          },
+          "rate_index": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Index"
+          },
+          "rate_margin": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,1}|(?=[\\d.]{1,10}0*$)\\d{0,1}\\.\\d{0,8}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Margin"
+          },
+          "term_months": {
+            "exclusiveMinimum": 0.0,
+            "maximum": 600.0,
+            "title": "Term Months",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "property_id",
+          "original_principal",
+          "interest_rate",
+          "term_months",
+          "originated_on"
+        ],
+        "title": "DebtIn",
+        "type": "object"
+      },
+      "DebtOut": {
+        "properties": {
+          "amortization": {
+            "title": "Amortization",
+            "type": "string"
+          },
+          "amortization_months": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amortization Months"
+          },
+          "document_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Id"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Id"
+          },
+          "escrows_insurance": {
+            "title": "Escrows Insurance",
+            "type": "boolean"
+          },
+          "escrows_taxes": {
+            "title": "Escrows Taxes",
+            "type": "boolean"
+          },
+          "first_payment_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Payment On"
+          },
+          "has_due_on_sale": {
+            "title": "Has Due On Sale",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "interest_paid": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Interest Paid",
+            "type": "string"
+          },
+          "interest_rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Interest Rate",
+            "type": "string"
+          },
+          "is_recourse": {
+            "title": "Is Recourse",
+            "type": "boolean"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "lender": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lender"
+          },
+          "lien_position": {
+            "title": "Lien Position",
+            "type": "integer"
+          },
+          "matures_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matures On"
+          },
+          "original_principal": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Original Principal",
+            "type": "string"
+          },
+          "originated_on": {
+            "format": "date",
+            "title": "Originated On",
+            "type": "string"
+          },
+          "paid_off_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paid Off On"
+          },
+          "payments_recorded": {
+            "title": "Payments Recorded",
+            "type": "integer"
+          },
+          "prepayment": {
+            "title": "Prepayment",
+            "type": "string"
+          },
+          "prepayment_terms": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prepayment Terms"
+          },
+          "principal_paid": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Principal Paid",
+            "type": "string"
+          },
+          "property_id": {
+            "title": "Property Id",
+            "type": "string"
+          },
+          "property_label": {
+            "title": "Property Label",
+            "type": "string"
+          },
+          "rate_adjusts_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Adjusts On"
+          },
+          "rate_index": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Index"
+          },
+          "scheduled_payment": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled Payment"
+          },
+          "term_months": {
+            "title": "Term Months",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "property_id",
+          "property_label",
+          "entity_id",
+          "lender",
+          "kind",
+          "lien_position",
+          "original_principal",
+          "interest_rate",
+          "amortization",
+          "term_months",
+          "amortization_months",
+          "originated_on",
+          "first_payment_on",
+          "matures_on",
+          "rate_adjusts_on",
+          "rate_index",
+          "prepayment",
+          "prepayment_terms",
+          "is_recourse",
+          "has_due_on_sale",
+          "escrows_taxes",
+          "escrows_insurance",
+          "paid_off_on",
+          "document_id",
+          "scheduled_payment",
+          "payments_recorded",
+          "principal_paid",
+          "interest_paid"
+        ],
+        "title": "DebtOut",
+        "type": "object"
+      },
       "DebtTerms": {
         "properties": {
           "annual_rate": {
@@ -3282,6 +3804,175 @@
         "title": "NoticeIn",
         "type": "object"
       },
+      "PaymentIn": {
+        "properties": {
+          "escrow": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "default": "0",
+            "title": "Escrow"
+          },
+          "extra_principal": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "default": "0",
+            "title": "Extra Principal"
+          },
+          "interest": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interest"
+          },
+          "paid_on": {
+            "format": "date",
+            "title": "Paid On",
+            "type": "string"
+          },
+          "post_to_ledger": {
+            "default": true,
+            "title": "Post To Ledger",
+            "type": "boolean"
+          },
+          "principal": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Principal"
+          }
+        },
+        "required": [
+          "paid_on"
+        ],
+        "title": "PaymentIn",
+        "type": "object"
+      },
+      "PaymentOut": {
+        "properties": {
+          "balance_after": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Balance After"
+          },
+          "debt_id": {
+            "title": "Debt Id",
+            "type": "string"
+          },
+          "escrow": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Escrow",
+            "type": "string"
+          },
+          "extra_principal": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Extra Principal",
+            "type": "string"
+          },
+          "from_schedule_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Schedule Month"
+          },
+          "interest": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Interest",
+            "type": "string"
+          },
+          "ledger_event_uuids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Ledger Event Uuids",
+            "type": "array"
+          },
+          "paid_on": {
+            "format": "date",
+            "title": "Paid On",
+            "type": "string"
+          },
+          "principal": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Principal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "debt_id",
+          "paid_on",
+          "principal",
+          "interest",
+          "escrow",
+          "extra_principal",
+          "balance_after",
+          "from_schedule_month",
+          "ledger_event_uuids"
+        ],
+        "title": "PaymentOut",
+        "type": "object"
+      },
+      "PayoffIn": {
+        "properties": {
+          "paid_off_on": {
+            "format": "date",
+            "title": "Paid Off On",
+            "type": "string"
+          }
+        },
+        "required": [
+          "paid_off_on"
+        ],
+        "title": "PayoffIn",
+        "type": "object"
+      },
       "PolicyIn": {
         "properties": {
           "annual_premium": {
@@ -4415,6 +5106,119 @@
           "caveat"
         ],
         "title": "ScheduleEReport",
+        "type": "object"
+      },
+      "ScheduleOut": {
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "debt_id": {
+            "title": "Debt Id",
+            "type": "string"
+          },
+          "next_interest": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Interest"
+          },
+          "next_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Month"
+          },
+          "next_principal": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Principal"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          },
+          "scheduled_payment": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Scheduled Payment",
+            "type": "string"
+          },
+          "total_interest": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Interest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "debt_id",
+          "scheduled_payment",
+          "total_interest",
+          "rows",
+          "next_month",
+          "next_interest",
+          "next_principal",
+          "citation"
+        ],
+        "title": "ScheduleOut",
+        "type": "object"
+      },
+      "ScheduleRow": {
+        "properties": {
+          "balance": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Balance",
+            "type": "string"
+          },
+          "interest": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Interest",
+            "type": "string"
+          },
+          "month": {
+            "title": "Month",
+            "type": "integer"
+          },
+          "payment": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Payment",
+            "type": "string"
+          },
+          "principal": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Principal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "month",
+          "payment",
+          "interest",
+          "principal",
+          "balance"
+        ],
+        "title": "ScheduleRow",
         "type": "object"
       },
       "ScreeningIn": {
@@ -6367,6 +7171,332 @@
           }
         },
         "summary": "List Deadlines"
+      }
+    },
+    "/debts": {
+      "get": {
+        "operationId": "list_debts_debts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "property_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Property Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_paid_off",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Paid Off",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DebtOut"
+                  },
+                  "title": "Response List Debts Debts Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Debts"
+      },
+      "post": {
+        "operationId": "create_debt_debts_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebtIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Debt"
+      }
+    },
+    "/debts/{debt_id}": {
+      "get": {
+        "operationId": "read_debt_debts__debt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Debt Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Debt"
+      }
+    },
+    "/debts/{debt_id}/payments": {
+      "post": {
+        "operationId": "record_debt_payment_debts__debt_id__payments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Debt Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Record Debt Payment"
+      }
+    },
+    "/debts/{debt_id}/payoff": {
+      "post": {
+        "operationId": "pay_off_debt_debts__debt_id__payoff_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Debt Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PayoffIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Pay Off Debt"
+      }
+    },
+    "/debts/{debt_id}/schedule": {
+      "get": {
+        "operationId": "read_debt_schedule_debts__debt_id__schedule_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Debt Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "As Of"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Debt Schedule"
       }
     },
     "/documents": {

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -36,6 +36,7 @@ from hestia_api import (
     config,
     coverage,
     db,
+    debt,
     documents,
     dossier,
     jurisdiction,
@@ -1824,3 +1825,146 @@ def record_adverse_action(
         after_value={"sent_on": str(result.adverse_action_sent_on)},
     )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Debt: the note, its schedule, and the payment it demands
+# ---------------------------------------------------------------------------
+
+
+@app.post("/debts", response_model=debt.DebtOut, status_code=201)
+def create_debt(
+    body: debt.DebtIn, conn: Conn, request: Request, actor: Actor = "system"
+) -> debt.DebtOut:
+    try:
+        note = debt.create(conn, body)
+    except debt.UnknownProperty as error:
+        raise HTTPException(status_code=404, detail="property not found") from error
+    except psycopg.errors.CheckViolation as error:
+        raise HTTPException(
+            status_code=422,
+            detail=debt.DEBT_REFUSALS.get(
+                error.diag.constraint_name or "",
+                f"the note refused these terms: {error.diag.constraint_name}",
+            ),
+        ) from error
+    except psycopg.errors.ForeignKeyViolation as error:
+        raise HTTPException(
+            status_code=404, detail="that entity or document does not exist"
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="debts.create",
+        request_id=request.state.request_id,
+        table_name="debt_instruments",
+        record_id=note.id,
+        after_value={"lender": note.lender, "principal": str(note.original_principal)},
+    )
+    return note
+
+
+@app.get("/debts", response_model=list[debt.DebtOut])
+def list_debts(
+    conn: Conn,
+    property_id: Annotated[uuid.UUID | None, Query()] = None,
+    include_paid_off: Annotated[bool, Query()] = False,
+) -> list[debt.DebtOut]:
+    return debt.list_debts(
+        conn,
+        property_id=str(property_id) if property_id else None,
+        include_paid_off=include_paid_off,
+    )
+
+
+@app.get("/debts/{debt_id}", response_model=debt.DebtOut)
+def read_debt(debt_id: uuid.UUID, conn: Conn) -> debt.DebtOut:
+    try:
+        return debt.read(conn, str(debt_id))
+    except debt.UnknownDebt as error:
+        raise HTTPException(status_code=404, detail="note not found") from error
+
+
+@app.get("/debts/{debt_id}/schedule", response_model=debt.ScheduleOut)
+def read_debt_schedule(
+    debt_id: uuid.UUID, conn: Conn, as_of: Annotated[dt.date | None, Query()] = None
+) -> debt.ScheduleOut:
+    try:
+        return debt.schedule(conn, str(debt_id), as_of=as_of or dt.date.today())
+    except debt.UnknownDebt as error:
+        raise HTTPException(status_code=404, detail="note not found") from error
+    except debt.ScheduleUnavailable as error:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"no level-payment schedule for a {error} note; the engine "
+                "amortizes fully amortizing, balloon and ARM terms"
+            ),
+        ) from error
+
+
+@app.post("/debts/{debt_id}/payments", response_model=debt.PaymentOut, status_code=201)
+def record_debt_payment(
+    debt_id: uuid.UUID,
+    body: debt.PaymentIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> debt.PaymentOut:
+    try:
+        payment = debt.record_payment(conn, str(debt_id), body)
+    except debt.UnknownDebt as error:
+        raise HTTPException(status_code=404, detail="note not found") from error
+    except debt.AlreadyPaidOff as error:
+        raise HTTPException(status_code=409, detail=f"this note was paid off on {error}") from error
+    except debt.DuplicatePayment as error:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"a payment on {error} is already recorded; the ledger corrects "
+                "by reversal, never by overwrite"
+            ),
+        ) from error
+    except debt.ScheduleUnavailable as error:
+        raise HTTPException(
+            status_code=422,
+            detail=f"the engine cannot supply a split here ({error}); state it explicitly",
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="debts.payment",
+        request_id=request.state.request_id,
+        table_name="debt_payments",
+        record_id=str(debt_id),
+        after_value=payment.model_dump(mode="json"),
+    )
+    return payment
+
+
+@app.post("/debts/{debt_id}/payoff", response_model=debt.DebtOut)
+def pay_off_debt(
+    debt_id: uuid.UUID,
+    body: debt.PayoffIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> debt.DebtOut:
+    try:
+        note = debt.pay_off(conn, str(debt_id), body.paid_off_on)
+    except debt.UnknownDebt as error:
+        raise HTTPException(status_code=404, detail="note not found") from error
+    except debt.AlreadyPaidOff as error:
+        raise HTTPException(
+            status_code=409, detail=f"this note was already paid off on {error}"
+        ) from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="debts.payoff",
+        request_id=request.state.request_id,
+        table_name="debt_instruments",
+        record_id=str(debt_id),
+        after_value={"paid_off_on": str(note.paid_off_on)},
+    )
+    return note

--- a/services/api/hestia_api/debt.py
+++ b/services/api/hestia_api/debt.py
@@ -1,0 +1,488 @@
+"""Debt: recording the note, and splitting the payment it demands.
+
+`debt_instruments` and `debt_payments` have carried full schema since module
+003, and three consumers read them — the financials read model, the hold/sell
+card, and the bank-import mortgage split. Until now nothing outside the test
+suite could WRITE one, so an owner could not record their own mortgage and
+every consumer read an empty table.
+
+The split is not computed here. `hestia_sim.finance.amortization` produces the
+schedule in cents and this module reports what it says: the engines compute,
+this explains. A payment recorded without its split takes the engine's, to the
+cent, for the period it belongs to — which is the same number the bank-import
+mortgage split will suggest.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+from hestia_sim.finance import amortization
+from pydantic import BaseModel, Field
+
+from hestia_api import ledger as ledger_module
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+CENTS = Decimal("100")
+
+DebtKind = Literal[
+    "conventional_mortgage",
+    "portfolio_loan",
+    "dscr_loan",
+    "agency_multifamily",
+    "bridge",
+    "hard_money",
+    "heloc",
+    "seller_financing",
+    "private_note",
+]
+AmortizationKind = Literal[
+    "fully_amortizing", "interest_only", "balloon", "arm", "negative_amortizing"
+]
+PrepaymentKind = Literal[
+    "none", "step_down", "flat_percent", "yield_maintenance", "defeasance", "lockout"
+]
+
+
+# The note's own rules, named so a refusal says which one bit.
+DEBT_REFUSALS: dict[str, str] = {
+    "principal_is_positive": "a note has to be for some money",
+    "positive_term": "a note has to have a term",
+    "amortization_at_least_term": (
+        "the amortization period cannot be shorter than the term — a balloon "
+        "amortizes over longer than it runs, never shorter"
+    ),
+    "arm_has_index": "an adjustable note has to say what it adjusts against",
+    "lien_position_positive": "lien position counts from first",
+}
+
+
+class PayoffIn(BaseModel):
+    paid_off_on: dt.date
+
+
+class UnknownProperty(Exception):
+    pass
+
+
+class UnknownDebt(Exception):
+    pass
+
+
+class AlreadyPaidOff(Exception):
+    pass
+
+
+class DuplicatePayment(Exception):
+    """One payment per date per note; a correction reverses, it does not overwrite."""
+
+
+class ScheduleUnavailable(Exception):
+    """The engine only amortizes a level-payment note."""
+
+
+class DebtIn(BaseModel):
+    property_id: uuid.UUID
+    entity_id: uuid.UUID | None = None
+    lender: str | None = Field(default=None, max_length=200)
+    kind: DebtKind = "conventional_mortgage"
+    lien_position: int = Field(default=1, ge=1, le=9)
+
+    original_principal: Decimal = Field(gt=0, decimal_places=2, max_digits=18)
+    interest_rate: Decimal = Field(ge=0, lt=1, decimal_places=8, max_digits=9)
+    amortization: AmortizationKind = "fully_amortizing"
+    term_months: int = Field(gt=0, le=600)
+    amortization_months: int | None = Field(default=None, gt=0, le=600)
+    originated_on: dt.date
+    first_payment_on: dt.date | None = None
+    matures_on: dt.date | None = None
+
+    rate_adjusts_on: dt.date | None = None
+    rate_index: str | None = None
+    rate_margin: Decimal | None = Field(default=None, ge=0, lt=1, decimal_places=8, max_digits=9)
+    rate_cap_periodic: Decimal | None = Field(
+        default=None, ge=0, lt=1, decimal_places=8, max_digits=9
+    )
+    rate_cap_lifetime: Decimal | None = Field(
+        default=None, ge=0, lt=1, decimal_places=8, max_digits=9
+    )
+
+    prepayment: PrepaymentKind = "none"
+    prepayment_terms: str | None = None
+    is_recourse: bool = True
+    has_due_on_sale: bool = True
+    escrows_taxes: bool = False
+    escrows_insurance: bool = False
+    document_id: uuid.UUID | None = None
+
+
+class PaymentIn(BaseModel):
+    paid_on: dt.date
+    # Leave the split out and the engine supplies it for the period this date
+    # falls in. Supply it and what the lender actually applied is recorded.
+    principal: Decimal | None = Field(default=None, ge=0, decimal_places=2, max_digits=18)
+    interest: Decimal | None = Field(default=None, ge=0, decimal_places=2, max_digits=18)
+    escrow: Decimal = Field(default=Decimal("0"), ge=0, decimal_places=2, max_digits=18)
+    extra_principal: Decimal = Field(default=Decimal("0"), ge=0, decimal_places=2, max_digits=18)
+    # Money that moved belongs in the ledger, split across the two categories
+    # module 005 already carries.
+    post_to_ledger: bool = True
+
+
+class ScheduleRow(BaseModel):
+    month: int
+    payment: Decimal
+    interest: Decimal
+    principal: Decimal
+    balance: Decimal
+
+
+class DebtOut(BaseModel):
+    id: str
+    property_id: str
+    property_label: str
+    entity_id: str | None
+    lender: str | None
+    kind: str
+    lien_position: int
+    original_principal: Decimal
+    interest_rate: Decimal
+    amortization: str
+    term_months: int
+    amortization_months: int | None
+    originated_on: dt.date
+    first_payment_on: dt.date | None
+    matures_on: dt.date | None
+    rate_adjusts_on: dt.date | None
+    rate_index: str | None
+    prepayment: str
+    prepayment_terms: str | None
+    is_recourse: bool
+    has_due_on_sale: bool
+    escrows_taxes: bool
+    escrows_insurance: bool
+    paid_off_on: dt.date | None
+    document_id: str | None
+    # Everything below is computed by the engine, never stored.
+    scheduled_payment: Decimal | None
+    payments_recorded: int
+    principal_paid: Decimal
+    interest_paid: Decimal
+
+
+class ScheduleOut(BaseModel):
+    debt_id: str
+    scheduled_payment: Decimal
+    total_interest: Decimal
+    rows: list[ScheduleRow]
+    # What the next payment owes, so a split never has to be guessed at.
+    next_month: int | None
+    next_interest: Decimal | None
+    next_principal: Decimal | None
+    citation: str
+
+
+ENGINE_CITATION = (
+    "level-payment amortization, hestia_sim.finance.amortization — the same "
+    "schedule the hold/sell card and the bank-import split read"
+)
+
+
+def _schedule(row: dict[str, Any]) -> dict[str, Any]:
+    """The engine's schedule for a note, in cents. Interest-only and negative
+    amortization are different arithmetic and are not claimed here."""
+    if row["amortization"] not in ("fully_amortizing", "balloon", "arm"):
+        raise ScheduleUnavailable(row["amortization"])
+    months = row["amortization_months"] or row["term_months"]
+    return amortization(int(row["original_principal"] * CENTS), str(row["interest_rate"]), months)
+
+
+def _payment_number(row: dict[str, Any], paid_on: dt.date) -> int:
+    """Which scheduled payment a date belongs to, counting from the first."""
+    start = row["first_payment_on"] or row["originated_on"]
+    return (paid_on.year - start.year) * 12 + (paid_on.month - start.month) + 1
+
+
+def _read(conn: Conn, debt_id: str) -> DebtOut:
+    row = conn.execute(
+        """
+        SELECT d.id::text, d.property_id::text, p.label AS property_label,
+               d.entity_id::text, d.lender, d.kind::text AS kind, d.lien_position,
+               d.original_principal, d.interest_rate,
+               d.amortization::text AS amortization, d.term_months,
+               d.amortization_months, d.originated_on, d.first_payment_on,
+               d.matures_on, d.rate_adjusts_on, d.rate_index,
+               d.prepayment::text AS prepayment, d.prepayment_terms, d.is_recourse,
+               d.has_due_on_sale, d.escrows_taxes, d.escrows_insurance,
+               d.paid_off_on, d.document_id::text,
+               (SELECT count(*) FROM debt_payments dp WHERE dp.debt_id = d.id)
+                 AS payments_recorded,
+               (SELECT coalesce(sum(dp.principal + dp.extra_principal), 0)
+                  FROM debt_payments dp WHERE dp.debt_id = d.id) AS principal_paid,
+               (SELECT coalesce(sum(dp.interest), 0) FROM debt_payments dp
+                 WHERE dp.debt_id = d.id) AS interest_paid
+        FROM debt_instruments d JOIN properties p ON p.id = d.property_id
+        WHERE d.id = %s
+        """,
+        (debt_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownDebt(debt_id)
+    try:
+        scheduled = Decimal(_schedule(row)["payment"]) / CENTS
+    except ScheduleUnavailable:
+        scheduled = None
+    return DebtOut(**row, scheduled_payment=scheduled)
+
+
+def create(conn: Conn, body: DebtIn) -> DebtOut:
+    prop = conn.execute(
+        "SELECT id::text, entity_id::text FROM properties WHERE id = %s",
+        (body.property_id,),
+    ).fetchone()
+    if prop is None:
+        raise UnknownProperty(str(body.property_id))
+    row = conn.execute(
+        """
+        INSERT INTO debt_instruments
+          (property_id, entity_id, lender, kind, lien_position, original_principal,
+           interest_rate, amortization, term_months, amortization_months,
+           originated_on, first_payment_on, matures_on, rate_adjusts_on, rate_index,
+           rate_margin, rate_cap_periodic, rate_cap_lifetime, prepayment,
+           prepayment_terms, is_recourse, has_due_on_sale, escrows_taxes,
+           escrows_insurance, document_id)
+        VALUES (%s, coalesce(%s::uuid, %s::uuid), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING id::text
+        """,
+        (
+            body.property_id,
+            body.entity_id,
+            prop["entity_id"],
+            body.lender,
+            body.kind,
+            body.lien_position,
+            body.original_principal,
+            body.interest_rate,
+            body.amortization,
+            body.term_months,
+            body.amortization_months,
+            body.originated_on,
+            body.first_payment_on,
+            body.matures_on,
+            body.rate_adjusts_on,
+            body.rate_index,
+            body.rate_margin,
+            body.rate_cap_periodic,
+            body.rate_cap_lifetime,
+            body.prepayment,
+            body.prepayment_terms,
+            body.is_recourse,
+            body.has_due_on_sale,
+            body.escrows_taxes,
+            body.escrows_insurance,
+            body.document_id,
+        ),
+    ).fetchone()
+    return _read(conn, row["id"])
+
+
+def read(conn: Conn, debt_id: str) -> DebtOut:
+    return _read(conn, debt_id)
+
+
+def list_debts(
+    conn: Conn, *, property_id: str | None = None, include_paid_off: bool = False
+) -> list[DebtOut]:
+    rows = conn.execute(
+        """
+        SELECT id::text FROM debt_instruments
+        WHERE (%(property_id)s::uuid IS NULL OR property_id = %(property_id)s::uuid)
+          AND (%(include_paid_off)s OR paid_off_on IS NULL)
+        ORDER BY lien_position, originated_on
+        """,
+        {"property_id": property_id, "include_paid_off": include_paid_off},
+    ).fetchall()
+    return [_read(conn, row["id"]) for row in rows]
+
+
+def schedule(conn: Conn, debt_id: str, *, as_of: dt.date) -> ScheduleOut:
+    row = conn.execute(
+        """
+        SELECT id::text, original_principal, interest_rate,
+               amortization::text AS amortization, term_months, amortization_months,
+               originated_on, first_payment_on
+        FROM debt_instruments WHERE id = %s
+        """,
+        (debt_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownDebt(debt_id)
+    computed = _schedule(row)
+    rows = [
+        ScheduleRow(
+            month=entry["month"],
+            payment=Decimal(entry["payment"]) / CENTS,
+            interest=Decimal(entry["interest"]) / CENTS,
+            principal=Decimal(entry["principal"]) / CENTS,
+            balance=Decimal(entry["balance"]) / CENTS,
+        )
+        for entry in computed["rows"]
+    ]
+    number = _payment_number(row, as_of)
+    upcoming = rows[number - 1] if 1 <= number <= len(rows) else None
+    return ScheduleOut(
+        debt_id=row["id"],
+        scheduled_payment=Decimal(computed["payment"]) / CENTS,
+        total_interest=Decimal(computed["total_interest"]) / CENTS,
+        rows=rows,
+        next_month=upcoming.month if upcoming else None,
+        next_interest=upcoming.interest if upcoming else None,
+        next_principal=upcoming.principal if upcoming else None,
+        citation=ENGINE_CITATION,
+    )
+
+
+class PaymentOut(BaseModel):
+    debt_id: str
+    paid_on: dt.date
+    principal: Decimal
+    interest: Decimal
+    escrow: Decimal
+    extra_principal: Decimal
+    balance_after: Decimal | None
+    # Which schedule row supplied the split, when the caller did not.
+    from_schedule_month: int | None
+    ledger_event_uuids: list[str]
+
+
+def record_payment(conn: Conn, debt_id: str, body: PaymentIn) -> PaymentOut:
+    """One payment, its split, and the two ledger rows it becomes.
+
+    Interest and principal are different lines on Schedule E — one is
+    deductible and the other is equity — so a mortgage payment has never been
+    one ledger row here, and this posts the pair the categories were made for.
+    """
+    row = conn.execute(
+        """
+        SELECT id::text, property_id::text, entity_id::text, lender, paid_off_on,
+               original_principal, interest_rate, amortization::text AS amortization,
+               term_months, amortization_months, originated_on, first_payment_on
+        FROM debt_instruments WHERE id = %s FOR UPDATE
+        """,
+        (debt_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownDebt(debt_id)
+    if row["paid_off_on"] is not None:
+        raise AlreadyPaidOff(str(row["paid_off_on"]))
+
+    from_month: int | None = None
+    principal = body.principal
+    interest = body.interest
+    if principal is None or interest is None:
+        computed = _schedule(row)
+        number = _payment_number(row, body.paid_on)
+        if not 1 <= number <= len(computed["rows"]):
+            raise ScheduleUnavailable(f"payment {number} is outside the schedule")
+        entry = computed["rows"][number - 1]
+        from_month = entry["month"]
+        principal = Decimal(entry["principal"]) / CENTS if principal is None else principal
+        interest = Decimal(entry["interest"]) / CENTS if interest is None else interest
+
+    try:
+        payment = conn.execute(
+            """
+            INSERT INTO debt_payments
+              (debt_id, paid_on, principal, interest, escrow, extra_principal)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id::text
+            """,
+            (
+                debt_id,
+                body.paid_on,
+                principal,
+                interest,
+                body.escrow,
+                body.extra_principal,
+            ),
+        ).fetchone()
+    except psycopg.errors.UniqueViolation as error:
+        raise DuplicatePayment(str(body.paid_on)) from error
+
+    events: list[str] = []
+    if body.post_to_ledger:
+        for category, amount in (
+            ("mortgage_interest", interest),
+            ("mortgage_principal", principal + body.extra_principal),
+        ):
+            if amount <= 0:
+                continue
+            event = ledger_module.append_event(
+                conn,
+                ledger_module.LedgerEntryIn(
+                    occurred_on=body.paid_on,
+                    category=category,  # type: ignore[arg-type]
+                    amount=-amount,
+                    memo=f"{row['lender'] or 'note'} payment",
+                    counterparty=row["lender"],
+                    property_id=row["property_id"],
+                    entity_id=row["entity_id"],
+                ),
+            )
+            events.append(event.event_uuid)
+
+    balance = conn.execute(
+        """
+        UPDATE debt_payments SET balance_after = %s WHERE id = %s
+        RETURNING balance_after
+        """,
+        (
+            _balance_after(conn, debt_id, row),
+            payment["id"],
+        ),
+    ).fetchone()
+    return PaymentOut(
+        debt_id=debt_id,
+        paid_on=body.paid_on,
+        principal=principal,
+        interest=interest,
+        escrow=body.escrow,
+        extra_principal=body.extra_principal,
+        balance_after=balance["balance_after"],
+        from_schedule_month=from_month,
+        ledger_event_uuids=events,
+    )
+
+
+def _balance_after(conn: Conn, debt_id: str, row: dict[str, Any]) -> Decimal:
+    """Original principal less every principal dollar recorded against it."""
+    paid = conn.execute(
+        "SELECT coalesce(sum(principal + extra_principal), 0) AS paid"
+        " FROM debt_payments WHERE debt_id = %s",
+        (debt_id,),
+    ).fetchone()
+    return max(Decimal("0"), row["original_principal"] - paid["paid"])
+
+
+def pay_off(conn: Conn, debt_id: str, paid_off_on: dt.date) -> DebtOut:
+    updated = conn.execute(
+        """
+        UPDATE debt_instruments SET paid_off_on = %s, updated_at = now()
+        WHERE id = %s AND paid_off_on IS NULL RETURNING id::text
+        """,
+        (paid_off_on, debt_id),
+    ).fetchone()
+    if updated is None:
+        existing = conn.execute(
+            "SELECT paid_off_on FROM debt_instruments WHERE id = %s", (debt_id,)
+        ).fetchone()
+        if existing is None:
+            raise UnknownDebt(debt_id)
+        raise AlreadyPaidOff(str(existing["paid_off_on"]))
+    return _read(conn, debt_id)

--- a/services/api/tests/test_debt.py
+++ b/services/api/tests/test_debt.py
@@ -1,0 +1,347 @@
+"""Recording a note, and the payment it demands.
+
+Issue #37's acceptance, executable: record the real 998 Monmouth note, the
+hold/sell card picks it up without SQL, the schedule renders, and a split
+matches the engine to the cent.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from hestia_sim.finance import amortization
+
+# The note the fixture property actually carries in the demo world.
+NOTE = {
+    "lender": "Licking Valley Savings Bank",
+    "original_principal": "150000.00",
+    "interest_rate": "0.04625",
+    "term_months": 360,
+    "originated_on": "2019-04-11",
+    "first_payment_on": "2019-06-01",
+}
+
+
+@pytest.fixture
+def note(newport_property: str, client: TestClient) -> dict[str, Any]:
+    response = client.post("/debts", json={"property_id": newport_property, **NOTE})
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+class TestTheAcceptanceWalk:
+    def test_the_note_is_recorded_and_the_schedule_matches_the_engine(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        assert note["lender"] == NOTE["lender"]
+        assert note["payments_recorded"] == 0
+        assert Decimal(note["principal_paid"]) == 0
+
+        engine = amortization(15_000_000, NOTE["interest_rate"], 360)
+        expected_payment = Decimal(engine["payment"]) / 100
+        assert Decimal(note["scheduled_payment"]) == expected_payment
+
+        schedule = client.get(f"/debts/{note['id']}/schedule?as_of=2019-06-01").json()
+        assert Decimal(schedule["scheduled_payment"]) == expected_payment
+        assert Decimal(schedule["total_interest"]) == Decimal(engine["total_interest"]) / 100
+        assert len(schedule["rows"]) == 360
+        # To the cent, every row, because the engine produced them.
+        assert [Decimal(r["interest"]) for r in schedule["rows"][:3]] == [
+            Decimal(e["interest"]) / 100 for e in engine["rows"][:3]
+        ]
+        # The last row closes the loan out exactly.
+        assert Decimal(schedule["rows"][-1]["balance"]) == 0
+        assert "hestia_sim.finance.amortization" in schedule["citation"]
+        # The first payment is month 1.
+        assert schedule["next_month"] == 1
+        assert Decimal(schedule["next_interest"]) == Decimal(engine["rows"][0]["interest"]) / 100
+
+    def test_the_hold_sell_card_picks_it_up_without_sql(
+        self, note: dict[str, Any], newport_property: str, client: TestClient
+    ) -> None:
+        """The financials read model is the hold/sell card's only source; it
+        read an empty table until a note could be written through the API."""
+        financials = client.get(f"/properties/{newport_property}/financials").json()
+        assert len(financials["debts"]) == 1
+        carried = financials["debts"][0]
+        assert carried["lender"] == NOTE["lender"]
+        assert Decimal(carried["original_principal"]) == Decimal("150000.00")
+        assert Decimal(carried["annual_rate"]) == Decimal(NOTE["interest_rate"])
+        assert carried["term_months"] == 360
+        assert carried["months_elapsed"] > 0
+
+    def test_a_payment_takes_the_engine_s_split_and_posts_the_pair(
+        self, note: dict[str, Any], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """Interest is deductible and principal is equity — different lines on
+        Schedule E, so a mortgage payment was never one ledger row."""
+        engine = amortization(15_000_000, NOTE["interest_rate"], 360)
+        first = engine["rows"][0]
+
+        payment = client.post(
+            f"/debts/{note['id']}/payments",
+            json={"paid_on": "2019-06-01", "escrow": "310.00"},
+        )
+        assert payment.status_code == 201, payment.text
+        body = payment.json()
+        assert body["from_schedule_month"] == 1
+        assert Decimal(body["interest"]) == Decimal(first["interest"]) / 100
+        assert Decimal(body["principal"]) == Decimal(first["principal"]) / 100
+        assert Decimal(body["balance_after"]) == Decimal("150000.00") - Decimal(body["principal"])
+        assert len(body["ledger_event_uuids"]) == 2
+
+        posted = conn.execute(
+            """
+            SELECT category::text AS category, amount FROM ledger_events
+            WHERE event_uuid = ANY(%s) ORDER BY category
+            """,
+            (body["ledger_event_uuids"],),
+        ).fetchall()
+        assert [row["category"] for row in posted] == [
+            "mortgage_interest",
+            "mortgage_principal",
+        ]
+        assert posted[0]["amount"] == -Decimal(body["interest"])
+        assert posted[1]["amount"] == -Decimal(body["principal"])
+
+        after = client.get(f"/debts/{note['id']}").json()
+        assert after["payments_recorded"] == 1
+        assert Decimal(after["interest_paid"]) == Decimal(body["interest"])
+
+
+class TestPayments:
+    def test_what_the_lender_actually_applied_wins_over_the_schedule(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        body = client.post(
+            f"/debts/{note['id']}/payments",
+            json={
+                "paid_on": "2019-06-01",
+                "principal": "300.00",
+                "interest": "500.00",
+                "extra_principal": "1000.00",
+            },
+        ).json()
+        assert body["from_schedule_month"] is None
+        assert Decimal(body["principal"]) == Decimal("300.00")
+        # Extra principal goes against the balance and rides the principal line.
+        assert Decimal(body["balance_after"]) == Decimal("148700.00")
+
+    def test_extra_principal_lands_on_the_principal_line(
+        self, note: dict[str, Any], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        body = client.post(
+            f"/debts/{note['id']}/payments",
+            json={
+                "paid_on": "2019-06-01",
+                "principal": "200.00",
+                "interest": "500.00",
+                "extra_principal": "800.00",
+            },
+        ).json()
+        principal_event = conn.execute(
+            """
+            SELECT amount FROM ledger_events
+            WHERE event_uuid = ANY(%s) AND category::text = 'mortgage_principal'
+            """,
+            (body["ledger_event_uuids"],),
+        ).fetchone()
+        assert principal_event["amount"] == Decimal("-1000.00")
+
+    def test_a_payment_may_stay_out_of_the_ledger(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        body = client.post(
+            f"/debts/{note['id']}/payments",
+            json={"paid_on": "2019-06-01", "post_to_ledger": False},
+        ).json()
+        assert body["ledger_event_uuids"] == []
+
+    def test_an_interest_only_period_posts_one_line(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        body = client.post(
+            f"/debts/{note['id']}/payments",
+            json={"paid_on": "2019-06-01", "principal": "0.00", "interest": "578.13"},
+        ).json()
+        assert len(body["ledger_event_uuids"]) == 1
+
+    def test_one_payment_per_date(self, note: dict[str, Any], client: TestClient) -> None:
+        client.post(f"/debts/{note['id']}/payments", json={"paid_on": "2019-06-01"})
+        again = client.post(f"/debts/{note['id']}/payments", json={"paid_on": "2019-06-01"})
+        assert again.status_code == 409
+        assert "corrects by reversal" in again.json()["detail"]
+
+    def test_a_payment_outside_the_schedule_asks_for_the_split(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        response = client.post(f"/debts/{note['id']}/payments", json={"paid_on": "2019-05-01"})
+        assert response.status_code == 422
+        assert "state it explicitly" in response.json()["detail"]
+
+
+class TestLifecycle:
+    def test_paying_off_retires_the_note_from_every_reader(
+        self, note: dict[str, Any], newport_property: str, client: TestClient
+    ) -> None:
+        paid = client.post(f"/debts/{note['id']}/payoff", json={"paid_off_on": "2026-08-27"}).json()
+        assert paid["paid_off_on"] == "2026-08-27"
+        assert client.get(f"/debts?property_id={newport_property}").json() == []
+        assert (
+            len(client.get(f"/debts?property_id={newport_property}&include_paid_off=true").json())
+            == 1
+        )
+        # The hold/sell card stops carrying it too.
+        financials = client.get(f"/properties/{newport_property}/financials").json()
+        assert financials["debts"] == []
+        assert (
+            client.post(
+                f"/debts/{note['id']}/payoff", json={"paid_off_on": "2026-09-01"}
+            ).status_code
+            == 409
+        )
+        assert (
+            client.post(f"/debts/{note['id']}/payments", json={"paid_on": "2019-06-01"}).status_code
+            == 409
+        )
+
+    def test_a_second_lien_sorts_behind_the_first(
+        self, note: dict[str, Any], newport_property: str, client: TestClient
+    ) -> None:
+        client.post(
+            "/debts",
+            json={
+                "property_id": newport_property,
+                "lender": "Second Position",
+                "original_principal": "25000.00",
+                "interest_rate": "0.09000",
+                "term_months": 180,
+                "originated_on": "2021-03-01",
+                "lien_position": 2,
+                "kind": "heloc",
+            },
+        )
+        rows = client.get(f"/debts?property_id={newport_property}").json()
+        assert [row["lien_position"] for row in rows] == [1, 2]
+        assert rows[1]["kind"] == "heloc"
+
+
+class TestRefusals:
+    def test_the_note_s_own_rules_refuse_by_name(
+        self, newport_property: str, client: TestClient
+    ) -> None:
+        base = {"property_id": newport_property, **NOTE}
+        short_amortization = client.post(
+            "/debts", json={**base, "term_months": 360, "amortization_months": 120}
+        )
+        assert short_amortization.status_code == 422
+        assert "shorter than the term" in short_amortization.json()["detail"]
+
+        armless = client.post("/debts", json={**base, "amortization": "arm"})
+        assert armless.status_code == 422
+        assert "what it adjusts against" in armless.json()["detail"]
+
+    def test_bad_terms_are_refused_at_the_edge(
+        self, newport_property: str, client: TestClient
+    ) -> None:
+        base = {"property_id": newport_property, **NOTE}
+        for bad in (
+            {"original_principal": "0.00"},
+            {"original_principal": "-1.00"},
+            {"term_months": 0},
+            {"interest_rate": "1.5"},
+            {"lien_position": 0},
+        ):
+            assert client.post("/debts", json={**base, **bad}).status_code == 422, bad
+
+    def test_unknown_things_are_404(self, newport_property: str, client: TestClient) -> None:
+        ghost = "00000000-0000-4000-8000-000000000000"
+        assert client.get(f"/debts/{ghost}").status_code == 404
+        assert client.get(f"/debts/{ghost}/schedule").status_code == 404
+        assert (
+            client.post(f"/debts/{ghost}/payments", json={"paid_on": "2026-01-01"}).status_code
+            == 404
+        )
+        assert (
+            client.post(f"/debts/{ghost}/payoff", json={"paid_off_on": "2026-01-01"}).status_code
+            == 404
+        )
+        assert client.post("/debts", json={"property_id": ghost, **NOTE}).status_code == 404
+        assert (
+            client.post(
+                "/debts",
+                json={"property_id": newport_property, "entity_id": ghost, **NOTE},
+            ).status_code
+            == 404
+        )
+
+    def test_an_interest_only_note_gets_no_level_schedule(
+        self, newport_property: str, client: TestClient
+    ) -> None:
+        """The engine amortizes level payments; claiming a schedule for
+        interest-only terms would be arithmetic nobody did."""
+        io_note = client.post(
+            "/debts",
+            json={
+                "property_id": newport_property,
+                **NOTE,
+                "amortization": "interest_only",
+                "lien_position": 3,
+            },
+        ).json()
+        assert io_note["scheduled_payment"] is None
+        response = client.get(f"/debts/{io_note['id']}/schedule")
+        assert response.status_code == 422
+        assert "interest_only" in response.json()["detail"]
+        # ...and a payment on it must state its own split.
+        assert (
+            client.post(
+                f"/debts/{io_note['id']}/payments", json={"paid_on": "2019-06-01"}
+            ).status_code
+            == 422
+        )
+
+
+class TestScheduleEdges:
+    def test_a_date_past_the_last_payment_has_no_next_row(
+        self, note: dict[str, Any], client: TestClient
+    ) -> None:
+        schedule = client.get(f"/debts/{note['id']}/schedule?as_of=2060-01-01").json()
+        assert schedule["next_month"] is None
+        assert schedule["next_interest"] is None
+        assert schedule["next_principal"] is None
+        # The schedule itself still renders in full.
+        assert len(schedule["rows"]) == 360
+
+    def test_a_balloon_amortizes_over_the_longer_period(
+        self, newport_property: str, client: TestClient
+    ) -> None:
+        balloon = client.post(
+            "/debts",
+            json={
+                "property_id": newport_property,
+                **NOTE,
+                "amortization": "balloon",
+                "term_months": 84,
+                "amortization_months": 360,
+                "lien_position": 4,
+            },
+        ).json()
+        schedule = client.get(f"/debts/{balloon['id']}/schedule?as_of=2019-06-01").json()
+        # Amortized over 360 even though it comes due in 84 — that is the whole
+        # point of a balloon, and the payment reflects the longer period.
+        assert len(schedule["rows"]) == 360
+        assert (
+            Decimal(schedule["scheduled_payment"])
+            == Decimal(amortization(15_000_000, NOTE["interest_rate"], 360)["payment"]) / 100
+        )
+
+    def test_the_schedule_defaults_to_today(self, note: dict[str, Any], client: TestClient) -> None:
+        schedule = client.get(f"/debts/{note['id']}/schedule").json()
+        expected = (dt.date.today().year - 2019) * 12 + (dt.date.today().month - 6) + 1
+        assert schedule["next_month"] == expected


### PR DESCRIPTION
Closes #37. Unblocks #51.

`debt_instruments` and `debt_payments` have carried full schema since module 003 with **three consumers reading them** — the financials read model, the hold/sell card, and the bank-import mortgage split. Nothing outside the test suite could ever write one, so all three read an empty table and the hold/sell card aggregated liens that could not exist.

**The schedule is not computed here.** `hestia_sim.finance.amortization` produces it in cents; this reports what it says, with the citation attached. A payment recorded without a split takes the engine's for the period its date falls in — to the cent, the same number the bank-import split will suggest — while a payment that states its own records what the lender actually applied.

**The pair, not the row.** Interest is deductible and principal is equity: two different lines on Schedule E, so a mortgage payment posts as two ledger events across the categories module 005 has carried all along. Extra principal rides the principal line. A payment can also stay out of the ledger, for backfilling a note's history.

**What the engine cannot honestly amortize, it does not.** Interest-only and negative-amortizing notes get no level-payment schedule and no inferred split — they say so instead of inventing arithmetic nobody did. A balloon amortizes over the longer period, which is the point of one.

**Refusals by name**: an amortization period shorter than the term, an adjustable note with nothing to adjust against, a second payment on a date already recorded (the ledger corrects by reversal, never by overwrite).

### Acceptance
- [x] Record the real 998 Monmouth note through the API.
- [x] The hold/sell card picks it up without SQL — the test reads `/properties/{id}/financials` and finds the lender, principal, rate, term and elapsed months.
- [x] The amortization schedule renders — 360 rows, final balance exactly zero, every row equal to the engine's to the cent.
- [x] A split suggestion matches the engine to the cent, and posts as the interest/principal pair.

263 API tests at 100% line+branch · contract regenerated · web typechecks · lint, ratchet and config audit clean. No schema change: both tables already existed.

**Handed over:** the debt panel on the property page is `apps/web`. The API returns the schedule and the next payment's split ready to render.