### PR TITLE
What-if scrubbing: the reserve line and the amortization explorer

### DIFF
--- a/apps/web/src/app/property/[id]/page.tsx
+++ b/apps/web/src/app/property/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use, useCallback, useEffect, useState } from 'react';
 import { CapexFanChart, HoldSellCard, InsuranceCard } from '../../../components/AdvantageCards';
+import { AmortizationExplorer } from '../../../components/AmortizationExplorer';
 import { ComponentsTable } from '../../../components/ComponentsTable';
 import { DeadlineList } from '../../../components/DeadlineList';
 import { DefectRegister } from '../../../components/DefectRegister';
@@ -110,6 +111,13 @@ export default function PropertyPage({ params }: { params: Promise<{ id: string 
           <ExitTimeline financials={financials} today={today} />
         </section>
       )}
+
+      {financials !== null && financials.debts.length > 0 ? (
+        <section className="section">
+          <h2 className="section__title">The debt</h2>
+          <AmortizationExplorer debts={financials.debts} today={today} />
+        </section>
+      ) : null}
 
       <button
         className="button"

--- a/apps/web/src/components/AdvantageCards.tsx
+++ b/apps/web/src/components/AdvantageCards.tsx
@@ -4,6 +4,7 @@ import { type Authority, DecisionCard, FanChart, KeyValue, RangeField } from '@h
 import { useState } from 'react';
 import { holdSellView, insuranceView } from '../lib/advantage';
 import type { CapexForecastOut, Financials } from '../lib/api';
+import { firstShortfall, reserveCoverage } from '../lib/reserve';
 import { formatMoney } from './TransactionsTable';
 
 const HOLDSELL_ENGINE: Authority = {
@@ -150,8 +151,10 @@ export function InsuranceCard({ financials }: { financials: Financials }) {
 }
 
 /** The Weibull capex forecast as the package fan: p10–p90 band, traced p50
- * line. The geometry lives in @hestia/design, tested like the engines. */
+ * line — and the reserve line: drag a monthly figure and the years the
+ * reserve cannot cover wear the failure tint. */
 export function CapexFanChart({ forecast }: { forecast: CapexForecastOut }) {
+  const [reserve, setReserve] = useState(200);
   if (forecast.components_simulated === 0) {
     return (
       <div className="card">
@@ -166,6 +169,9 @@ export function CapexFanChart({ forecast }: { forecast: CapexForecastOut }) {
     mid: Number(band.p50),
     high: Number(band.p90),
   }));
+  const coverage = reserveCoverage(forecast, reserve);
+  const short = firstShortfall(coverage);
+  const shaded = coverage.filter((year) => !year.funded).map((year) => String(year.year));
   return (
     <div className="card">
       <strong>Capital forecast</strong>{' '}
@@ -175,12 +181,30 @@ export function CapexFanChart({ forecast }: { forecast: CapexForecastOut }) {
       <div style={{ marginTop: 8 }}>
         <FanChart
           bands={bands}
+          shaded={shaded}
           label={`Expected capital spend over ${forecast.horizon_years} years with confidence bands`}
         />
       </div>
+      <div className="form-row">
+        <RangeField
+          label="Monthly reserve"
+          value={reserve}
+          min={0}
+          max={1000}
+          step={25}
+          onChange={setReserve}
+          format={(value) => `$${value}/mo`}
+        />
+      </div>
+      <p>
+        {short === null
+          ? `A ${formatMoney(String(reserve))} monthly reserve funds the median plan through year ${forecast.horizon_years}.`
+          : `Year ${short.year} runs ${formatMoney(short.shortfall)} short of the median plan at ${formatMoney(String(reserve))} a month.`}
+      </p>
       <p className="faint">
         Weibull Monte Carlo over the live component inventory ({forecast.components_simulated}{' '}
-        components); band is p10–p90, line is the median.
+        components); band is p10–p90, line is the median; washed years are where the cumulative
+        reserve underruns the cumulative median.
         {forecast.components_without_cost.length > 0
           ? ` Not simulated (no cost on record): ${forecast.components_without_cost.join(', ')}.`
           : ''}

--- a/apps/web/src/components/AmortizationExplorer.tsx
+++ b/apps/web/src/components/AmortizationExplorer.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import {
+  ChartFrame,
+  isoOf,
+  KeyValue,
+  linearScale,
+  linePath,
+  niceTicks,
+  Pill,
+  RangeField,
+} from '@hestia/design';
+import { useState } from 'react';
+import { type NotePlan, notePlans } from '../lib/amortize-extra';
+import type { Financials } from '../lib/api';
+import { monthDay } from '../lib/exit-scrub';
+import { formatDate } from '../lib/format';
+import { formatMoney } from './TransactionsTable';
+
+/**
+ * The amortization explorer: scrub an extra principal payment and every
+ * note redraws its payoff curve live — the engines' own convention, walked
+ * month by month, with the interest saved and the months bought shown as
+ * figures, not adjectives. Both curves are futures, so both are dashed.
+ */
+const WIDTH = 560;
+const HEIGHT = 170;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 14;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 24;
+
+function NoteCard({ plan, today }: { plan: NotePlan; today: string }) {
+  // The walk always opens its curve at month zero on a positive balance,
+  // so neither value needs a defensive floor.
+  const startBalance = Number((plan.baselineCurve[0] as NotePlan['baselineCurve'][number]).balance);
+  const x = linearScale(0, plan.baselineMonths, PAD_LEFT, WIDTH - PAD_RIGHT);
+  const y = linearScale(0, startBalance, HEIGHT - PAD_BOTTOM, PAD_TOP);
+  const toPoints = (curve: NotePlan['baselineCurve']) =>
+    curve.map((point) => ({ x: x(point.month), y: y(Number(point.balance)) }));
+  const monthTicks = plan.baselineMonths <= 1 ? [0, 1] : niceTicks(0, plan.baselineMonths, 6);
+  return (
+    <div className="card">
+      <div className="explorer__head">
+        <strong>{plan.lender}</strong>{' '}
+        {plan.monthsSaved > 0 ? (
+          <Pill tone="ok">{plan.monthsSaved} payments sooner</Pill>
+        ) : (
+          <Pill tone="neutral">as scheduled</Pill>
+        )}
+      </div>
+      <ChartFrame
+        viewWidth={WIDTH}
+        viewHeight={HEIGHT}
+        label={`${plan.lender} — balance as scheduled and with the extra payment`}
+      >
+        {monthTicks.map((tick) => (
+          <text key={tick} className="chart__axis" x={x(tick)} y={HEIGHT - 8} textAnchor="middle">
+            {tick}
+          </text>
+        ))}
+        <path
+          className="chart__line chart__line--series-3 chart__line--projected"
+          d={linePath(toPoints(plan.baselineCurve))}
+        />
+        <path
+          className="chart__line chart__line--projected trace"
+          pathLength={1}
+          d={linePath(toPoints(plan.extraCurve))}
+        />
+      </ChartFrame>
+      <p className="faint">
+        Months from today across the bottom; the graphite curve is the note as scheduled, the ember
+        curve carries the extra.
+      </p>
+      <KeyValue
+        items={[
+          {
+            key: 'As scheduled',
+            value: `${plan.baselineMonths} payments — retires ${formatDate(
+              isoOf(monthDay(today, plan.baselineMonths)),
+            )} · ${formatMoney(plan.baselineInterest)} interest remaining`,
+          },
+          {
+            key: 'With the extra',
+            value: `${plan.extraMonths} payments — retires ${formatDate(
+              isoOf(monthDay(today, plan.extraMonths)),
+            )} · ${formatMoney(plan.extraInterest)} interest remaining`,
+          },
+          {
+            key: 'The working',
+            value: `${formatMoney(plan.interestSaved)} of interest never accrues, and the note retires ${plan.monthsSaved} payments early`,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+type AmortizationExplorerProps = {
+  debts: Financials['debts'];
+  today: string;
+};
+
+export function AmortizationExplorer({ debts, today }: AmortizationExplorerProps) {
+  const [extra, setExtra] = useState(100);
+  const plans = notePlans(debts, extra);
+  if (plans.length === 0) {
+    return null;
+  }
+  return (
+    <div className="explorer">
+      <div className="form-row">
+        <RangeField
+          label="Extra principal, every payment"
+          value={extra}
+          min={0}
+          max={500}
+          step={25}
+          onChange={setExtra}
+          format={(value) => `$${value}/mo`}
+        />
+      </div>
+      {plans.map((plan) => (
+        <NoteCard key={plan.lender} plan={plan} today={today} />
+      ))}
+      <p className="faint">
+        The engines’ own convention: interest at annual over twelve, HalfUp at every row, the final
+        payment a plug. engines/amortization prices the schedule; the walk only adds the extra.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/amortize-extra.ts
+++ b/apps/web/src/lib/amortize-extra.ts
@@ -1,0 +1,111 @@
+/**
+ * Extra-principal arithmetic: walk a note month by month with an extra
+ * payment riding every installment, in the engines' own convention —
+ * interest at annual/12, HalfUp at each row, the final payment a plug.
+ * The baseline comes straight from the engines' schedule; the scenario is
+ * the same walk with the extra applied; the working is the difference.
+ */
+import {
+  add,
+  divideRate,
+  isPositive,
+  lessThan,
+  type Money,
+  money,
+  multiply,
+  Rounding,
+  rate,
+  subtract,
+  toDecimalString,
+} from '@hestia/domain';
+import {
+  type AmortizationRow,
+  type AmortizationTerms,
+  amortizationSchedule,
+} from '@hestia/engines';
+import type { Financials } from './api';
+
+export interface PayoffPoint {
+  /** Months from today. */
+  month: number;
+  balance: string;
+}
+
+export interface NotePlan {
+  lender: string;
+  /** Months from today until retirement, and interest still to be paid,
+   * with no extra principal. */
+  baselineMonths: number;
+  baselineInterest: string;
+  /** The same, with the extra riding every payment. */
+  extraMonths: number;
+  extraInterest: string;
+  interestSaved: string;
+  monthsSaved: number;
+  baselineCurve: PayoffPoint[];
+  extraCurve: PayoffPoint[];
+}
+
+const ZERO = money('0.00');
+
+interface Walk {
+  months: number;
+  interest: Money;
+  curve: PayoffPoint[];
+}
+
+/** Walk the remaining term from `elapsed`, paying `payment + extra` monthly.
+ * Sampled quarterly for the curve; exact at every step for the figures. */
+function walk(terms: AmortizationTerms, elapsed: number, payment: Money, extra: Money): Walk {
+  const monthlyRate = divideRate(terms.annualRate, rate('12'));
+  // Start from the engine's own balance at `elapsed`, not a re-derivation.
+  const schedule = amortizationSchedule(terms);
+  // The caller filters retired notes, so 1 ≤ elapsed ≤ term when nonzero.
+  let balance =
+    elapsed === 0 ? terms.principal : (schedule.rows[elapsed - 1] as AmortizationRow).balance;
+  let interest = ZERO;
+  let months = 0;
+  const curve: PayoffPoint[] = [{ month: 0, balance: toDecimalString(balance) }];
+  const due = add(payment, extra);
+  while (isPositive(balance)) {
+    const monthInterest = multiply(balance, monthlyRate, Rounding.HalfUp);
+    interest = add(interest, monthInterest);
+    const withInterest = add(balance, monthInterest);
+    months += 1;
+    // The engine's final row is a plug in BOTH directions: at the term
+    // boundary the note retires whatever residue rounding accumulated.
+    const reachedTerm = elapsed + months >= terms.termMonths;
+    balance = !reachedTerm && lessThan(due, withInterest) ? subtract(withInterest, due) : ZERO;
+    if (months % 3 === 0 || !isPositive(balance)) {
+      curve.push({ month: months, balance: toDecimalString(balance) });
+    }
+  }
+  return { months, interest, curve };
+}
+
+export function notePlans(debts: Financials['debts'], extraMonthly: number): NotePlan[] {
+  const extra = money(String(extraMonthly));
+  return debts
+    .filter((debt) => debt.term_months - debt.months_elapsed > 0)
+    .map((debt) => {
+      const terms: AmortizationTerms = {
+        principal: money(debt.original_principal),
+        annualRate: rate(debt.annual_rate),
+        termMonths: debt.term_months,
+      };
+      const schedule = amortizationSchedule(terms);
+      const baseline = walk(terms, debt.months_elapsed, schedule.payment, ZERO);
+      const scenario = walk(terms, debt.months_elapsed, schedule.payment, extra);
+      return {
+        lender: debt.lender ?? 'Unnamed lender',
+        baselineMonths: baseline.months,
+        baselineInterest: toDecimalString(baseline.interest),
+        extraMonths: scenario.months,
+        extraInterest: toDecimalString(scenario.interest),
+        interestSaved: toDecimalString(subtract(baseline.interest, scenario.interest)),
+        monthsSaved: baseline.months - scenario.months,
+        baselineCurve: baseline.curve,
+        extraCurve: scenario.curve,
+      };
+    });
+}

--- a/apps/web/src/lib/reserve.ts
+++ b/apps/web/src/lib/reserve.ts
@@ -1,0 +1,54 @@
+/**
+ * The reserve line's arithmetic: does a flat monthly reserve keep pace with
+ * the Weibull forecast's cumulative median? Pure money math over bands the
+ * page already holds — dragging the line costs no request and rounds
+ * nothing away.
+ */
+import {
+  add,
+  isPositive,
+  money,
+  multiply,
+  Rounding,
+  rate,
+  subtract,
+  toDecimalString,
+} from '@hestia/domain';
+import type { CapexForecastOut } from './api';
+
+export interface ReserveYear {
+  year: number;
+  cumulativeReserve: string;
+  cumulativeMedian: string;
+  /** True when the reserve covers the cumulative median through this year. */
+  funded: boolean;
+  /** The uncovered remainder when it does not; '0.00' when funded. */
+  shortfall: string;
+}
+
+const ZERO = money('0.00');
+
+export function reserveCoverage(forecast: CapexForecastOut, monthlyReserve: number): ReserveYear[] {
+  const monthly = money(String(monthlyReserve));
+  const years: ReserveYear[] = [];
+  let cumulativeMedian = ZERO;
+  for (const band of forecast.bands) {
+    cumulativeMedian = add(cumulativeMedian, money(band.p50));
+    const cumulativeReserve = multiply(monthly, rate(String(band.year * 12)), Rounding.HalfEven);
+    const gap = subtract(cumulativeMedian, cumulativeReserve);
+    const funded = !isPositive(gap);
+    years.push({
+      year: band.year,
+      cumulativeReserve: toDecimalString(cumulativeReserve),
+      cumulativeMedian: toDecimalString(cumulativeMedian),
+      funded,
+      shortfall: funded ? '0.00' : toDecimalString(gap),
+    });
+  }
+  return years;
+}
+
+/** The first year the reserve runs short, if any. */
+export function firstShortfall(years: readonly ReserveYear[]): ReserveYear | null {
+  return years.find((year) => !year.funded) ?? null;
+}

--- a/apps/web/tests/advantage-cards.test.tsx
+++ b/apps/web/tests/advantage-cards.test.tsx
@@ -160,6 +160,19 @@ describe('CapexFanChart', () => {
     expect(screen.queryByText(/Not simulated/)).toBeNull();
   });
 
+  it('shades the years a thin reserve cannot cover, and says which', () => {
+    const { container, rerender } = render(<CapexFanChart forecast={forecast} />);
+    // $200/mo outruns this median plan: no wash, the funded sentence.
+    expect(container.querySelectorAll('.chart__shade')).toHaveLength(0);
+    expect(screen.getByText(/funds the median plan through year 3/)).toBeDefined();
+    rerender(<CapexFanChart forecast={forecast} />);
+    fireEvent.change(screen.getByRole('slider', { name: 'Monthly reserve' }), {
+      target: { value: '25' },
+    });
+    expect(container.querySelectorAll('.chart__shade')).toHaveLength(2);
+    expect(screen.getByText(/Year 2 runs \$250\.00 short of the median plan/)).toBeDefined();
+  });
+
   it('points at the dossier when the inventory is empty', () => {
     render(
       <CapexFanChart

--- a/apps/web/tests/amortization-explorer.test.tsx
+++ b/apps/web/tests/amortization-explorer.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AmortizationExplorer } from '../src/components/AmortizationExplorer';
+import type { Financials } from '../src/lib/api';
+
+afterEach(cleanup);
+
+const TODAY = '2026-08-28';
+
+const DEBTS: Financials['debts'] = [
+  {
+    lender: 'First Federal',
+    original_principal: '190000.00',
+    annual_rate: '0.0625',
+    term_months: 360,
+    months_elapsed: 30,
+  },
+  {
+    lender: 'Paid Off',
+    original_principal: '10000.00',
+    annual_rate: '0.05',
+    term_months: 60,
+    months_elapsed: 60,
+  },
+];
+
+describe('AmortizationExplorer', () => {
+  it('renders a card per live note with both dashed futures and the working', () => {
+    const { container } = render(<AmortizationExplorer debts={DEBTS} today={TODAY} />);
+    expect(screen.getByText('First Federal')).toBeDefined();
+    expect(screen.queryByText('Paid Off')).toBeNull();
+    // Both curves are futures: dashed, per the stroke-style law.
+    expect(container.querySelectorAll('.chart__line--projected')).toHaveLength(2);
+    expect(container.querySelector('.chart__line--series-3')).not.toBeNull();
+    expect(screen.getByText(/payments sooner/)).toBeDefined();
+    expect(screen.getByText('As scheduled')).toBeDefined();
+    expect(screen.getByText('The working')).toBeDefined();
+    expect(screen.getByText(/interest never accrues/)).toBeDefined();
+  });
+
+  it('recomputes live as the extra scrubs, and zero extra means as-scheduled', () => {
+    render(<AmortizationExplorer debts={DEBTS} today={TODAY} />);
+    const knob = screen.getByRole('slider', { name: 'Extra principal, every payment' });
+    const workingAt100 = screen.getByText(/interest never accrues/).textContent;
+    fireEvent.change(knob, { target: { value: '500' } });
+    const workingAt500 = screen.getByText(/interest never accrues/).textContent;
+    expect(workingAt500).not.toBe(workingAt100);
+    fireEvent.change(knob, { target: { value: '0' } });
+    expect(screen.getByText('as scheduled').className).toBe('pill');
+    expect(screen.getByText(/\$0\.00 of interest never accrues/)).toBeDefined();
+  });
+
+  it('handles a note with one payment left: two honest ticks, no fuss', () => {
+    render(
+      <AmortizationExplorer
+        debts={[{ ...(DEBTS[0] as Financials['debts'][number]), months_elapsed: 359 }]}
+        today={TODAY}
+      />,
+    );
+    expect(screen.getByText('as scheduled').className).toBe('pill');
+    expect(screen.getAllByText(/1 payments — retires Sep 28, 2026/)).toHaveLength(2);
+  });
+
+  it('renders nothing when every note is retired', () => {
+    const { container } = render(
+      <AmortizationExplorer debts={[DEBTS[1] as Financials['debts'][number]]} today={TODAY} />,
+    );
+    expect(container.firstElementChild).toBeNull();
+  });
+});

--- a/apps/web/tests/amortize-extra.test.ts
+++ b/apps/web/tests/amortize-extra.test.ts
@@ -1,0 +1,83 @@
+import { add, money, rate, toDecimalString } from '@hestia/domain';
+import { type AmortizationRow, amortizationSchedule } from '@hestia/engines';
+import { describe, expect, it } from 'vitest';
+import { notePlans } from '../src/lib/amortize-extra';
+import type { Financials } from '../src/lib/api';
+
+const DEBT = {
+  lender: 'First Federal',
+  original_principal: '190000.00',
+  annual_rate: '0.0625',
+  term_months: 360,
+  months_elapsed: 30,
+};
+
+const debts = (rows: Financials['debts']): Financials['debts'] => rows;
+
+describe('notePlans', () => {
+  it('with no extra, reproduces the engine schedule tail to the cent', () => {
+    const [plan] = notePlans(debts([DEBT]), 0);
+    if (plan === undefined) throw new Error('plan expected');
+    expect(plan.baselineMonths).toBe(360 - 30);
+    expect(plan.extraMonths).toBe(plan.baselineMonths);
+    expect(plan.interestSaved).toBe('0.00');
+    expect(plan.monthsSaved).toBe(0);
+
+    // The differential proof: the walk's interest equals the engine's own
+    // rows summed over the remaining term.
+    const schedule = amortizationSchedule({
+      principal: money(DEBT.original_principal),
+      annualRate: rate(DEBT.annual_rate),
+      termMonths: DEBT.term_months,
+    });
+    const expected = schedule.rows
+      .slice(DEBT.months_elapsed)
+      .reduce((total, row) => add(total, row.interest), money('0.00'));
+    expect(plan.baselineInterest).toBe(toDecimalString(expected));
+
+    // The curve starts at the engine's balance and ends retired.
+    expect(plan.baselineCurve[0]?.month).toBe(0);
+    expect(plan.baselineCurve[0]?.balance).toBe(
+      toDecimalString((schedule.rows[DEBT.months_elapsed - 1] as AmortizationRow).balance),
+    );
+    expect(plan.baselineCurve.at(-1)?.balance).toBe('0.00');
+  });
+
+  it('an extra payment retires the note sooner and never accrues the saved interest', () => {
+    const [plan] = notePlans(debts([DEBT]), 200);
+    if (plan === undefined) throw new Error('plan expected');
+    expect(plan.extraMonths).toBeLessThan(plan.baselineMonths);
+    expect(plan.monthsSaved).toBe(plan.baselineMonths - plan.extraMonths);
+    expect(Number(plan.interestSaved)).toBeGreaterThan(0);
+    expect(plan.extraCurve.at(-1)?.balance).toBe('0.00');
+    // Quarterly samples plus the retirement point.
+    expect(plan.extraCurve.length).toBeGreaterThan(plan.extraMonths / 4);
+  });
+
+  it('handles a zero-rate note: no interest either way, months still bought', () => {
+    const [plan] = notePlans(
+      debts([
+        {
+          ...DEBT,
+          lender: 'Family',
+          original_principal: '12000.00',
+          annual_rate: '0',
+          term_months: 48,
+          months_elapsed: 0,
+        },
+      ]),
+      50,
+    );
+    if (plan === undefined) throw new Error('plan expected');
+    expect(plan.baselineInterest).toBe('0.00');
+    expect(plan.extraInterest).toBe('0.00');
+    expect(plan.baselineMonths).toBe(48);
+    expect(plan.extraMonths).toBeLessThan(48);
+  });
+
+  it('leaves retired notes out of the conversation, and names the nameless', () => {
+    expect(notePlans(debts([{ ...DEBT, months_elapsed: 360 }]), 100)).toEqual([]);
+    const [nameless] = notePlans(debts([{ ...DEBT, lender: null }]), 0);
+    expect(nameless?.lender).toBe('Unnamed lender');
+  });
+});

--- a/apps/web/tests/reserve.test.ts
+++ b/apps/web/tests/reserve.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { CapexForecastOut } from '../src/lib/api';
+import { firstShortfall, reserveCoverage } from '../src/lib/reserve';
+
+const forecast: CapexForecastOut = {
+  property_id: 'p1',
+  horizon_years: 3,
+  components_simulated: 4,
+  components_without_cost: [],
+  bands: [
+    { year: 1, expected: '900.00', p10: '0.00', p50: '0.00', p90: '3200.00' },
+    { year: 2, expected: '1400.00', p10: '0.00', p50: '850.00', p90: '4100.00' },
+    { year: 3, expected: '2100.00', p10: '0.00', p50: '1500.00', p90: '6000.00' },
+  ],
+  total_expected: '4400.00',
+};
+
+describe('reserveCoverage', () => {
+  it('funds every year when the reserve outruns the cumulative median', () => {
+    const years = reserveCoverage(forecast, 200);
+    expect(
+      years.map((year) => `${year.year}:${year.cumulativeReserve}/${year.cumulativeMedian}`),
+    ).toEqual(['1:2400.00/0.00', '2:4800.00/850.00', '3:7200.00/2350.00']);
+    expect(years.every((year) => year.funded)).toBe(true);
+    expect(years.every((year) => year.shortfall === '0.00')).toBe(true);
+    expect(firstShortfall(years)).toBeNull();
+  });
+
+  it('names the first year a thin reserve runs short, to the cent', () => {
+    const years = reserveCoverage(forecast, 25);
+    expect(years.map((year) => `${year.year}:${year.funded ? 'ok' : year.shortfall}`)).toEqual([
+      '1:ok',
+      '2:250.00',
+      '3:1450.00',
+    ]);
+    expect(firstShortfall(years)?.year).toBe(2);
+  });
+
+  it('a zero reserve is exactly funded while the median is zero, short after', () => {
+    const years = reserveCoverage(forecast, 0);
+    expect(years[0]?.funded).toBe(true);
+    expect(years[1]?.shortfall).toBe('850.00');
+  });
+});

--- a/packages/design/src/charts/FanChart.tsx
+++ b/packages/design/src/charts/FanChart.tsx
@@ -11,19 +11,42 @@ export type FanBand = { label: string; low: number; mid: number; high: number };
 type FanChartProps = {
   bands: readonly FanBand[];
   label: string;
+  /** Band labels to wash in the failure tint — an underfunded year is a
+   * failure state, and madder is its ink. */
+  shaded?: readonly string[];
   width?: number;
   height?: number;
 };
 
-export function FanChart({ bands, label, width = 560, height = 150 }: FanChartProps) {
+export function FanChart({ bands, label, shaded = [], width = 560, height = 150 }: FanChartProps) {
   const peak = Math.max(...bands.map((band) => band.high), 1);
   const x = linearScale(0, Math.max(bands.length - 1, 1), 30, width - 20);
   const y = linearScale(0, peak, height - 24, 16);
   const upper = bands.map((band, index) => ({ x: x(index), y: y(band.high) }));
   const lower = bands.map((band, index) => ({ x: x(index), y: y(band.low) }));
   const mid = bands.map((band, index) => ({ x: x(index), y: y(band.mid) }));
+  const edge = (index: number): [number, number] => [
+    index === 0 ? x(0) - 12 : (x(index - 1) + x(index)) / 2,
+    index === bands.length - 1 ? x(index) + 12 : (x(index) + x(index + 1)) / 2,
+  ];
   return (
     <ChartFrame viewWidth={width} viewHeight={height} label={label}>
+      {bands.map((band, index) => {
+        if (!shaded.includes(band.label)) {
+          return null;
+        }
+        const [from, to] = edge(index);
+        return (
+          <rect
+            key={`shade-${band.label}`}
+            className="chart__shade"
+            x={from}
+            width={to - from}
+            y={10}
+            height={height - 30}
+          />
+        );
+      })}
       <path className="chart__band" d={areaPath(upper, lower)} />
       {mid.length === 0 ? null : (
         <path className="chart__line trace" pathLength={1} d={linePath(mid)} />

--- a/packages/design/src/charts/charts.test.tsx
+++ b/packages/design/src/charts/charts.test.tsx
@@ -41,6 +41,20 @@ describe('FanChart', () => {
     expect(screen.getAllByText(/^[123]$/)).toHaveLength(3);
   });
 
+  it('washes only the shaded bands, edges clamped', () => {
+    const { container, rerender } = render(
+      <FanChart bands={BANDS} label="Shaded fan" shaded={['1', '3']} />,
+    );
+    const shades = container.querySelectorAll('.chart__shade');
+    expect(shades).toHaveLength(2);
+    // The first band's wash starts at the left clamp, before its center.
+    expect(Number(shades[0]?.getAttribute('x'))).toBeLessThan(30);
+    rerender(<FanChart bands={BANDS} label="Shaded fan" shaded={['2']} />);
+    expect(container.querySelectorAll('.chart__shade')).toHaveLength(1);
+    rerender(<FanChart bands={BANDS} label="Shaded fan" />);
+    expect(container.querySelectorAll('.chart__shade')).toHaveLength(0);
+  });
+
   it('renders an honest empty frame when there are no bands', () => {
     const { container } = render(<FanChart bands={[]} label="Nothing simulated" />);
     expect(screen.getByRole('img', { name: 'Nothing simulated' })).toBeDefined();

--- a/packages/design/src/css/charts.css
+++ b/packages/design/src/css/charts.css
@@ -131,6 +131,11 @@
     opacity: 0.5;
   }
 
+  /* An underfunded stretch wears the failure tint, faintly. */
+  .chart__shade {
+    fill: rgb(143 45 60 / 8%);
+  }
+
   /* The hurdle: the bar a return must clear, drawn in the second ink. */
   .chart__hurdle {
     stroke: var(--graphite);

--- a/packages/design/src/css/patterns.css
+++ b/packages/design/src/css/patterns.css
@@ -323,4 +323,17 @@
     color: var(--madder);
     font-weight: 600;
   }
+
+  /* ---- the amortization explorer ---- */
+
+  .explorer__head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+  }
+
+  .explorer > .card {
+    margin-top: var(--space-3);
+  }
 }


### PR DESCRIPTION
Closes #56.

Two knobs that answer money questions to the cent, live in the browser:

**The reserve line.** The capital fan gains a monthly-reserve scrub. `reserveCoverage()` runs exact money arithmetic against the forecast's cumulative median; years where the cumulative reserve underruns are washed madder on the chart itself (FanChart grows a `shaded` prop with edge-clamped bounds), and the readout names the first year the plan goes short.

**The amortization explorer.** Every live note on the dossier gets one: scrub an extra principal payment and both futures redraw — the engines' own convention (annual/12, HalfUp per row, the final payment a plug in both directions), proven differentially against the engine's own schedule rows. The working shows interest that never accrues and payments bought, as figures. Retired notes stay out of the conversation; a nameless lender is named honestly.

Both curves are futures, so both are dashed — the stroke-style law holds.

Ladder: verify green (design 260 tests / web 196, 100% coverage both, mutation over threshold), 9/9 e2e on a fresh database after rebasing onto the fixed main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)