### PR TITLE
Deposits: the jurisdiction answers, or the gap says nobody did

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -227,6 +227,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/deposits/open": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Open Deposits */
+        get: operations["list_open_deposits_deposits_open_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/documents": {
         parameters: {
             query?: never;
@@ -411,6 +428,40 @@ export interface paths {
         put?: never;
         /** Collect Rent */
         post: operations["collect_rent_leases__lease_id__collect_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/leases/{lease_id}/deposit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Deposit */
+        get: operations["read_deposit_leases__lease_id__deposit_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/leases/{lease_id}/deposit-return": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Return Deposit */
+        post: operations["return_deposit_leases__lease_id__deposit_return_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1677,6 +1728,34 @@ export interface components {
             /** Triggers Disclosure */
             triggers_disclosure: boolean;
         };
+        /** DepositOut */
+        DepositOut: {
+            /** Deposit Account */
+            deposit_account: string | null;
+            /** Deposit Returned */
+            deposit_returned: string | null;
+            /** Deposit Returned On */
+            deposit_returned_on: string | null;
+            /** Duties */
+            duties: components["schemas"]["DutyOut"][];
+            /** Gaps */
+            gaps: components["schemas"]["GapOut"][];
+            interest: components["schemas"]["InterestOut"] | null;
+            /** Lease Id */
+            lease_id: string;
+            /** Moved Out On */
+            moved_out_on: string | null;
+            /** Return Citation */
+            return_citation: string | null;
+            /** Return Days */
+            return_days: number | null;
+            /** Return Due On */
+            return_due_on: string | null;
+            /** Security Deposit */
+            security_deposit: string;
+            /** State */
+            state: string;
+        };
         /** DocumentDetail */
         DocumentDetail: {
             /** Applied At */
@@ -1826,6 +1905,18 @@ export interface components {
             /** Year Built */
             year_built: number | null;
         };
+        /**
+         * DutyOut
+         * @description One thing the jurisdiction requires, and the authority that requires it.
+         */
+        DutyOut: {
+            /** Citation */
+            citation: string;
+            /** Code */
+            code: string;
+            /** Requirement */
+            requirement: string;
+        };
         /** EntityIn */
         EntityIn: {
             /** Formation State */
@@ -1918,6 +2009,18 @@ export interface components {
             property_id: string;
             valuation: components["schemas"]["ValuationOut"] | null;
         };
+        /**
+         * GapOut
+         * @description A duty this chain cannot answer. Named, never defaulted.
+         */
+        GapOut: {
+            /** Code */
+            code: string;
+            /** Detail */
+            detail: string;
+            /** Reason */
+            reason: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -1959,6 +2062,21 @@ export interface components {
             staged: number;
             /** Suggested */
             suggested: number;
+        };
+        /** InterestOut */
+        InterestOut: {
+            /** Accrued */
+            accrued: string;
+            /** Citation */
+            citation: string;
+            /** Exempt Amount */
+            exempt_amount: string;
+            /** Interest Bearing */
+            interest_bearing: string;
+            /** Months Held */
+            months_held: number;
+            /** Rate */
+            rate: string;
         };
         /** LeaseDetail */
         LeaseDetail: {
@@ -2542,6 +2660,40 @@ export interface components {
             chain: string[];
             /** Level */
             level: string;
+        };
+        /** ReturnIn */
+        ReturnIn: {
+            /** Amount */
+            amount: number | string;
+            /**
+             * Post To Ledger
+             * @default true
+             */
+            post_to_ledger: boolean;
+            /** Returned On */
+            returned_on?: string | null;
+            /** Withheld Reason */
+            withheld_reason?: string | null;
+        };
+        /** ReturnOut */
+        ReturnOut: {
+            /** Deadline Resolved */
+            deadline_resolved: boolean;
+            /** Lease Id */
+            lease_id: string;
+            /** Ledger Event Uuid */
+            ledger_event_uuid: string | null;
+            /** Returned */
+            returned: string;
+            /**
+             * Returned On
+             * Format: date
+             */
+            returned_on: string;
+            /** Withheld */
+            withheld: string;
+            /** Withheld Reason */
+            withheld_reason: string | null;
         };
         /** ReversalIn */
         ReversalIn: {
@@ -3578,6 +3730,37 @@ export interface operations {
             };
         };
     };
+    list_open_deposits_deposits_open_get: {
+        parameters: {
+            query?: {
+                as_of?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepositOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_documents_documents_get: {
         parameters: {
             query?: {
@@ -4000,6 +4183,76 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CollectOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_deposit_leases__lease_id__deposit_get: {
+        parameters: {
+            query?: {
+                as_of?: string | null;
+            };
+            header?: never;
+            path: {
+                lease_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DepositOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    return_deposit_leases__lease_id__deposit_return_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                lease_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReturnIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReturnOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -2102,6 +2102,145 @@
         "title": "DefectOut",
         "type": "object"
       },
+      "DepositOut": {
+        "properties": {
+          "deposit_account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deposit Account"
+          },
+          "deposit_returned": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deposit Returned"
+          },
+          "deposit_returned_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deposit Returned On"
+          },
+          "duties": {
+            "items": {
+              "$ref": "#/components/schemas/DutyOut"
+            },
+            "title": "Duties",
+            "type": "array"
+          },
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/GapOut"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "interest": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InterestOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lease_id": {
+            "title": "Lease Id",
+            "type": "string"
+          },
+          "moved_out_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Moved Out On"
+          },
+          "return_citation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Citation"
+          },
+          "return_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Days"
+          },
+          "return_due_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Due On"
+          },
+          "security_deposit": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Security Deposit",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "lease_id",
+          "state",
+          "security_deposit",
+          "deposit_account",
+          "moved_out_on",
+          "deposit_returned_on",
+          "deposit_returned",
+          "duties",
+          "gaps",
+          "return_days",
+          "return_due_on",
+          "return_citation",
+          "interest"
+        ],
+        "title": "DepositOut",
+        "type": "object"
+      },
       "DocumentDetail": {
         "properties": {
           "applied_at": {
@@ -2577,6 +2716,30 @@
         "title": "DossierView",
         "type": "object"
       },
+      "DutyOut": {
+        "description": "One thing the jurisdiction requires, and the authority that requires it.",
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "requirement": {
+            "title": "Requirement",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "requirement",
+          "citation"
+        ],
+        "title": "DutyOut",
+        "type": "object"
+      },
       "EntityIn": {
         "properties": {
           "formation_state": {
@@ -2918,6 +3081,30 @@
         "title": "Financials",
         "type": "object"
       },
+      "GapOut": {
+        "description": "A duty this chain cannot answer. Named, never defaulted.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "reason",
+          "detail"
+        ],
+        "title": "GapOut",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -3031,6 +3218,48 @@
           "suggested"
         ],
         "title": "ImportSummary",
+        "type": "object"
+      },
+      "InterestOut": {
+        "properties": {
+          "accrued": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Accrued",
+            "type": "string"
+          },
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "exempt_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Exempt Amount",
+            "type": "string"
+          },
+          "interest_bearing": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Interest Bearing",
+            "type": "string"
+          },
+          "months_held": {
+            "title": "Months Held",
+            "type": "integer"
+          },
+          "rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Rate",
+            "type": "string"
+          }
+        },
+        "required": [
+          "accrued",
+          "rate",
+          "months_held",
+          "exempt_amount",
+          "interest_bearing",
+          "citation"
+        ],
+        "title": "InterestOut",
         "type": "object"
       },
       "LeaseDetail": {
@@ -4898,6 +5127,116 @@
           "chain"
         ],
         "title": "Resolution",
+        "type": "object"
+      },
+      "ReturnIn": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Amount"
+          },
+          "post_to_ledger": {
+            "default": true,
+            "title": "Post To Ledger",
+            "type": "boolean"
+          },
+          "returned_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Returned On"
+          },
+          "withheld_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Withheld Reason"
+          }
+        },
+        "required": [
+          "amount"
+        ],
+        "title": "ReturnIn",
+        "type": "object"
+      },
+      "ReturnOut": {
+        "properties": {
+          "deadline_resolved": {
+            "title": "Deadline Resolved",
+            "type": "boolean"
+          },
+          "lease_id": {
+            "title": "Lease Id",
+            "type": "string"
+          },
+          "ledger_event_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ledger Event Uuid"
+          },
+          "returned": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Returned",
+            "type": "string"
+          },
+          "returned_on": {
+            "format": "date",
+            "title": "Returned On",
+            "type": "string"
+          },
+          "withheld": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Withheld",
+            "type": "string"
+          },
+          "withheld_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Withheld Reason"
+          }
+        },
+        "required": [
+          "lease_id",
+          "returned_on",
+          "returned",
+          "withheld",
+          "withheld_reason",
+          "ledger_event_uuid",
+          "deadline_resolved"
+        ],
+        "title": "ReturnOut",
         "type": "object"
       },
       "ReversalIn": {
@@ -7499,6 +7838,57 @@
         "summary": "Read Debt Schedule"
       }
     },
+    "/deposits/open": {
+      "get": {
+        "operationId": "list_open_deposits_deposits_open_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "As Of"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DepositOut"
+                  },
+                  "title": "Response List Open Deposits Deposits Open Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Open Deposits"
+      }
+    },
     "/documents": {
       "get": {
         "operationId": "list_documents_documents_get",
@@ -8113,6 +8503,123 @@
           }
         },
         "summary": "Collect Rent"
+      }
+    },
+    "/leases/{lease_id}/deposit": {
+      "get": {
+        "operationId": "read_deposit_leases__lease_id__deposit_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "lease_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Lease Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "As Of"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepositOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Read Deposit"
+      }
+    },
+    "/leases/{lease_id}/deposit-return": {
+      "post": {
+        "operationId": "return_deposit_leases__lease_id__deposit_return_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "lease_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Lease Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReturnIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReturnOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Return Deposit"
       }
     },
     "/leases/{lease_id}/receipts": {

--- a/packages/domain/schema/seed/906_deposit_interest_formula.sql
+++ b/packages/domain/schema/seed/906_deposit_interest_formula.sql
@@ -1,0 +1,22 @@
+-- ===========================================================================
+--  Seed — the deposit-interest formula, named by the pack
+--
+--  ADR 0003: states are data. Knowing that Ohio owes interest is a rule;
+--  knowing HOW to compute it is a second rule naming a registered builder,
+--  exactly as `appeal.window.calendar` names a registered window builder.
+--  Without this the API would have to branch on a state literal, which the
+--  ratchet in scripts/check_state_literals.sh exists to refuse.
+--
+--  The builders live in services/api/hestia_api/deposit.py and a key with no
+--  builder is a named coverage gap, never a silent default — the same
+--  contract calendar_key_unregistered already has.
+-- ===========================================================================
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+SELECT id, 'security_deposit', 'deposit.interest_formula',
+       NULL, 'us-oh.excess-over-month-rent',
+       'ORC 5321.16(A) — 5% per annum on the excess over the greater of $50 '
+       'or one month''s rent, held six months or more',
+       DATE '1974-11-04'
+FROM jurisdictions WHERE level = 'state' AND state = 'OH';

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -37,6 +37,7 @@ from hestia_api import (
     coverage,
     db,
     debt,
+    deposit,
     documents,
     dossier,
     jurisdiction,
@@ -1968,3 +1969,64 @@ def pay_off_debt(
         after_value={"paid_off_on": str(note.paid_off_on)},
     )
     return note
+
+
+# ---------------------------------------------------------------------------
+# The security deposit: the jurisdiction's duties, and returning it
+# ---------------------------------------------------------------------------
+
+
+@app.get("/leases/{lease_id}/deposit", response_model=deposit.DepositOut)
+def read_deposit(
+    lease_id: uuid.UUID, conn: Conn, as_of: Annotated[dt.date | None, Query()] = None
+) -> deposit.DepositOut:
+    try:
+        return deposit.read(conn, str(lease_id), as_of=as_of or dt.date.today())
+    except deposit.UnknownLease as error:
+        raise HTTPException(status_code=404, detail="lease not found") from error
+
+
+@app.get("/deposits/open", response_model=list[deposit.DepositOut])
+def list_open_deposits(
+    conn: Conn, as_of: Annotated[dt.date | None, Query()] = None
+) -> list[deposit.DepositOut]:
+    return deposit.list_open(conn, as_of=as_of or dt.date.today())
+
+
+@app.post(
+    "/leases/{lease_id}/deposit-return",
+    response_model=deposit.ReturnOut,
+    status_code=201,
+)
+def return_deposit(
+    lease_id: uuid.UUID,
+    body: deposit.ReturnIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> deposit.ReturnOut:
+    try:
+        result = deposit.return_deposit(conn, str(lease_id), body)
+    except deposit.UnknownLease as error:
+        raise HTTPException(status_code=404, detail="lease not found") from error
+    except deposit.AlreadyReturned as error:
+        raise HTTPException(
+            status_code=409, detail=f"the deposit was returned on {error}"
+        ) from error
+    except deposit.NotMovedOut as error:
+        raise HTTPException(
+            status_code=422,
+            detail="record the move-out date first; a deposit is settled after the tenancy",
+        ) from error
+    except deposit.ReturnExceedsDeposit as error:
+        raise HTTPException(status_code=422, detail=f"the deposit held was only {error}") from error
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="deposit.return",
+        request_id=request.state.request_id,
+        table_name="leases",
+        record_id=str(lease_id),
+        after_value=result.model_dump(mode="json"),
+    )
+    return result

--- a/services/api/hestia_api/deposit.py
+++ b/services/api/hestia_api/deposit.py
@@ -1,0 +1,395 @@
+"""The security deposit: what the jurisdiction requires of it, and returning it.
+
+Kentucky and Ohio rules have been seeded in the packs since module 010 and
+nothing consumed them. This does: the duties come from the chain, cited, and
+where a chain has nothing to say the answer is a NAMED GAP rather than a
+default. A deposit deadline invented from a national average would be worse
+than no deadline at all, because it would look like law.
+
+The two regimes the packs already prove apart:
+  - Kentucky, KRS 383.580 — the deposit is held in a separate account and the
+    tenant gets an itemized list. URLTA binds only where a municipality has
+    adopted it, which is why the rule is resolved through the chain and not
+    from the state.
+  - Ohio, ORC 5321.16 — thirty days to return with an itemization, and 5% per
+    annum on the excess over the greater of $50 or one month's rent when the
+    deposit has been held six months or more.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import ROUND_HALF_EVEN, Decimal
+from typing import Any
+
+import psycopg
+from pydantic import BaseModel, Field
+
+from hestia_api import ledger as ledger_module
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+CENT = Decimal("0.01")
+
+# ORC 5321.16(A): five per cent per annum, on the amount exceeding the greater
+# of fifty dollars or one month's rent, once the deposit has been held six
+# months or more. Every number here comes from the statute; none is a default.
+OHIO_INTEREST_RATE = Decimal("0.05")
+OHIO_EXEMPT_FLOOR = Decimal("50.00")
+OHIO_QUALIFYING_MONTHS = 6
+
+
+class UnknownLease(Exception):
+    pass
+
+
+class AlreadyReturned(Exception):
+    pass
+
+
+class NotMovedOut(Exception):
+    """A deposit is returned after the tenancy ends, not during it."""
+
+
+class ReturnExceedsDeposit(Exception):
+    pass
+
+
+class DutyOut(BaseModel):
+    """One thing the jurisdiction requires, and the authority that requires it."""
+
+    code: str
+    requirement: str
+    citation: str
+
+
+class GapOut(BaseModel):
+    """A duty this chain cannot answer. Named, never defaulted."""
+
+    code: str
+    reason: str
+    detail: str
+
+
+class InterestOut(BaseModel):
+    accrued: Decimal
+    rate: Decimal
+    months_held: int
+    exempt_amount: Decimal
+    interest_bearing: Decimal
+    citation: str
+
+
+class DepositOut(BaseModel):
+    lease_id: str
+    state: str
+    security_deposit: Decimal
+    deposit_account: str | None
+    moved_out_on: dt.date | None
+    deposit_returned_on: dt.date | None
+    deposit_returned: Decimal | None
+    # Everything below is resolved from the chain, as of the read.
+    duties: list[DutyOut]
+    gaps: list[GapOut]
+    return_days: int | None
+    return_due_on: dt.date | None
+    return_citation: str | None
+    interest: InterestOut | None
+
+
+class ReturnIn(BaseModel):
+    returned_on: dt.date | None = None
+    amount: Decimal = Field(ge=0, decimal_places=2, max_digits=18)
+    # What was kept and why. A withholding nobody can explain is a withholding
+    # nobody can defend.
+    withheld_reason: str | None = None
+    post_to_ledger: bool = True
+
+
+class ReturnOut(BaseModel):
+    lease_id: str
+    returned_on: dt.date
+    returned: Decimal
+    withheld: Decimal
+    withheld_reason: str | None
+    ledger_event_uuid: str | None
+    deadline_resolved: bool
+
+
+# The chain's answer for one lease, every security_deposit rule it carries.
+_DEPOSIT_RULES = """
+WITH lease_anchor AS (
+  SELECT l.id AS lease_id, p.state,
+         COALESCE(p.jurisdiction_id, s.id) AS start_id
+  FROM leases l
+  JOIN units u ON u.id = l.unit_id
+  JOIN properties p ON p.id = u.property_id
+  LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+  WHERE l.id = ANY(%(lease_ids)s)
+)
+SELECT DISTINCT ON (a.lease_id, r.code)
+       a.lease_id::text, a.state, r.code, r.value_numeric, r.value_text, r.citation
+FROM lease_anchor a
+CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+WHERE r.domain = 'security_deposit'
+  AND r.superseded_by IS NULL
+  AND r.effective_from <= %(as_of)s
+  AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+ORDER BY a.lease_id, r.code, c.depth ASC, r.effective_from DESC
+"""
+
+# How a rule code reads to a human. The text belongs to the pack; this is only
+# the sentence that carries it.
+_REQUIREMENTS: dict[str, str] = {
+    "deposit.return_days": (
+        "return the deposit, with an itemization, within {value} days of move-out"
+    ),
+    "urlta.deposit.separate_account_required": (
+        "hold the deposit in a separate account, disclosed to the tenant"
+    ),
+    "urlta.deposit.itemized_list_required": (
+        "give the tenant an itemized list of damages before applying the deposit"
+    ),
+    "deposit.interest_required": "pay interest on the deposit",
+}
+
+
+def _rules_for(conn: Conn, lease_ids: list[str], as_of: dt.date) -> dict[str, list[Any]]:
+    rows = conn.execute(_DEPOSIT_RULES, {"lease_ids": lease_ids, "as_of": as_of}).fetchall()
+    grouped: dict[str, list[Any]] = {}
+    for row in rows:
+        grouped.setdefault(row["lease_id"], []).append(row)
+    return grouped
+
+
+def _months_held(start: dt.date, end: dt.date) -> int:
+    """Whole months the deposit was held, which is what 'six months or more'
+    counts."""
+    months = (end.year - start.year) * 12 + (end.month - start.month)
+    if end.day < start.day:
+        months -= 1
+    return max(0, months)
+
+
+def _excess_over_month_rent(
+    *, deposit: Decimal, monthly_rent: Decimal, months: int, citation: str
+) -> InterestOut:
+    """The 'us-oh.excess-over-month-rent' builder — ORC 5321.16(A)."""
+    exempt = max(OHIO_EXEMPT_FLOOR, monthly_rent)
+    return InterestOut(
+        accrued=ohio_interest(
+            deposit=deposit,
+            monthly_rent=monthly_rent,
+            months=months,
+            as_of_rate=OHIO_INTEREST_RATE,
+        ),
+        rate=OHIO_INTEREST_RATE,
+        months_held=months,
+        exempt_amount=exempt,
+        interest_bearing=max(Decimal("0.00"), deposit - exempt),
+        citation=citation,
+    )
+
+
+def _interest_formula(key: str | None) -> Any:
+    """The registry, keyed by what a pack may name. Built inside the lookup so
+    a new state is a seed row plus a builder, never a branch."""
+    registry = {"us-oh.excess-over-month-rent": _excess_over_month_rent}
+    return registry.get(key) if key is not None else None
+
+
+def ohio_interest(
+    *, deposit: Decimal, monthly_rent: Decimal, months: int, as_of_rate: Decimal
+) -> Decimal:
+    """ORC 5321.16(A). Interest runs only on the excess over the GREATER of
+    fifty dollars or one month's rent, and only once the deposit has been held
+    six months or more."""
+    if months < OHIO_QUALIFYING_MONTHS:
+        return Decimal("0.00")
+    exempt = max(OHIO_EXEMPT_FLOOR, monthly_rent)
+    bearing = deposit - exempt
+    if bearing <= 0:
+        return Decimal("0.00")
+    return (bearing * as_of_rate * Decimal(months) / Decimal(12)).quantize(
+        CENT, rounding=ROUND_HALF_EVEN
+    )
+
+
+def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
+    lease = conn.execute(
+        """
+        SELECT l.id::text, p.state, l.security_deposit, l.deposit_account,
+               l.moved_out_on, l.deposit_returned_on, l.deposit_returned,
+               l.rent, l.starts_on
+        FROM leases l
+        JOIN units u ON u.id = l.unit_id
+        JOIN properties p ON p.id = u.property_id
+        WHERE l.id = %s
+        """,
+        (lease_id,),
+    ).fetchone()
+    if lease is None:
+        raise UnknownLease(lease_id)
+
+    rules = _rules_for(conn, [lease_id], as_of).get(lease_id, [])
+    by_code = {row["code"]: row for row in rules}
+
+    duties: list[DutyOut] = []
+    for code, row in sorted(by_code.items()):
+        template = _REQUIREMENTS.get(code)
+        if template is None:
+            continue  # a pack may carry codes this release has no sentence for
+        value = row["value_numeric"] if row["value_numeric"] is not None else row["value_text"]
+        duties.append(
+            DutyOut(
+                code=code,
+                requirement=template.format(value=value),
+                citation=row["citation"],
+            )
+        )
+
+    gaps: list[GapOut] = []
+    return_rule = by_code.get("deposit.return_days")
+    return_days = int(return_rule["value_numeric"]) if return_rule else None
+    if return_rule is None:
+        gaps.append(
+            GapOut(
+                code="deposit.return_days",
+                reason="no_rule_for_domain",
+                detail=(
+                    f"no deposit return period is seeded for {lease['state']}; the "
+                    "deadline is not invented and the lease terms govern until a "
+                    "pack says otherwise"
+                ),
+            )
+        )
+    return_due = (
+        lease["moved_out_on"] + dt.timedelta(days=return_days)
+        if return_days is not None and lease["moved_out_on"] is not None
+        else None
+    )
+
+    interest: InterestOut | None = None
+    interest_rule = by_code.get("deposit.interest_required")
+    if interest_rule is not None:
+        # WHICH formula is a rule too (ADR 0003): the pack names a registered
+        # builder and the code never branches on a state literal.
+        formula_rule = by_code.get("deposit.interest_formula")
+        key = formula_rule["value_text"] if formula_rule else None
+        builder = _interest_formula(key)
+        if builder is None:
+            gaps.append(
+                GapOut(
+                    code="deposit.interest_formula",
+                    reason=("no_formula_rule" if key is None else "formula_key_unregistered"),
+                    detail=(
+                        f"{interest_rule['citation']} requires deposit interest but "
+                        + (
+                            "the pack names no formula"
+                            if key is None
+                            else f"no builder is registered for {key!r}"
+                        )
+                        + "; the amount is not guessed"
+                    ),
+                )
+            )
+        else:
+            interest = builder(
+                deposit=lease["security_deposit"],
+                monthly_rent=lease["rent"],
+                months=_months_held(lease["starts_on"], lease["moved_out_on"] or as_of),
+                citation=formula_rule["citation"],
+            )
+
+    return DepositOut(
+        lease_id=lease["id"],
+        state=lease["state"],
+        security_deposit=lease["security_deposit"],
+        deposit_account=lease["deposit_account"],
+        moved_out_on=lease["moved_out_on"],
+        deposit_returned_on=lease["deposit_returned_on"],
+        deposit_returned=lease["deposit_returned"],
+        duties=duties,
+        gaps=gaps,
+        return_days=return_days,
+        return_due_on=return_due,
+        return_citation=return_rule["citation"] if return_rule else None,
+        interest=interest,
+    )
+
+
+def return_deposit(conn: Conn, lease_id: str, body: ReturnIn) -> ReturnOut:
+    """The money, the record and the deadline, in one transaction."""
+    lease = conn.execute(
+        """
+        SELECT l.id::text, l.security_deposit, l.moved_out_on, l.deposit_returned_on,
+               u.property_id::text, p.entity_id::text
+        FROM leases l
+        JOIN units u ON u.id = l.unit_id
+        JOIN properties p ON p.id = u.property_id
+        WHERE l.id = %s FOR UPDATE OF l
+        """,
+        (lease_id,),
+    ).fetchone()
+    if lease is None:
+        raise UnknownLease(lease_id)
+    if lease["deposit_returned_on"] is not None:
+        raise AlreadyReturned(str(lease["deposit_returned_on"]))
+    if lease["moved_out_on"] is None:
+        raise NotMovedOut(lease_id)
+    if body.amount > lease["security_deposit"]:
+        raise ReturnExceedsDeposit(str(lease["security_deposit"]))
+
+    returned_on = body.returned_on or dt.date.today()
+    withheld = lease["security_deposit"] - body.amount
+    conn.execute(
+        """
+        UPDATE leases SET deposit_returned_on = %s, deposit_returned = %s
+        WHERE id = %s
+        """,
+        (returned_on, body.amount, lease_id),
+    )
+    event_uuid: str | None = None
+    if body.post_to_ledger and body.amount > 0:
+        event = ledger_module.append_event(
+            conn,
+            ledger_module.LedgerEntryIn(
+                occurred_on=returned_on,
+                category="deposit_returned",
+                amount=-body.amount,
+                memo=body.withheld_reason or "security deposit returned",
+                property_id=lease["property_id"],
+                lease_id=lease_id,
+                entity_id=lease["entity_id"],
+            ),
+        )
+        event_uuid = event.event_uuid
+    resolved = conn.execute(
+        """
+        UPDATE deadlines SET status = 'done', completed_on = %s
+        WHERE lease_id = %s AND kind::text = 'deposit_itemization' AND status = 'upcoming'
+        """,
+        (returned_on, lease_id),
+    )
+    return ReturnOut(
+        lease_id=lease_id,
+        returned_on=returned_on,
+        returned=body.amount,
+        withheld=withheld,
+        withheld_reason=body.withheld_reason,
+        ledger_event_uuid=event_uuid,
+        deadline_resolved=resolved.rowcount > 0,
+    )
+
+
+def list_open(conn: Conn, *, as_of: dt.date) -> list[DepositOut]:
+    """Every tenancy that has ended without the deposit being settled."""
+    rows = conn.execute(
+        """
+        SELECT id::text FROM leases
+        WHERE moved_out_on IS NOT NULL AND deposit_returned_on IS NULL
+        ORDER BY moved_out_on
+        """,
+    ).fetchall()
+    return [read(conn, row["id"], as_of=as_of) for row in rows]

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -377,6 +377,101 @@ def _adverse_action_notices(conn: Conn, as_of: dt.date) -> list[dict[str, Any]]:
     ]
 
 
+def _deposit_itemizations(conn: Conn, as_of: dt.date) -> list[dict[str, Any]]:
+    """A tenancy that ended owes the deposit back inside the period the
+    jurisdiction sets. Where the chain sets none, the sweep says so as a gap
+    rather than inventing a period — a made-up deadline looks like law.
+    """
+    rows = conn.execute(
+        """
+        WITH lease_anchor AS (
+          SELECT l.id AS lease_id, u.property_id, p.state,
+                 l.moved_out_on,
+                 COALESCE(p.jurisdiction_id, s.id) AS start_id
+          FROM leases l
+          JOIN units u ON u.id = l.unit_id
+          JOIN properties p ON p.id = u.property_id
+          LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+          WHERE l.moved_out_on IS NOT NULL AND l.deposit_returned_on IS NULL
+        ),
+        resolved AS (
+          SELECT DISTINCT ON (a.lease_id)
+                 a.lease_id, r.value_numeric AS return_days, r.citation
+          FROM lease_anchor a
+          CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+          JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+          WHERE r.domain = 'security_deposit'
+            AND r.code = 'deposit.return_days'
+            AND r.superseded_by IS NULL
+            AND r.effective_from <= %(as_of)s
+            AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+          ORDER BY a.lease_id, c.depth ASC, r.effective_from DESC
+        )
+        SELECT a.lease_id, a.property_id, a.state, a.moved_out_on,
+               resolved.return_days, resolved.citation
+        FROM lease_anchor a LEFT JOIN resolved ON resolved.lease_id = a.lease_id
+        """,
+        {"as_of": as_of},
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for record in rows:
+        if record["return_days"] is None:
+            continue  # reported as a coverage gap by run_sweep, never defaulted
+        out.append(
+            _row(
+                "deposit_itemization",
+                record["moved_out_on"] + dt.timedelta(days=int(record["return_days"])),
+                record["citation"],
+                property_id=record["property_id"],
+                lease_id=record["lease_id"],
+                window_opens_on=record["moved_out_on"],
+                note=f"deposit itemisation and return, {record['return_days']} days from move-out",
+            )
+        )
+    return out
+
+
+def _deposit_gaps(conn: Conn, as_of: dt.date) -> list[CoverageGap]:
+    """Ended tenancies whose chain sets no return period."""
+    rows = conn.execute(
+        """
+        WITH lease_anchor AS (
+          SELECT l.id AS lease_id, u.property_id, p.state,
+                 COALESCE(p.jurisdiction_id, s.id) AS start_id
+          FROM leases l
+          JOIN units u ON u.id = l.unit_id
+          JOIN properties p ON p.id = u.property_id
+          LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+          WHERE l.moved_out_on IS NOT NULL AND l.deposit_returned_on IS NULL
+        )
+        SELECT a.lease_id::text, a.property_id::text, a.state
+        FROM lease_anchor a
+        WHERE NOT EXISTS (
+          SELECT 1 FROM jurisdiction_chain(a.start_id) c
+          JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+          WHERE r.domain = 'security_deposit' AND r.code = 'deposit.return_days'
+            AND r.superseded_by IS NULL
+            AND r.effective_from <= %(as_of)s
+            AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+        )
+        """,
+        {"as_of": as_of},
+    ).fetchall()
+    return [
+        CoverageGap(
+            property_id=record["property_id"],
+            state=record["state"],
+            domain="security_deposit",
+            reason="no_rule_for_domain",
+            detail=(
+                f"lease {record['lease_id']} has ended with the deposit unsettled and "
+                f"no deposit.return_days rule resolves for {record['state']}"
+            ),
+        )
+        for record in rows
+    ]
+
+
 GENERATORS = (
     _lease_expirations,
     _policy_expirations,
@@ -385,6 +480,7 @@ GENERATORS = (
     _entity_tax_dates,
     _vendor_credentials,
     _adverse_action_notices,
+    _deposit_itemizations,
 )
 
 
@@ -392,6 +488,7 @@ def run_sweep(conn: Conn, as_of: dt.date) -> SweepResult:
     inserted: dict[str, int] = {}
     appeal_rows, gaps = _appeal_windows(conn, as_of)
     rows = appeal_rows + [row for generator in GENERATORS for row in generator(conn, as_of)]
+    gaps = gaps + _deposit_gaps(conn, as_of)
     for row in rows:
         result = conn.execute(INSERT, row)
         if result.rowcount == 1:

--- a/services/api/tests/test_deposit.py
+++ b/services/api/tests/test_deposit.py
@@ -1,0 +1,383 @@
+"""The security deposit, answered by the jurisdiction rather than by default.
+
+Issue #5's acceptance, executable: an Ohio lease with a move-out date gets a
+thirty-day deadline citing ORC 5321.16(B); a Kentucky lease shows the
+separate-account duty; a state with no pack reports a gap instead of a guess.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from hestia_api import deposit
+
+
+def make_lease(
+    client: TestClient,
+    *,
+    state: str,
+    city: str,
+    postal: str,
+    label: str,
+    rent: str = "1450.00",
+    security_deposit: str = "1450.00",
+    starts_on: str = "2025-01-01",
+) -> str:
+    entity = client.post("/entities", json={"name": f"{label} LLC", "kind": "llc"}).json()
+    prop = client.post(
+        "/properties",
+        json={
+            "entity_id": entity["id"],
+            "label": label,
+            "street_1": f"1 {label} St",
+            "city": city,
+            "state": state,
+            "postal_code": postal,
+            "kind": "single_family",
+        },
+    ).json()
+    unit = client.post("/units", json={"property_id": prop["id"], "label": "A"}).json()
+    lease = client.post(
+        "/leases",
+        json={
+            "unit_id": unit["id"],
+            "starts_on": starts_on,
+            "ends_on": None,
+            "rent": rent,
+            "rent_due_day": 1,
+            "security_deposit": security_deposit,
+            "escalation": "none",
+            "status": "active",
+            "resident_ids": [],
+        },
+    ).json()
+    return lease["id"]
+
+
+def move_out(conn: psycopg.Connection[Any], lease_id: str, on: str) -> None:
+    conn.execute("UPDATE leases SET moved_out_on = %s WHERE id = %s", (on, lease_id))
+    conn.commit()
+
+
+@pytest.fixture
+def ohio_lease(clean: None, client: TestClient) -> str:
+    # Cincinnati: ORC ch. 5321 applies statewide, no adoption step.
+    return make_lease(client, state="OH", city="Cincinnati", postal="45202", label="Ohio")
+
+
+@pytest.fixture
+def kentucky_lease(clean: None, client: TestClient) -> str:
+    # Newport has adopted URLTA; Campbell County has not — the contrast the
+    # packs exist to prove.
+    return make_lease(client, state="KY", city="Newport", postal="41071", label="Newport")
+
+
+class TestTheAcceptanceWalk:
+    def test_an_ohio_move_out_gets_a_thirty_day_deadline_citing_the_statute(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        move_out(conn, ohio_lease, "2026-08-01")
+        panel = client.get(f"/leases/{ohio_lease}/deposit?as_of=2026-08-05").json()
+        assert panel["return_days"] == 30
+        assert panel["return_due_on"] == "2026-08-31"
+        assert "5321.16(B)" in panel["return_citation"]
+        assert panel["gaps"] == []
+
+        client.post("/sweep/deadlines?as_of=2026-08-05")
+        row = conn.execute(
+            """
+            SELECT kind::text AS kind, due_on, window_opens_on, citation, status::text AS status
+            FROM deadlines WHERE lease_id = %s AND kind::text = 'deposit_itemization'
+            """,
+            (ohio_lease,),
+        ).fetchone()
+        assert row is not None
+        assert row["due_on"] == dt.date(2026, 8, 31)
+        # The runway is visible: the duty opens at move-out.
+        assert row["window_opens_on"] == dt.date(2026, 8, 1)
+        assert "5321.16(B)" in row["citation"]
+        assert row["status"] == "upcoming"
+
+    def test_a_kentucky_lease_shows_the_separate_account_duty(
+        self, kentucky_lease: str, client: TestClient
+    ) -> None:
+        panel = client.get(f"/leases/{kentucky_lease}/deposit?as_of=2026-08-05").json()
+        codes = {duty["code"]: duty for duty in panel["duties"]}
+        assert "urlta.deposit.separate_account_required" in codes
+        assert "separate account" in codes["urlta.deposit.separate_account_required"]["requirement"]
+        assert "383.580" in codes["urlta.deposit.separate_account_required"]["citation"]
+        assert "urlta.deposit.itemized_list_required" in codes
+        # Kentucky's pack sets no return period, so none is invented.
+        assert panel["return_days"] is None
+        assert panel["return_due_on"] is None
+        assert [gap["code"] for gap in panel["gaps"]] == ["deposit.return_days"]
+
+    def test_a_state_with_no_pack_reports_a_gap_and_raises_no_deadline(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """Tennessee has no pack yet (issue #14). The honest answer is a named
+        gap — a deadline invented from a national average would look like law."""
+        lease = make_lease(client, state="TN", city="Nashville", postal="37206", label="Nashville")
+        move_out(conn, lease, "2026-08-01")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
+        assert panel["duties"] == []
+        assert panel["return_days"] is None
+        gap = next(g for g in panel["gaps"] if g["code"] == "deposit.return_days")
+        assert gap["reason"] == "no_rule_for_domain"
+        assert "TN" in gap["detail"]
+
+        sweep = client.post("/sweep/deadlines?as_of=2026-08-05").json()
+        assert (
+            conn.execute(
+                "SELECT count(*) AS n FROM deadlines WHERE lease_id = %s", (lease,)
+            ).fetchone()["n"]
+            == 0
+        )
+        assert any(
+            g["domain"] == "security_deposit" and g["state"] == "TN" for g in sweep["coverage_gaps"]
+        )
+
+
+class TestOhioInterest:
+    def test_interest_runs_only_on_the_excess_over_a_month_s_rent(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """ORC 5321.16(A): 5% per annum on the amount exceeding the greater of
+        $50 or one month's rent, once held six months or more."""
+        move_out(conn, ohio_lease, "2026-01-01")
+        panel = client.get(f"/leases/{ohio_lease}/deposit?as_of=2026-01-05").json()
+        interest = panel["interest"]
+        assert interest is not None
+        assert Decimal(interest["rate"]) == Decimal("0.05")
+        assert interest["months_held"] == 12
+        # Deposit equals one month's rent, so nothing bears interest at all.
+        assert Decimal(interest["exempt_amount"]) == Decimal("1450.00")
+        assert Decimal(interest["interest_bearing"]) == 0
+        assert Decimal(interest["accrued"]) == 0
+        assert "5321.16(A)" in interest["citation"]
+
+    def test_a_deposit_above_one_month_accrues(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        lease = make_lease(
+            client,
+            state="OH",
+            city="Cincinnati",
+            postal="45202",
+            label="Bigger",
+            rent="1000.00",
+            security_deposit="2500.00",
+        )
+        move_out(conn, lease, "2026-01-01")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-01-05").json()
+        interest = panel["interest"]
+        # 2500 - 1000 = 1500 bearing, at 5% for 12 whole months.
+        assert Decimal(interest["interest_bearing"]) == Decimal("1500.00")
+        assert Decimal(interest["accrued"]) == Decimal("75.00")
+
+    def test_the_pure_formula(self) -> None:
+        """Held under six months: nothing, however large the deposit."""
+        assert deposit.ohio_interest(
+            deposit=Decimal("5000.00"),
+            monthly_rent=Decimal("1000.00"),
+            months=5,
+            as_of_rate=Decimal("0.05"),
+        ) == Decimal("0.00")
+        # The floor is fifty dollars when the rent is lower than that.
+        assert deposit.ohio_interest(
+            deposit=Decimal("100.00"),
+            monthly_rent=Decimal("20.00"),
+            months=12,
+            as_of_rate=Decimal("0.05"),
+        ) == Decimal("2.50")
+
+    def test_kentucky_owes_no_interest(self, kentucky_lease: str, client: TestClient) -> None:
+        panel = client.get(f"/leases/{kentucky_lease}/deposit?as_of=2026-08-05").json()
+        assert panel["interest"] is None
+
+
+class TestUnfamiliarPacks:
+    """A state whose pack says something this release has no formula or
+    sentence for. The honest answer is a named gap, never Ohio's numbers."""
+
+    def _quexland(self, conn: psycopg.Connection[Any]) -> None:
+        """Sandboxed in 'QZ' — jurisdiction_rules is append-only, so planting
+        a fixture rule on a real chain would poison every later test."""
+        exists = conn.execute(
+            "SELECT 1 AS x FROM jurisdictions WHERE state = 'QZ' AND level = 'state'"
+        ).fetchone()
+        if exists is None:
+            conn.execute(
+                """
+                WITH state_row AS (
+                  INSERT INTO jurisdictions (level, name, state, parent_id)
+                  SELECT 'state', 'Quizland', 'QZ', id
+                  FROM jurisdictions WHERE level = 'federal' RETURNING id
+                )
+                INSERT INTO jurisdiction_rules
+                  (jurisdiction_id, domain, code, value_numeric, value_text,
+                   citation, effective_from)
+                SELECT id, 'security_deposit', 'deposit.interest_required', NULL,
+                       'true; a formula this build does not implement',
+                       'QZ Rev. Stat. 2.2 (test fixture)', DATE '2000-01-01'
+                FROM state_row
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO jurisdiction_rules
+                  (jurisdiction_id, domain, code, value_numeric, value_text,
+                   citation, effective_from)
+                SELECT id, 'security_deposit', 'deposit.custodian_bond_required', NULL,
+                       'true', 'QZ Rev. Stat. 2.3 (test fixture)', DATE '2000-01-01'
+                FROM jurisdictions WHERE state = 'QZ' AND level = 'state'
+                """
+            )
+        conn.commit()
+
+    def test_an_unimplemented_interest_formula_is_a_gap_not_ohio_s_numbers(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        self._quexland(conn)
+        lease = make_lease(client, state="QZ", city="Quizville", postal="00001", label="Quiz")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
+        assert panel["interest"] is None
+        gap = next(g for g in panel["gaps"] if g["code"] == "deposit.interest_formula")
+        # The pack says interest is owed but names no formula, so nothing is
+        # computed and the citation of the duty is carried into the gap.
+        assert gap["reason"] == "no_formula_rule"
+        assert "2.2" in gap["detail"]
+
+    def test_a_rule_this_release_has_no_sentence_for_is_left_out(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """A pack may carry codes a later release will read. Showing a raw code
+        to an owner would be worse than showing nothing."""
+        self._quexland(conn)
+        lease = make_lease(client, state="QZ", city="Quizville", postal="00002", label="Quiz2")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
+        codes = [duty["code"] for duty in panel["duties"]]
+        assert "deposit.custodian_bond_required" not in codes
+        # ...and the one it does understand still reads.
+        assert "deposit.interest_required" in codes
+
+
+class TestMonthsHeld:
+    def test_a_part_month_does_not_count(self) -> None:
+        """'Six months or more' counts whole months: the 15th to the 14th is
+        five, not six."""
+        assert deposit._months_held(dt.date(2026, 1, 15), dt.date(2026, 7, 14)) == 5
+        assert deposit._months_held(dt.date(2026, 1, 15), dt.date(2026, 7, 15)) == 6
+        assert deposit._months_held(dt.date(2026, 7, 1), dt.date(2026, 1, 1)) == 0
+
+
+class TestReturn:
+    def test_returning_settles_the_money_the_record_and_the_deadline(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        move_out(conn, ohio_lease, "2026-08-01")
+        client.post("/sweep/deadlines?as_of=2026-08-05")
+
+        result = client.post(
+            f"/leases/{ohio_lease}/deposit-return",
+            json={
+                "returned_on": "2026-08-20",
+                "amount": "1200.00",
+                "withheld_reason": "carpet replacement, itemised",
+            },
+        )
+        assert result.status_code == 201, result.text
+        body = result.json()
+        assert Decimal(body["returned"]) == Decimal("1200.00")
+        assert Decimal(body["withheld"]) == Decimal("250.00")
+        assert body["deadline_resolved"] is True
+
+        event = conn.execute(
+            "SELECT category::text AS category, amount, lease_id::text FROM ledger_events"
+            " WHERE event_uuid = %s",
+            (body["ledger_event_uuid"],),
+        ).fetchone()
+        assert event["category"] == "deposit_returned"
+        assert event["amount"] == Decimal("-1200.00")
+        assert event["lease_id"] == ohio_lease
+
+        resolved = conn.execute(
+            "SELECT status::text AS status, completed_on FROM deadlines"
+            " WHERE lease_id = %s AND kind::text = 'deposit_itemization'",
+            (ohio_lease,),
+        ).fetchone()
+        assert resolved["status"] == "done"
+        assert resolved["completed_on"] == dt.date(2026, 8, 20)
+
+        # Re-sweeping raises nothing: the duty is discharged.
+        client.post("/sweep/deadlines?as_of=2026-08-21")
+        assert (
+            conn.execute(
+                "SELECT count(*) AS n FROM deadlines WHERE lease_id = %s"
+                " AND kind::text = 'deposit_itemization'",
+                (ohio_lease,),
+            ).fetchone()["n"]
+            == 1
+        )
+
+    def test_withholding_everything_posts_no_ledger_row(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        move_out(conn, ohio_lease, "2026-08-01")
+        body = client.post(
+            f"/leases/{ohio_lease}/deposit-return",
+            json={"returned_on": "2026-08-20", "amount": "0.00", "withheld_reason": "damages"},
+        ).json()
+        assert body["ledger_event_uuid"] is None
+        assert Decimal(body["withheld"]) == Decimal("1450.00")
+
+    def test_a_return_can_stay_out_of_the_ledger(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        move_out(conn, ohio_lease, "2026-08-01")
+        body = client.post(
+            f"/leases/{ohio_lease}/deposit-return",
+            json={"amount": "100.00", "post_to_ledger": False},
+        ).json()
+        assert body["ledger_event_uuid"] is None
+        assert body["returned_on"] == dt.date.today().isoformat()
+
+    def test_the_open_queue_answers_which_deposits_are_unsettled(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        move_out(conn, ohio_lease, "2026-08-01")
+        queue = client.get("/deposits/open?as_of=2026-08-05").json()
+        assert [row["lease_id"] for row in queue] == [ohio_lease]
+        client.post(
+            f"/leases/{ohio_lease}/deposit-return",
+            json={"returned_on": "2026-08-20", "amount": "1450.00"},
+        )
+        assert client.get("/deposits/open?as_of=2026-08-21").json() == []
+
+    def test_refusals(
+        self, ohio_lease: str, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        ghost = "00000000-0000-4000-8000-000000000000"
+        assert client.get(f"/leases/{ghost}/deposit").status_code == 404
+        assert (
+            client.post(f"/leases/{ghost}/deposit-return", json={"amount": "1.00"}).status_code
+            == 404
+        )
+        # Still living there: nothing to settle yet.
+        still_there = client.post(f"/leases/{ohio_lease}/deposit-return", json={"amount": "1.00"})
+        assert still_there.status_code == 422
+        assert "move-out date first" in still_there.json()["detail"]
+
+        move_out(conn, ohio_lease, "2026-08-01")
+        too_much = client.post(f"/leases/{ohio_lease}/deposit-return", json={"amount": "5000.00"})
+        assert too_much.status_code == 422
+        assert "1450.00" in too_much.json()["detail"]
+
+        client.post(f"/leases/{ohio_lease}/deposit-return", json={"amount": "1450.00"})
+        again = client.post(f"/leases/{ohio_lease}/deposit-return", json={"amount": "10.00"})
+        assert again.status_code == 409


### PR DESCRIPTION
Closes #5.

Kentucky and Ohio deposit rules have sat in the packs since module 010 with **nothing reading them**. This reads them — duties come from the chain with their citations, and where a chain has nothing to say the answer is a **named gap**. A deadline invented from a national average would be worse than no deadline, because it would look like law.

### The three regimes, as the acceptance asks
- **Ohio** — thirty days from move-out (ORC 5321.16(B)); the sweep raises the itemisation deadline dated from move-out, with `window_opens_on` set so the runway is visible from the day the tenancy ended.
- **Kentucky** — the URLTA pack gives separate-account and itemised-list duties but *no* return period, so the panel shows both duties and reports the missing period rather than borrowing Ohio's thirty days.
- **Tennessee** — no pack yet (#14). No duties, no deadline, one coverage gap naming the state.

### The ratchet earned its keep
My first cut branched on `state == "OH"` and `scripts/check_state_literals.sh` refused it — correctly, per ADR 0003. **Which formula applies is itself a rule**: seed 906 has Ohio's pack name a registered builder exactly as appeal windows already name a calendar, so a new state is a seed row plus a builder and never a branch. A pack that requires interest and names no formula — or names one nothing implements — gets a gap carrying its own citation, never Ohio's numbers wearing another state's name.

Ohio's builder is the statute: 5% per annum on the excess over the greater of $50 or one month's rent, once held six months or more, counting whole months. **A deposit equal to one month's rent accrues nothing at all** — surprising, and what the law says.

### Returning
One transaction settles the money, the record and the deadline: the lease's returned date and amount, the `deposit_returned` ledger row for what actually went back, and the itemisation deadline marked done. Withholding everything posts no ledger row, because no money moved.

278 API tests at 100% line+branch · 136 schema assertions · contract regenerated · ratchet, config audit and typecheck clean. **No schema change** — every column this needed has existed since module 003.

**Handed over:** the lease deposit panel is `apps/web`. The API returns duties, gaps, the due date and the accrued interest ready to render.