### PR TITLE
The 11pm surface — three taps to a number that answers

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -79,6 +79,22 @@ test('the command palette answers ⌘K and navigates', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Calendar' })).toBeVisible();
 });
 
+test('the 11pm surface: property, symptom, proof, and the incident on the board', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Emergency', exact: true }).click();
+  await page.getByRole('button', { name: '998 Monmouth St', exact: true }).first().click();
+  await page.getByRole('button', { name: /Water — burst pipe/ }).click();
+  // The smoke vendor carries a live certificate; the proof line says so.
+  await expect(page.getByText(/insured through Jun 30, 2027/).first()).toBeVisible();
+  await page.getByRole('button', { name: 'Log with this vendor' }).first().click();
+  await expect(page.getByText(/is on the maintenance board as an emergency/)).toBeVisible();
+  await page.getByRole('button', { name: 'Close', exact: true }).click();
+  await page.goto('/maintenance');
+  await expect(page.getByRole('link', { name: /Water emergency/ }).first()).toBeVisible();
+});
+
 test('the calendar and coverage pages answer', async ({ page }) => {
   await page.goto('/calendar');
   await expect(

--- a/apps/web/src/components/CommandBar.tsx
+++ b/apps/web/src/components/CommandBar.tsx
@@ -4,6 +4,7 @@ import { type Command, CommandPalette, useCommandK } from '@hestia/design';
 import { useRouter } from 'next/navigation';
 import { useCallback, useRef, useState } from 'react';
 import { api, type PropertySummary } from '../lib/api';
+import { EmergencyDispatch } from './EmergencyDispatch';
 
 /**
  * ⌘K, wired: one keystroke to any page or property. Routes are static;
@@ -26,6 +27,7 @@ const ROUTES: readonly { label: string; path: string }[] = [
 export function CommandBar() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [dispatchOpen, setDispatchOpen] = useState(false);
   const [properties, setProperties] = useState<readonly PropertySummary[]>([]);
   const fetched = useRef(false);
 
@@ -46,6 +48,12 @@ export function CommandBar() {
   useCommandK(openPalette);
 
   const commands: Command[] = [
+    {
+      id: 'emergency',
+      label: 'Emergency: burst pipe, no heat, electrical…',
+      hint: 'dispatch',
+      run: () => setDispatchOpen(true),
+    },
     ...ROUTES.map((route) => ({
       id: `go${route.path}`,
       label: `Go: ${route.label}`,
@@ -70,6 +78,9 @@ export function CommandBar() {
       >
         ⌘K
       </button>
+      <button type="button" className="masthead__emergency" onClick={() => setDispatchOpen(true)}>
+        Emergency
+      </button>
       <CommandPalette
         open={open}
         onClose={() => {
@@ -77,6 +88,7 @@ export function CommandBar() {
         }}
         commands={commands}
       />
+      <EmergencyDispatch open={dispatchOpen} onClose={() => setDispatchOpen(false)} />
     </>
   );
 }

--- a/apps/web/src/components/EmergencyDispatch.tsx
+++ b/apps/web/src/components/EmergencyDispatch.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { Button, Dialog, EmptyState, Pill } from '@hestia/design';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api, type PropertySummary, type VendorOut } from '../lib/api';
+import { rankVendors, SYMPTOMS, type Symptom } from '../lib/dispatch';
+
+/**
+ * The 11pm surface. Three taps: open — property — CALL. Urgency is
+ * stillness: no motion, no charts, the largest type on the page, targets
+ * built for wet hands and a dying phone. An expired certificate warns but
+ * never hides the number; a missing plumber degrades to an honest empty
+ * state and the incident logger still works.
+ */
+type Step =
+  | { name: 'property' }
+  | { name: 'symptom'; property: PropertySummary | null }
+  | { name: 'call'; property: PropertySummary | null; symptom: Symptom }
+  | { name: 'logged'; summary: string };
+
+type EmergencyDispatchProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+function CallStep({
+  property,
+  symptom,
+  vendors,
+  onBack,
+  onLogged,
+}: {
+  property: PropertySummary | null;
+  symptom: Symptom;
+  vendors: readonly VendorOut[];
+  onBack: () => void;
+  onLogged: (summary: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const ranked = rankVendors(vendors, symptom.trade);
+
+  const logIncident = async (target: PropertySummary, vendorId?: string) => {
+    setBusy(true);
+    setError(null);
+    // A symptom label always has a head before its ' — ' elaboration.
+    const summary = `${symptom.label.split(' — ')[0] as string} emergency`;
+    try {
+      await api.createWorkOrder({
+        property_id: target.id,
+        summary,
+        detail: `Logged from emergency dispatch: ${symptom.label}`,
+        priority: 'emergency',
+        reported_by: 'owner',
+        ...(vendorId === undefined ? {} : { vendor_id: vendorId }),
+      });
+      onLogged(summary);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      {symptom.note === undefined ? null : <p className="dispatch__note">{symptom.note}</p>}
+      {ranked.length === 0 ? (
+        <EmptyState>
+          No {symptom.trade.replace('_', ' ')} on file — add one under Vendors when the water stops.
+          Log the incident now so the record starts tonight.
+        </EmptyState>
+      ) : (
+        ranked.map(({ vendor, fallback, proof, proofTone }) => (
+          <div key={vendor.id} className="dispatch__vendor">
+            <div className="dispatch__vendor-head">
+              <strong>{vendor.name}</strong>
+              {fallback ? <Pill tone="neutral">{vendor.trade.replace('_', ' ')}</Pill> : null}
+            </div>
+            {vendor.phone === null ? (
+              <p className="muted">No number on file{vendor.email ? ` — ${vendor.email}` : ''}.</p>
+            ) : (
+              <a className="dispatch__call" href={`tel:${vendor.phone}`}>
+                Call {vendor.phone}
+              </a>
+            )}
+            <p
+              className={
+                proofTone === 'ok'
+                  ? 'dispatch__proof'
+                  : proofTone === 'warn'
+                    ? 'dispatch__proof dispatch__proof--warn'
+                    : 'dispatch__proof dispatch__proof--bad'
+              }
+            >
+              {proof}
+            </p>
+            {property === null ? null : (
+              <Button
+                variant="quiet"
+                disabled={busy}
+                onClick={() => void logIncident(property, vendor.id)}
+              >
+                Log with this vendor
+              </Button>
+            )}
+          </div>
+        ))
+      )}
+      {property === null ? null : (
+        <Button variant="quiet" disabled={busy} onClick={() => void logIncident(property)}>
+          Log the incident without a vendor
+        </Button>
+      )}
+      {error === null ? null : <p className="error-note">{error}</p>}
+      <Button variant="quiet" onClick={onBack}>
+        Back
+      </Button>
+    </>
+  );
+}
+
+export function EmergencyDispatch({ open, onClose }: EmergencyDispatchProps) {
+  const [step, setStep] = useState<Step>({ name: 'property' });
+  const [properties, setProperties] = useState<readonly PropertySummary[]>([]);
+  const [vendors, setVendors] = useState<readonly VendorOut[]>([]);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (open && !fetched.current) {
+      fetched.current = true;
+      Promise.all([api.listProperties(), api.listVendors()])
+        .then(([propertyRows, vendorRows]) => {
+          setProperties(propertyRows);
+          setVendors(vendorRows);
+        })
+        .catch(() => {
+          // The overlay still renders; retry on the next open.
+          fetched.current = false;
+        });
+    }
+  }, [open]);
+
+  const close = useCallback(() => {
+    setStep({ name: 'property' });
+    onClose();
+  }, [onClose]);
+
+  return (
+    <Dialog open={open} onClose={close} label="Emergency dispatch" className="dispatch">
+      <p className="dispatch__title">Emergency</p>
+
+      {step.name === 'property' ? (
+        <>
+          <p className="dispatch__ask">Which property?</p>
+          {properties.map((property) => (
+            <button
+              key={property.id}
+              type="button"
+              className="dispatch__choice"
+              onClick={() => setStep({ name: 'symptom', property })}
+            >
+              {property.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="dispatch__choice dispatch__choice--quiet"
+            onClick={() => setStep({ name: 'symptom', property: null })}
+          >
+            Skip — just get me a number
+          </button>
+        </>
+      ) : null}
+
+      {step.name === 'symptom' ? (
+        <>
+          <p className="dispatch__ask">What is happening?</p>
+          {SYMPTOMS.map((symptom) => (
+            <button
+              key={symptom.id}
+              type="button"
+              className="dispatch__choice"
+              onClick={() => setStep({ name: 'call', property: step.property, symptom })}
+            >
+              {symptom.label}
+            </button>
+          ))}
+          <Button variant="quiet" onClick={() => setStep({ name: 'property' })}>
+            Back
+          </Button>
+        </>
+      ) : null}
+
+      {step.name === 'call' ? (
+        <CallStep
+          property={step.property}
+          symptom={step.symptom}
+          vendors={vendors}
+          onBack={() => setStep({ name: 'symptom', property: step.property })}
+          onLogged={(summary) => setStep({ name: 'logged', summary })}
+        />
+      ) : null}
+
+      {step.name === 'logged' ? (
+        <>
+          <p className="dispatch__ask">
+            Logged. “{step.summary}” is on the maintenance board as an emergency.
+          </p>
+          <Button onClick={close}>Close</Button>
+        </>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/dispatch.ts
+++ b/apps/web/src/lib/dispatch.ts
@@ -1,0 +1,111 @@
+/**
+ * The 11pm arithmetic: symptom → trade → a ranked call list. Pure, so the
+ * overlay stays a dumb surface. The ranking never hides a vendor for an
+ * expired certificate — at 11pm the owner may still choose them, knowingly —
+ * it demotes and says why. 'Unknown' is not 'covered', and the copy says
+ * that too.
+ */
+import type { VendorOut } from './api';
+import { formatDate } from './format';
+
+export type VendorTrade = VendorOut['trade'];
+
+export interface Symptom {
+  id: string;
+  label: string;
+  trade: VendorTrade;
+  /** Safety guidance that outranks any phone call. */
+  note?: string;
+}
+
+export const SYMPTOMS: readonly Symptom[] = [
+  { id: 'water', label: 'Water — burst pipe, leak, no water', trade: 'plumbing' },
+  { id: 'heat', label: 'No heat or cooling', trade: 'hvac' },
+  {
+    id: 'electrical',
+    label: 'Electrical — outage, sparks, burning smell',
+    trade: 'electrical',
+    note: 'If anything is arcing or smoking, cut the breaker before you dial.',
+  },
+  { id: 'roof', label: 'Roof leak or storm damage', trade: 'roofing' },
+  {
+    id: 'gas',
+    label: 'Gas smell',
+    trade: 'plumbing',
+    note: 'Leave the building and call the gas utility’s emergency line FIRST. A plumber is the second call, not the first.',
+  },
+];
+
+const FALLBACK_TRADES: readonly VendorTrade[] = ['general_contractor', 'handyman'];
+
+const COVERAGE_ORDER: Record<VendorOut['coverage_state'], number> = {
+  current: 0,
+  expiring: 1,
+  unknown: 2,
+  expired: 3,
+};
+
+export interface RankedVendor {
+  vendor: VendorOut;
+  /** A general trade standing in because no exact match exists to call. */
+  fallback: boolean;
+  proof: string;
+  proofTone: 'ok' | 'warn' | 'bad';
+}
+
+function proofOf(vendor: VendorOut): { proof: string; proofTone: 'ok' | 'warn' | 'bad' } {
+  switch (vendor.coverage_state) {
+    case 'current':
+      return {
+        proof:
+          vendor.liability_expires_on === null
+            ? 'insured — certificate on file'
+            : `insured through ${formatDate(vendor.liability_expires_on)}`,
+        proofTone: 'ok',
+      };
+    case 'expiring':
+      return {
+        proof:
+          vendor.liability_expires_on === null
+            ? 'insurance expiring soon — renew the certificate'
+            : `insurance expires ${formatDate(vendor.liability_expires_on)} — renew the certificate`,
+        proofTone: 'warn',
+      };
+    case 'unknown':
+      return { proof: 'insurance unverified — no certificate on record', proofTone: 'warn' };
+    case 'expired':
+      return {
+        proof:
+          vendor.liability_expires_on === null
+            ? 'liability coverage lapsed — their mistakes bill to your policy'
+            : `liability lapsed ${formatDate(vendor.liability_expires_on)} — their mistakes bill to your policy`,
+        proofTone: 'bad',
+      };
+  }
+}
+
+const rankWithin = (a: VendorOut, b: VendorOut): number => {
+  const phone = Number(a.phone === null) - Number(b.phone === null);
+  if (phone !== 0) {
+    return phone;
+  }
+  const coverage = COVERAGE_ORDER[a.coverage_state] - COVERAGE_ORDER[b.coverage_state];
+  if (coverage !== 0) {
+    return coverage;
+  }
+  return a.name.localeCompare(b.name);
+};
+
+/** Exact-trade vendors first, general trades after, each group ranked by
+ * reachability (a number to dial), then coverage, then name. */
+export function rankVendors(vendors: readonly VendorOut[], trade: VendorTrade): RankedVendor[] {
+  const active = vendors.filter((vendor) => vendor.retired_on === null);
+  const primary = active.filter((vendor) => vendor.trade === trade).sort(rankWithin);
+  const fallback = FALLBACK_TRADES.includes(trade)
+    ? []
+    : active.filter((vendor) => FALLBACK_TRADES.includes(vendor.trade)).sort(rankWithin);
+  return [
+    ...primary.map((vendor) => ({ vendor, fallback: false, ...proofOf(vendor) })),
+    ...fallback.map((vendor) => ({ vendor, fallback: true, ...proofOf(vendor) })),
+  ];
+}

--- a/apps/web/tests/command-bar.test.tsx
+++ b/apps/web/tests/command-bar.test.tsx
@@ -61,6 +61,20 @@ describe('CommandBar', () => {
     expect(list).toHaveBeenCalledTimes(1);
   });
 
+  it('opens the 11pm surface from the palette and the masthead control', async () => {
+    vi.spyOn(api, 'listProperties').mockResolvedValue(PROPERTIES);
+    vi.spyOn(api, 'listVendors').mockResolvedValue([]);
+    render(<CommandBar />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    fireEvent.click(screen.getByText(/Emergency: burst pipe/));
+    const dispatch = screen.getByLabelText('Emergency dispatch', { selector: 'dialog' });
+    expect(dispatch.hasAttribute('open')).toBe(true);
+    fireEvent(dispatch, new Event('close'));
+    expect(dispatch.hasAttribute('open')).toBe(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Emergency' }));
+    expect(dispatch.hasAttribute('open')).toBe(true);
+  });
+
   it('stays useful when the property fetch fails, and retries next open', async () => {
     const list = vi
       .spyOn(api, 'listProperties')

--- a/apps/web/tests/dispatch.test.ts
+++ b/apps/web/tests/dispatch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { VendorOut } from '../src/lib/api';
+import { rankVendors, SYMPTOMS } from '../src/lib/dispatch';
+
+const vendor = (overrides: Partial<VendorOut>): VendorOut => ({
+  id: overrides.name ?? 'v',
+  entity_id: 'e1',
+  entity_name: 'Smoke Test LLC',
+  name: 'Vendor',
+  trade: 'plumbing',
+  phone: '859-555-0100',
+  email: null,
+  license_number: null,
+  license_expires_on: null,
+  insurer: null,
+  liability_expires_on: '2027-06-30',
+  workers_comp_expires_on: null,
+  w9_on_file: false,
+  is_1099_reportable: false,
+  notes: null,
+  coverage_state: 'current',
+  earliest_expiry: null,
+  open_work_orders: 0,
+  also_registered_under: [],
+  retired_on: null,
+  ...overrides,
+});
+
+describe('SYMPTOMS', () => {
+  it('names a trade the schema actually holds, and safety notes where they matter', () => {
+    for (const symptom of SYMPTOMS) {
+      expect(symptom.trade).toBeTruthy();
+    }
+    expect(SYMPTOMS.find((s) => s.id === 'gas')?.note).toMatch(/utility.*FIRST/);
+  });
+});
+
+describe('rankVendors', () => {
+  it('ranks reachable before unreachable, covered before lapsed, then by name', () => {
+    const ranked = rankVendors(
+      [
+        vendor({ name: 'Zeta Covered', coverage_state: 'current' }),
+        vendor({ name: 'Alpha Covered', coverage_state: 'current' }),
+        vendor({ name: 'Lapsed', coverage_state: 'expired', liability_expires_on: '2026-07-01' }),
+        vendor({ name: 'No Phone', phone: null }),
+        vendor({ name: 'Unknown Cover', coverage_state: 'unknown', liability_expires_on: null }),
+      ],
+      'plumbing',
+    );
+    expect(ranked.map((entry) => entry.vendor.name)).toEqual([
+      'Alpha Covered',
+      'Zeta Covered',
+      'Unknown Cover',
+      'Lapsed',
+      'No Phone',
+    ]);
+  });
+
+  it('never hides a lapsed vendor — it demotes and says why', () => {
+    const [lapsed] = rankVendors(
+      [vendor({ name: 'Lapsed', coverage_state: 'expired', liability_expires_on: '2026-07-01' })],
+      'plumbing',
+    );
+    expect(lapsed?.proofTone).toBe('bad');
+    expect(lapsed?.proof).toBe('liability lapsed Jul 1, 2026 — their mistakes bill to your policy');
+  });
+
+  it('speaks each coverage state honestly, with and without a date', () => {
+    const proofs = (v: VendorOut) => rankVendors([v], v.trade)[0];
+    expect(proofs(vendor({ coverage_state: 'current' }))?.proof).toBe(
+      'insured through Jun 30, 2027',
+    );
+    expect(proofs(vendor({ coverage_state: 'current', liability_expires_on: null }))?.proof).toBe(
+      'insured — certificate on file',
+    );
+    expect(proofs(vendor({ coverage_state: 'expiring' }))?.proof).toBe(
+      'insurance expires Jun 30, 2027 — renew the certificate',
+    );
+    expect(proofs(vendor({ coverage_state: 'expiring', liability_expires_on: null }))?.proof).toBe(
+      'insurance expiring soon — renew the certificate',
+    );
+    expect(proofs(vendor({ coverage_state: 'unknown', liability_expires_on: null }))?.proof).toBe(
+      'insurance unverified — no certificate on record',
+    );
+    expect(proofs(vendor({ coverage_state: 'expired', liability_expires_on: null }))?.proof).toBe(
+      'liability coverage lapsed — their mistakes bill to your policy',
+    );
+    expect(proofs(vendor({ coverage_state: 'expiring' }))?.proofTone).toBe('warn');
+    expect(
+      proofs(vendor({ coverage_state: 'unknown', liability_expires_on: null }))?.proofTone,
+    ).toBe('warn');
+  });
+
+  it('appends general trades as a labeled fallback, never for their own call', () => {
+    const ranked = rankVendors(
+      [
+        vendor({ name: 'GC', trade: 'general_contractor' }),
+        vendor({ name: 'Handy', trade: 'handyman' }),
+        vendor({ name: 'Pipes', trade: 'plumbing' }),
+      ],
+      'plumbing',
+    );
+    expect(ranked.map((entry) => `${entry.vendor.name}${entry.fallback ? '*' : ''}`)).toEqual([
+      'Pipes',
+      'GC*',
+      'Handy*',
+    ]);
+    // Asking FOR a general trade must not duplicate them as their own fallback.
+    const general = rankVendors(
+      [vendor({ name: 'Handy', trade: 'handyman' }), vendor({ name: 'Pipes' })],
+      'handyman',
+    );
+    expect(general.map((entry) => entry.vendor.name)).toEqual(['Handy']);
+  });
+
+  it('leaves the retired in peace', () => {
+    expect(rankVendors([vendor({ retired_on: '2026-01-01' })], 'plumbing')).toEqual([]);
+  });
+});

--- a/apps/web/tests/emergency-dispatch.test.tsx
+++ b/apps/web/tests/emergency-dispatch.test.tsx
@@ -1,0 +1,213 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EmergencyDispatch } from '../src/components/EmergencyDispatch';
+import { api, type PropertySummary, type VendorOut } from '../src/lib/api';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const PROPERTY: PropertySummary = {
+  id: 'p1',
+  label: '516 Overton St',
+  street_1: '516 Overton St',
+  city: 'Newport',
+  state: 'KY',
+  postal_code: '41071',
+  kind: 'single_family',
+  year_built: 1910,
+  jurisdiction: 'us-ky-newport',
+  component_count: 0,
+  defect_count: 0,
+  next_deadline_on: null,
+};
+
+const vendor = (overrides: Partial<VendorOut>): VendorOut => ({
+  id: overrides.name ?? 'v',
+  entity_id: 'e1',
+  entity_name: 'Smoke Test LLC',
+  name: 'Vendor',
+  trade: 'plumbing',
+  phone: '859-555-0100',
+  email: null,
+  license_number: null,
+  license_expires_on: null,
+  insurer: null,
+  liability_expires_on: '2027-06-30',
+  workers_comp_expires_on: null,
+  w9_on_file: false,
+  is_1099_reportable: false,
+  notes: null,
+  coverage_state: 'current',
+  earliest_expiry: null,
+  open_work_orders: 0,
+  also_registered_under: [],
+  retired_on: null,
+  ...overrides,
+});
+
+const VENDORS = [
+  vendor({ name: 'NKY Plumbing' }),
+  vendor({
+    name: 'Lapsed Larry',
+    phone: '859-555-0199',
+    coverage_state: 'expired',
+    liability_expires_on: '2026-07-01',
+  }),
+  vendor({
+    name: 'Silent Sam',
+    phone: null,
+    email: 'sam@example.test',
+    coverage_state: 'unknown',
+    liability_expires_on: null,
+  }),
+  vendor({
+    name: 'Any Trade Tony',
+    trade: 'general_contractor',
+    phone: '859-555-0142',
+    coverage_state: 'expiring',
+  }),
+  vendor({
+    name: 'Mute Moe',
+    phone: null,
+    email: null,
+    coverage_state: 'expired',
+    liability_expires_on: null,
+  }),
+];
+
+const openDispatch = async () => {
+  vi.spyOn(api, 'listProperties').mockResolvedValue([PROPERTY]);
+  vi.spyOn(api, 'listVendors').mockResolvedValue(VENDORS);
+  const view = render(<EmergencyDispatch open onClose={vi.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: '516 Overton St' })).toBeDefined();
+  });
+  return view;
+};
+
+describe('EmergencyDispatch', () => {
+  it('walks property → symptom → a ranked call list, lapsed shown and flagged', async () => {
+    await openDispatch();
+    fireEvent.click(screen.getByRole('button', { name: '516 Overton St' }));
+    expect(screen.getByText('What is happening?')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /Water — burst pipe/ }));
+
+    const call = screen.getByRole('link', { name: 'Call 859-555-0100' });
+    expect(call.getAttribute('href')).toBe('tel:859-555-0100');
+    expect(screen.getByText('insured through Jun 30, 2027').className).toBe('dispatch__proof');
+    // The lapsed vendor is present, demoted, and loud about why.
+    expect(screen.getByText(/liability lapsed Jul 1, 2026/).className).toBe(
+      'dispatch__proof dispatch__proof--bad',
+    );
+    // The unreachable vendor states its gap instead of pretending.
+    expect(screen.getByText(/No number on file — sam@example.test/)).toBeDefined();
+    expect(screen.getByText('No number on file.')).toBeDefined();
+    // The general trade stands in, labeled as what it is.
+    expect(screen.getByText('general contractor').className).toBe('pill');
+  });
+
+  it('carries the gas safety note above every number', async () => {
+    await openDispatch();
+    fireEvent.click(screen.getByRole('button', { name: '516 Overton St' }));
+    fireEvent.click(screen.getByRole('button', { name: /Gas smell/ }));
+    expect(screen.getByText(/gas utility’s emergency line FIRST/)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByText('What is happening?')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByText('Which property?')).toBeDefined();
+  });
+
+  it('logs the incident with the chosen vendor as an emergency work order', async () => {
+    const create = vi.spyOn(api, 'createWorkOrder').mockResolvedValue({} as never);
+    await openDispatch();
+    fireEvent.click(screen.getByRole('button', { name: '516 Overton St' }));
+    fireEvent.click(screen.getByRole('button', { name: /Water — burst pipe/ }));
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Log with this vendor' })[0] as HTMLElement,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/is on the maintenance board as an emergency/)).toBeDefined();
+    });
+    expect(create).toHaveBeenCalledWith({
+      property_id: 'p1',
+      summary: 'Water emergency',
+      detail: 'Logged from emergency dispatch: Water — burst pipe, leak, no water',
+      priority: 'emergency',
+      reported_by: 'owner',
+      vendor_id: 'NKY Plumbing',
+    });
+    // Close resets the walk for the next emergency.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.getByText('Which property?')).toBeDefined();
+  });
+
+  it('logs without a vendor, and shows the refusal when the ledger says no', async () => {
+    const create = vi
+      .spyOn(api, 'createWorkOrder')
+      .mockRejectedValueOnce(new Error('409: someone got there first'))
+      .mockRejectedValueOnce('a bare string refusal')
+      .mockResolvedValue({} as never);
+    await openDispatch();
+    fireEvent.click(screen.getByRole('button', { name: '516 Overton St' }));
+    fireEvent.click(screen.getByRole('button', { name: /No heat/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Log the incident without a vendor' }));
+    await waitFor(() => {
+      expect(screen.getByText(/someone got there first/)).toBeDefined();
+    });
+    // A refusal that is not an Error still reaches the owner as text.
+    fireEvent.click(screen.getByRole('button', { name: 'Log the incident without a vendor' }));
+    await waitFor(() => {
+      expect(screen.getByText('a bare string refusal')).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log the incident without a vendor' }));
+    await waitFor(() => {
+      expect(screen.getByText(/is on the maintenance board/)).toBeDefined();
+    });
+    expect(create).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ vendor_id: expect.anything() }),
+    );
+  });
+
+  it('skips the property honestly: numbers yes, logging no', async () => {
+    await openDispatch();
+    fireEvent.click(screen.getByRole('button', { name: 'Skip — just get me a number' }));
+    fireEvent.click(screen.getByRole('button', { name: /Water — burst pipe/ }));
+    expect(screen.getByRole('link', { name: 'Call 859-555-0100' })).toBeDefined();
+    expect(screen.queryByText(/Log/)).toBeNull();
+  });
+
+  it('degrades to an honest empty state when no one answers the trade', async () => {
+    // No general trades on this roster either — nobody can stand in.
+    vi.spyOn(api, 'listProperties').mockResolvedValue([PROPERTY]);
+    vi.spyOn(api, 'listVendors').mockResolvedValue([vendor({ name: 'Pipes Only' })]);
+    render(<EmergencyDispatch open onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '516 Overton St' })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '516 Overton St' }));
+    fireEvent.click(screen.getByRole('button', { name: /Roof leak/ }));
+    expect(screen.getByText(/No roofing on file/)).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Log the incident without a vendor' })).toBeDefined();
+  });
+
+  it('retries the fetch on the next open after a failure', async () => {
+    const list = vi
+      .spyOn(api, 'listProperties')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue([PROPERTY]);
+    vi.spyOn(api, 'listVendors').mockResolvedValue(VENDORS);
+    const onClose = vi.fn();
+    const { rerender } = render(<EmergencyDispatch open onClose={onClose} />);
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledTimes(1);
+    });
+    rerender(<EmergencyDispatch open={false} onClose={onClose} />);
+    rerender(<EmergencyDispatch open onClose={onClose} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '516 Overton St' })).toBeDefined();
+    });
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/exit-scrub.test.ts
+++ b/apps/web/tests/exit-scrub.test.ts
@@ -123,7 +123,9 @@ describe('buildExitModel', () => {
     expect(model.crossovers).toEqual([]);
   });
 
-  it('finds the crossover where a leveraged return decays through the hurdle', () => {
+  it('finds the crossover where a leveraged return decays through the hurdle', {
+    timeout: 30_000,
+  }, () => {
     // Leverage: small equity earns the whole building's growth early, then
     // the return decays toward the unlevered rate as equity accretes. Pick
     // a hurdle between the two and the verdict must flip mid-horizon.

--- a/packages/design/src/css/patterns.css
+++ b/packages/design/src/css/patterns.css
@@ -193,4 +193,134 @@
   .exit__knobs {
     margin-top: var(--space-4);
   }
+
+  /* ---- the 11pm surface: urgency is stillness ---- */
+
+  /* The masthead control: a madder hairline, never crying wolf. */
+  .masthead__emergency {
+    font-size: var(--type-label);
+    letter-spacing: var(--track-label);
+    text-transform: uppercase;
+    color: var(--madder);
+    background: none;
+    border: 1px solid rgb(143 45 60 / 40%);
+    border-radius: var(--radius-sm);
+    padding: 2px var(--space-2);
+    cursor: pointer;
+    margin-left: var(--space-2);
+  }
+
+  .masthead__emergency:hover {
+    background: var(--madder-wash);
+  }
+
+  .masthead__emergency:focus-visible {
+    outline: 2px solid var(--madder);
+    outline-offset: 2px;
+  }
+
+  .dispatch {
+    width: min(520px, calc(100vw - var(--space-6)));
+  }
+
+  .dispatch__title {
+    font-family: var(--serif);
+    font-size: var(--type-sub);
+    font-weight: 600;
+    color: var(--madder);
+    margin: 0 0 var(--space-3);
+  }
+
+  .dispatch__ask {
+    font-size: var(--type-lead);
+    margin: 0 0 var(--space-3);
+  }
+
+  .dispatch__choice {
+    display: block;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    font-size: var(--type-lead);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    margin-bottom: var(--space-2);
+    cursor: pointer;
+    min-height: 56px;
+  }
+
+  .dispatch__choice:hover {
+    border-color: var(--ember);
+  }
+
+  .dispatch__choice:focus-visible {
+    outline: var(--focus-outline);
+    outline-offset: 2px;
+  }
+
+  .dispatch__choice--quiet {
+    background: none;
+    color: var(--ink-dim);
+    min-height: 44px;
+    font-size: var(--type-body);
+  }
+
+  /* Safety guidance outranks every phone number on the page. */
+  .dispatch__note {
+    background: var(--madder-wash);
+    color: var(--madder);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    font-size: var(--type-lead);
+    margin: 0 0 var(--space-3);
+  }
+
+  .dispatch__vendor {
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-3);
+  }
+
+  .dispatch__vendor-head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    font-size: var(--type-sub);
+  }
+
+  /* The one thing a wet hand must hit. */
+  .dispatch__call {
+    display: block;
+    text-align: center;
+    background: var(--ember);
+    color: var(--hearth-white);
+    font-size: var(--type-lead);
+    font-weight: 600;
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    margin: var(--space-2) 0;
+    min-height: 56px;
+  }
+
+  .dispatch__call:hover {
+    background: var(--ember-deep);
+  }
+
+  .dispatch__proof {
+    font-size: var(--type-small);
+    color: var(--fern);
+    margin: 0 0 var(--space-2);
+  }
+
+  .dispatch__proof--warn {
+    color: var(--umber);
+  }
+
+  .dispatch__proof--bad {
+    color: var(--madder);
+    font-weight: 600;
+  }
 }


### PR DESCRIPTION
Closes #54. Emergency on the masthead + as the palette's first command: property → symptom → ranked call list (exact trade, labeled general fallbacks, lapsed demoted-and-loud, unknown ≠ covered), gas safety guidance above every number, one more tap logs the emergency work order. Urgency is stillness. 181 web tests at 100% everything; 9/9 e2e including the full night walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)