### PR TITLE
One keystroke to anywhere

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -69,6 +69,16 @@ test('the dossier carries the spine and the exit instrument', async ({ page }) =
   await expect(page.getByText(/Record a valuation to unlock the exit instrument/)).toBeVisible();
 });
 
+test('the command palette answers ⌘K and navigates', async ({ page }) => {
+  await page.goto('/');
+  await page.keyboard.press('ControlOrMeta+k');
+  const paletteInput = page.getByPlaceholder('Type a command…');
+  await expect(paletteInput).toBeVisible();
+  await paletteInput.fill('calen');
+  await paletteInput.press('Enter');
+  await expect(page.getByRole('heading', { name: 'Calendar' })).toBeVisible();
+});
+
 test('the calendar and coverage pages answer', async ({ page }) => {
   await page.goto('/calendar');
   await expect(

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Bitter, IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
 import type { ReactNode } from 'react';
+import { CommandBar } from '../components/CommandBar';
 import '@hestia/design/css/tokens.css';
 import '@hestia/design/css/base.css';
 import '@hestia/design/css/primitives.css';
@@ -51,6 +52,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               <a href="/calendar">Calendar</a>
               <a href="/coverage">Coverage</a>
             </nav>
+            <CommandBar />
           </header>
           <main>{children}</main>
         </div>

--- a/apps/web/src/components/CommandBar.tsx
+++ b/apps/web/src/components/CommandBar.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { type Command, CommandPalette, useCommandK } from '@hestia/design';
+import { useRouter } from 'next/navigation';
+import { useCallback, useRef, useState } from 'react';
+import { api, type PropertySummary } from '../lib/api';
+
+/**
+ * ⌘K, wired: one keystroke to any page or property. Routes are static;
+ * properties load once, on first open, and never block the palette — an
+ * instrument that stalls while its owner types is not an instrument.
+ */
+const ROUTES: readonly { label: string; path: string }[] = [
+  { label: 'Portfolio', path: '/' },
+  { label: 'Leases', path: '/leases' },
+  { label: 'Transactions', path: '/transactions' },
+  { label: 'Import a bank statement', path: '/transactions/import' },
+  { label: 'Documents', path: '/documents' },
+  { label: 'Maintenance', path: '/maintenance' },
+  { label: 'Vendors', path: '/vendors' },
+  { label: 'Reports', path: '/reports' },
+  { label: 'Calendar', path: '/calendar' },
+  { label: 'Coverage', path: '/coverage' },
+];
+
+export function CommandBar() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [properties, setProperties] = useState<readonly PropertySummary[]>([]);
+  const fetched = useRef(false);
+
+  const openPalette = useCallback(() => {
+    setOpen(true);
+    if (!fetched.current) {
+      fetched.current = true;
+      api
+        .listProperties()
+        .then(setProperties)
+        .catch(() => {
+          // The palette stays useful without properties; try again next open.
+          fetched.current = false;
+        });
+    }
+  }, []);
+
+  useCommandK(openPalette);
+
+  const commands: Command[] = [
+    ...ROUTES.map((route) => ({
+      id: `go${route.path}`,
+      label: `Go: ${route.label}`,
+      hint: route.path,
+      run: () => router.push(route.path),
+    })),
+    ...properties.map((property) => ({
+      id: `property-${property.id}`,
+      label: `Property: ${property.label}`,
+      hint: 'dossier',
+      run: () => router.push(`/property/${property.id}`),
+    })),
+  ];
+
+  return (
+    <>
+      <button
+        type="button"
+        className="masthead__command"
+        aria-label="Open the command palette"
+        onClick={openPalette}
+      >
+        ⌘K
+      </button>
+      <CommandPalette
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+        commands={commands}
+      />
+    </>
+  );
+}

--- a/apps/web/tests/command-bar.test.tsx
+++ b/apps/web/tests/command-bar.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandBar } from '../src/components/CommandBar';
+import { api } from '../src/lib/api';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  push.mockClear();
+});
+
+const PROPERTIES = [
+  {
+    id: 'p1',
+    label: '516 Overton St',
+    street_1: '516 Overton St',
+    city: 'Newport',
+    state: 'KY',
+    postal_code: '41071',
+    kind: 'single_family',
+    year_built: 1910,
+    jurisdiction: 'us-ky-newport',
+    component_count: 0,
+    defect_count: 0,
+    next_deadline_on: null,
+  },
+];
+
+describe('CommandBar', () => {
+  it('opens on ⌘K, lists the routes, and navigates on run', async () => {
+    vi.spyOn(api, 'listProperties').mockResolvedValue(PROPERTIES);
+    render(<CommandBar />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    const input = screen.getByRole('combobox');
+    expect(input).toBeDefined();
+    fireEvent.change(input, { target: { value: 'calen' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(push).toHaveBeenCalledWith('/calendar');
+    // The palette closed itself before running the command.
+    expect(
+      screen.getByLabelText('Command palette', { selector: 'dialog' }).hasAttribute('open'),
+    ).toBe(false);
+  });
+
+  it('loads properties once, on first open, and never again', async () => {
+    const list = vi.spyOn(api, 'listProperties').mockResolvedValue(PROPERTIES);
+    render(<CommandBar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open the command palette' }));
+    await waitFor(() => {
+      expect(screen.getByText('Property: 516 Overton St')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Property: 516 Overton St'));
+    expect(push).toHaveBeenCalledWith('/property/p1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open the command palette' }));
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays useful when the property fetch fails, and retries next open', async () => {
+    const list = vi
+      .spyOn(api, 'listProperties')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue(PROPERTIES);
+    render(<CommandBar />);
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    // Routes answer even while properties are unavailable.
+    expect(screen.getByText('Go: Vendors')).toBeDefined();
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/Property:/)).toBeNull();
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    await waitFor(() => {
+      expect(screen.getByText('Property: 516 Overton St')).toBeDefined();
+    });
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,0 +1,10 @@
+// jsdom's <dialog> lacks showModal/close; the design primitives drive them.
+if (typeof HTMLDialogElement.prototype.showModal !== 'function') {
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   oxc: { jsx: { runtime: 'automatic' } },
   test: {
     environment: 'jsdom',
+    setupFiles: ['tests/setup.ts'],
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     coverage: {
       provider: 'v8',

--- a/packages/design/src/css/primitives.css
+++ b/packages/design/src/css/primitives.css
@@ -52,6 +52,29 @@
     color: var(--ember);
   }
 
+  /* The palette's key, worn as a quiet mono chip at the masthead's edge. */
+  .masthead__command {
+    font-family: var(--mono);
+    font-size: var(--type-label);
+    color: var(--ink-dim);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    padding: 2px var(--space-2);
+    cursor: pointer;
+    margin-left: var(--space-4);
+  }
+
+  .masthead__command:hover {
+    color: var(--ink);
+    border-color: var(--ember);
+  }
+
+  .masthead__command:focus-visible {
+    outline: var(--focus-outline);
+    outline-offset: 2px;
+  }
+
   /* ---- authority ---- */
 
   .citation {


### PR DESCRIPTION
Closes #57. ⌘K live over every page and property: lazy one-time property load that never blocks, honest retry on failure, router navigation, e2e presses the real key. 165 web tests, 100% coverage, 8/8 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)