### PR TITLE
e2e: the dispatch test owns its own plumber

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -82,12 +82,26 @@ test('the command palette answers ⌘K and navigates', async ({ page }) => {
 test('the 11pm surface: property, symptom, proof, and the incident on the board', async ({
   page,
 }) => {
+  // This test OWNS its plumber. It previously asserted a certificate date that
+  // a different test happened to create, and when the file order changed the
+  // vendor no longer existed by the time the overlay opened — five passed, this
+  // failed, three never ran. A fixture another test owns is a fixture that
+  // moves without warning.
+  await page.goto('/vendors');
+  const plumber = `Dispatch Plumbing ${String(Date.now())}`;
+  await page.getByLabel('Name').fill(plumber);
+  await page.getByLabel('Trade').selectOption('plumbing');
+  await page.getByLabel('Liability expires').fill('2028-09-30');
+  await page.getByRole('button', { name: 'Add vendor' }).click();
+  await expect(page.getByRole('row', { name: new RegExp(plumber) })).toBeVisible();
+
   await page.goto('/');
   await page.getByRole('button', { name: 'Emergency', exact: true }).click();
   await page.getByRole('button', { name: '998 Monmouth St', exact: true }).first().click();
   await page.getByRole('button', { name: /Water — burst pipe/ }).click();
-  // The smoke vendor carries a live certificate; the proof line says so.
-  await expect(page.getByText(/insured through Jun 30, 2027/).first()).toBeVisible();
+  // The plumber above carries a live certificate; the proof line says so, and
+  // names the date it read rather than a date somebody else wrote.
+  await expect(page.getByText(/insured through Sep 30, 2028/).first()).toBeVisible();
   await page.getByRole('button', { name: 'Log with this vendor' }).first().click();
   await expect(page.getByText(/is on the maintenance board as an emergency/)).toBeVisible();
   await page.getByRole('button', { name: 'Close', exact: true }).click();

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
+  // A cold production server, a cold uvicorn and a database seeing each query
+  // for the first time are all slower than a warm dev box, and every one of
+  // these assertions reads a row a POST has just created. Five seconds is the
+  // Playwright default and it is a local-machine default; the failures it
+  // produced on CI were timing, not truth. The test timeout above still caps
+  // a genuinely stuck expectation.
+  expect: { timeout: process.env.CI ? 15_000 : 5_000 },
   use: {
     baseURL: process.env.HESTIA_WEB_URL ?? 'http://localhost:3000',
     trace: 'retain-on-failure',


### PR DESCRIPTION
Closes #78. Unblocks #76.

`main` has been red since `f3e4ab2` (#54). The emergency-dispatch walk asserted `insured through Jun 30, 2027`, and the only vendor carrying that certificate was created by a **different test** — the D1 work-order walk, which sits *later* in the same serial file. When the dispatch test was inserted above it, the vendor no longer existed by the time the overlay opened: 5 passed, this failed, 3 never ran.

A fixture another test owns is a fixture that moves without warning, and in a `mode: 'serial'` file it reads as a passing dependency right until the order changes.

The dispatch test now creates its own plumber with its own certificate date (2028-09-30) and asserts on that — the date it names is a date it wrote.

Verified the way CI has it: clean build, fresh database, new stack — **9 passed**.

The dispatch feature was never wrong; the overlay and its ranking did exactly what they should. Crossing the `apps/web` surface boundary here with the founder's explicit go-ahead, since `main` was red and blocking.