### PR TITLE
Tennessee pack: a third state, and the seams a third state exposes

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -2947,7 +2947,7 @@ export interface components {
              * Reason
              * @enum {string}
              */
-            reason: "no_state_jurisdiction" | "no_rule_for_domain" | "calendar_key_unregistered";
+            reason: "no_state_jurisdiction" | "no_rule_for_domain" | "calendar_key_unregistered" | "window_not_published";
             /** State */
             state: string;
         };

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -6049,7 +6049,8 @@
             "enum": [
               "no_state_jurisdiction",
               "no_rule_for_domain",
-              "calendar_key_unregistered"
+              "calendar_key_unregistered",
+              "window_not_published"
             ],
             "title": "Reason",
             "type": "string"

--- a/packages/domain/schema/seed/907_jurisdictions_tennessee.sql
+++ b/packages/domain/schema/seed/907_jurisdictions_tennessee.sql
@@ -1,0 +1,335 @@
+-- ===========================================================================
+--  Seed — Tennessee: the third state, and the honest test of ADR 0003.
+--
+--  Kentucky and Ohio were built together; a third state is where "states are
+--  data" either holds or does not. Tennessee was chosen because it disagrees
+--  with both in ways that are structural rather than cosmetic:
+--
+--    * NO individual income tax at all. The Hall tax on interest and
+--      dividends was repealed outright, not suspended, so an individual
+--      owner has no second depreciation schedule to keep. Kentucky freezes
+--      2001 federal law and Ohio adds back two thirds; Tennessee asks
+--      nothing. "This state has no such rule" is a finding, and it is seeded
+--      as one rather than left as silence.
+--    * A CLASSIFIED assessment ratio — 25% residential, 40% commercial —
+--      against Kentucky's flat 100% and Ohio's flat 35%. Which class a
+--      rented house falls in is the whole question, and TCA 67-5-501(11)
+--      answers it by RENTAL UNIT COUNT: not more than one rental unit is
+--      residential, so a rented single-family house is 25% and a fully
+--      rented duplex is 40%.
+--    * A landlord-tenant act that binds by COUNTY POPULATION rather than by
+--      local adoption (Kentucky) or statewide fiat (Ohio). Because the
+--      county is what decides, every rule that rides on the act is seeded on
+--      the COUNTY rows and the non-URLTA law is seeded on the STATE row —
+--      so a property in an unseeded Tennessee county resolves to the law
+--      that actually governs it instead of borrowing Nashville's.
+--    * A summer appeal window against Kentucky's spring and Ohio's winter,
+--      and a county inside it that convenes a month early.
+--
+--  UUID block a0000000-0047-… (Tennessee FIPS 47, per seed/README.md).
+--  Figures not yet professionally confirmed say so in their citations.
+-- ===========================================================================
+
+INSERT INTO jurisdictions (id, level, name, state, parent_id, fips_code) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'state',        'Tennessee', 'TN', 'a0000000-0000-4000-8000-000000000001', '47'),
+  ('a0000000-0047-4000-8000-000000000021', 'county',       'Davidson County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47037'),
+  ('a0000000-0047-4000-8000-000000000022', 'county',       'Shelby County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47157'),
+  -- Nashville and Davidson County are one consolidated metropolitan
+  -- government. It is still modelled as a municipality beneath its county:
+  -- the chain is what resolution walks, and collapsing two levels for one
+  -- city would make Nashville the only place in the country whose property
+  -- resolves at a different depth than everywhere else.
+  ('a0000000-0047-4000-8000-000000000101', 'municipality', 'Nashville', 'TN', 'a0000000-0047-4000-8000-000000000021', '4752006'),
+  ('a0000000-0047-4000-8000-000000000102', 'municipality', 'Memphis', 'TN', 'a0000000-0047-4000-8000-000000000022', '4748000');
+
+-- ---------------------------------------------------------------------------
+-- Property tax: the county board of equalization.
+--
+-- The state row carries the ordinary calendar; Shelby County overrides it,
+-- which is the first time any pack has needed a county to disagree with its
+-- state about a calendar. Nothing in the resolver changed to allow that —
+-- depth-first chain resolution already prefers the nearer row.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.window.calendar',
+   NULL, 'us-tn.county-board',
+   'TCA 67-1-404(a) (the county board meets June 1); TCA 67-5-1412(e) (the '
+   'State Board filing deadline); TCA 1-3-102 (weekend and holiday extension)',
+   DATE '1973-01-01'),
+  -- Shelby convenes May 1 per the Comptroller's published county-board
+  -- schedule. A statewide row would have told a Memphis owner to wait a
+  -- month past the day the board actually sat.
+  ('a0000000-0047-4000-8000-000000000022', 'assessment_appeal', 'appeal.window.calendar',
+   NULL, 'us-tn.shelby-county-board',
+   'TCA 67-1-404 (session dates); Tennessee Comptroller, county board of '
+   'equalization schedule (Shelby County convenes May 1) — CONFIRM ANNUALLY',
+   DATE '1973-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.form',
+   NULL, 'Appeal to the county board of equalization; from its action, appeal '
+   'to the State Board of Equalization on the State Board''s form',
+   'TCA 67-5-1407; TCA 67-5-1412 — CONFIRM WITH TN COUNSEL', DATE '1973-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.conference_required',
+   NULL, 'false; an informal review with the assessor is available but is not a '
+   'prerequisite to the county board',
+   'TCA 67-5-1407 — CONFIRM WITH TN COUNSEL', DATE '1973-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.instructions',
+   NULL, 'Appeal to the county board of equalization once it convenes; an appeal '
+   'to the State Board of Equalization must be filed by August 1 of the tax year, '
+   'or within 45 days of the date notice of the local board''s action was sent if '
+   'that is later. The 45-day leg depends on a notice this system has not seen, so '
+   'the scheduled date is the August 1 leg, which is never the later of the two.',
+   'TCA 67-5-1412(e)', DATE '1973-01-01'),
+  -- Two deadlines the sweep does not yet schedule, recorded so the pack does
+  -- not imply August 1 is the only way in. Both hang off a notice date.
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.direct_to_state_days',
+   45, 'where notice of a change was sent later than ten days before the local '
+   'board adjourned, the taxpayer may appeal directly to the State Board within '
+   '45 days of the notice; where no notice was sent, within 45 days of the tax '
+   'billing date',
+   'TCA 67-5-1412(b)', DATE '1973-01-01');
+
+-- ---------------------------------------------------------------------------
+-- Assessment ratio: CLASSIFIED, unlike Kentucky's flat 100% or Ohio's 35%.
+--
+-- The dividing line is the number of RENTAL units, not owner-occupancy: a
+-- house rented to one tenant is residential at 25%, and a duplex with both
+-- halves rented is commercial at 40%. Both rows are seeded, because a pack
+-- carrying only the ratio its author needed would mis-assess the first
+-- duplex silently.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_ratio', 'assessment.ratio',
+   0.25, 'residential — real property used or held for use for dwelling purposes '
+   'containing not more than one rental unit',
+   'TCA 67-5-801(a); TCA 67-5-501(11); Tenn. Const. art. II, s.28', DATE '1973-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_ratio', 'assessment.ratio.commercial',
+   0.40, 'industrial and commercial — including dwelling property containing two '
+   'or more rental units',
+   'TCA 67-5-801(a); TCA 67-5-501(4); Tenn. Const. art. II, s.28', DATE '1973-01-01'),
+  -- The caveat travels with the ratio. Without it the platform would tell a
+  -- build-to-rent owner 25% with a confidence the law does not support.
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_ratio', 'assessment.ratio.caveat',
+   NULL, 'No bright-line rule. Separately parceled single-family homes owned and '
+   'managed as one rental enterprise may be classified commercial on all the facts '
+   'and circumstances; the assessor weighs them case by case.',
+   'Tenn. Att''y Gen. Op. 25-016 (2025); Spring Hill, L.P. v. State Board of '
+   'Equalization — CONFIRM WITH TN COUNSEL BEFORE RELIANCE', DATE '2025-01-01');
+
+-- ---------------------------------------------------------------------------
+-- Landlord-tenant: a THIRD adoption shape.
+--
+-- Kentucky's URLTA binds only where a municipality adopts it; Ohio's chapter
+-- 5321 binds statewide with no adoption step; Tennessee's binds in counties
+-- above a population threshold, by operation of the statute, with no local
+-- choice either way. The threshold reads the 2010 federal census and ONLY
+-- the 2010 census — the "or any subsequent census" language is gone, so the
+-- covered list is frozen at seventeen counties and does not grow. Davidson
+-- and Shelby are both well above it.
+--
+-- Everything that rides on the act is therefore seeded on the COUNTY rows.
+-- A Tennessee property in an unseeded county resolves past them to the state
+-- row, where the non-URLTA law lives — which is the law that actually
+-- governs it.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'landlord_tenant_act', 'ltl.statewide',
+   NULL, 'false; the act binds only counties above the population threshold, by '
+   'operation of the statute rather than by local adoption, and preempts '
+   'conflicting local ordinances where it applies',
+   'TCA 66-28-102(a); TCA 66-28-102(e) (preemption, effective 2021-07-01)',
+   DATE '1975-07-01');
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_text, citation, effective_from)
+SELECT id, 'landlord_tenant_act', 'urlta.adopted', 'true',
+       'TCA 66-28-102(a) (the chapter applies in counties over 75,000 by the 2010 '
+       'federal census; Davidson and Shelby are both above it)',
+       DATE '1975-07-01'
+FROM jurisdictions
+WHERE level = 'county' AND state = 'TN';
+
+-- ---------------------------------------------------------------------------
+-- Security deposit — TCA 66-28-301, and the seam a third state exposes.
+--
+-- Tennessee imposes NO fixed statutory deadline to return a deposit. The
+-- widely repeated "thirty days" is a secondary-source artifact of subsection
+-- (g), which is the window for discovering damage AFTER the tenant leaves,
+-- not an obligation to pay. What the statute actually gives is a forfeiture
+-- rule and a notification mechanic, and those are what is seeded.
+--
+-- "No deadline exists" and "no deadline is loaded" must not look alike, so
+-- the absence is stated as a rule rather than left to silence.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  -- Statewide: no county in Tennessee owes interest on a deposit.
+  ('a0000000-0047-4000-8000-000000000010', 'security_deposit', 'deposit.interest_required',
+   NULL, 'false; Tennessee imposes no interest obligation on a residential '
+   'security deposit',
+   'TCA ch. 66-28 (no interest provision) — CONFIRM WITH TN COUNSEL',
+   DATE '1975-07-01');
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+SELECT j.id, v.domain::rule_domain, v.code, v.value_numeric, v.value_text, v.citation, v.effective_from
+FROM jurisdictions j
+CROSS JOIN (VALUES
+  ('security_deposit', 'deposit.return_deadline_exists', NULL::NUMERIC,
+   'false; the chapter fixes no deadline to return a deposit. What it fixes '
+   'instead is a forfeiture: a landlord who did not hold the deposit in a '
+   'separate account, or who did not give the final damage listing, may retain '
+   'no part of it.',
+   'TCA 66-28-301(c) — CONFIRM WITH TN COUNSEL', DATE '1975-07-01'),
+  ('security_deposit', 'urlta.deposit.separate_account_required', NULL,
+   'true', 'TCA 66-28-301(a); TCA 66-28-301(h) (the tenant must be told where '
+   'the account is held, though not its number)', DATE '1975-07-01'),
+  ('security_deposit', 'urlta.deposit.itemized_list_required', NULL,
+   'true', 'TCA 66-28-301(b)', DATE '1975-07-01'),
+  ('security_deposit', 'deposit.inspection_notice_days', 5,
+   'the landlord must tell the tenant of the right to inspect within five days '
+   'of receiving notice to vacate; the inspection happens on the vacate day or '
+   'within four calendar days after',
+   'TCA 66-28-301(b)', DATE '1975-07-01'),
+  ('security_deposit', 'deposit.unclaimed_notification_days', 60,
+   'where a refund is due, the landlord sends notice to the last known address; '
+   'if the tenant does not respond within sixty days the landlord may remove the '
+   'deposit from the account and retain it',
+   'TCA 66-28-301(f)', DATE '1975-07-01')
+) AS v(domain, code, value_numeric, value_text, citation, effective_from)
+WHERE j.level = 'county' AND j.state = 'TN';
+
+-- ---------------------------------------------------------------------------
+-- Notice periods. The URLTA numbers are on the counties; the non-URLTA
+-- numbers are on the state, so a property in an unseeded Tennessee county
+-- resolves to TCA 66-7-109 rather than borrowing Nashville's law.
+--
+-- Note that the fourteen-day cure / thirty-day termination structure people
+-- remember is the NON-URLTA rule. Under the current chapter 28 both legs are
+-- fourteen days, with seven for a repeat of the same breach inside six
+-- months.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'notice_period', 'eviction.notice_days',
+   14, 'non-URLTA counties: fourteen days for rent in arrears on demand, for '
+   'damage beyond normal wear and tear, and for violent acts or a real and '
+   'present danger to health or safety',
+   'TCA 66-7-109(a)(1); TCA 66-7-109(g)', DATE '1975-07-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'notice_period', 'eviction.other_default_days',
+   30, 'non-URLTA counties: thirty days for all other defaults',
+   'TCA 66-7-109(b)', DATE '1975-07-01');
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+SELECT j.id, v.domain::rule_domain, v.code, v.value_numeric, v.value_text, v.citation, v.effective_from
+FROM jurisdictions j
+CROSS JOIN (VALUES
+  ('notice_period', 'urlta.notice.nonpayment_days', 14::NUMERIC,
+   'nonpayment is a remediable breach: the agreement terminates if it is not '
+   'cured within fourteen days of receipt of the notice',
+   'TCA 66-28-505(a)(2)', DATE '2021-07-01'),
+  ('notice_period', 'urlta.notice.material_noncompliance_days', 14,
+   'fourteen days to cure a remediable breach; for a non-remediable breach the '
+   'agreement terminates on a date not less than fourteen days after receipt',
+   'TCA 66-28-505(a)(2); TCA 66-28-505(a)(3)', DATE '2021-07-01'),
+  ('notice_period', 'urlta.notice.repeat_violation_days', 7,
+   'substantially the same breach recurring within six months terminates the '
+   'agreement on seven days'' notice, with no right to cure',
+   'TCA 66-28-505(a)(2)(B)', DATE '2021-07-01'),
+  ('late_fee', 'rent.grace_period_days', 5,
+   'no late fee before the fifth day; the fee is capped at ten percent of the '
+   'past-due rent, and where day five is a Sunday or legal holiday a payment on '
+   'the next business day is not late',
+   'TCA 66-28-201', DATE '1975-07-01')
+) AS v(domain, code, value_numeric, value_text, citation, effective_from)
+WHERE j.level = 'county' AND j.state = 'TN';
+
+-- ---------------------------------------------------------------------------
+-- Income tax: the simplest owner-side story in the union, and the reason
+-- Tennessee is a good third state.
+--
+-- There is no individual income tax on wages or rental income, and never was
+-- one on earned income; the Hall tax reached only interest and dividends and
+-- was repealed for tax years beginning on or after January 1, 2021. But the
+-- ENTITY that holds the property still meets the franchise and excise taxes,
+-- which is a different question from the owner's own return and is recorded
+-- as a different set of rules.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'income_tax', 'income.type',
+   NULL, 'none; no individual income tax on wages or on rental income',
+   'Tenn. Const. art. II, s.28; the Hall income tax (TCA tit. 67, ch. 2) was '
+   'repealed for tax years beginning on or after January 1, 2021 by 2017 Tenn. '
+   'Pub. Acts ch. 181, completing the phase-out begun by 2016 Tenn. Pub. Acts '
+   'ch. 1064', DATE '2021-01-01'),
+  -- The entity-level taxes. An owner-operator holding Tennessee rentals in an
+  -- LLC meets these whether or not there is a personal return to file.
+  ('a0000000-0047-4000-8000-000000000010', 'income_tax', 'income.entity_excise_rate',
+   0.065, 'excise tax on net earnings from business done in Tennessee',
+   'TCA 67-4-2007(a); TCA 67-4-2006 (net earnings) — CONFIRM WITH TN CPA',
+   DATE '1999-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'income_tax', 'income.entity_franchise_rate',
+   0.0025, 'franchise tax at twenty-five cents per hundred dollars of net worth, '
+   'apportioned to Tennessee. The former alternative property measure, which used '
+   'to set a floor and fell hardest on real-estate entities, was repealed for tax '
+   'years ending on or after January 1, 2024; net worth is now the sole base.',
+   'TCA 67-4-2106(a); TCA 67-4-2111 (apportionment); 2024 Tenn. Pub. Acts ch. 950 '
+   '(repeal of the property measure, formerly TCA 67-4-2108) — CONFIRM WITH TN CPA',
+   DATE '2024-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'income_tax', 'income.entity_franchise_minimum',
+   100, NULL, 'TCA 67-4-2119 — CONFIRM WITH TN CPA', DATE '1999-01-01'),
+  -- The exemption an owner-operator most often qualifies for, and the trap
+  -- inside it: "residential" here means four units or fewer, which is NOT the
+  -- one-unit line the assessment ratio uses. Two definitions of the same word
+  -- in the same code, and the platform must not conflate them.
+  ('a0000000-0047-4000-8000-000000000010', 'income_tax', 'income.entity_exemption',
+   NULL, 'FONCE — family-owned non-corporate entity. Both conditions must hold: '
+   'at least 95 percent of the ownership units are held by members of one family, '
+   'and at least two thirds of the entity''s activity produces passive investment '
+   'income. Rents from residential property count as passive; COMMERCIAL rents do '
+   'not, and "residential" here means property with not more than FOUR residential '
+   'units, which is a different line than the assessment ratio''s one-unit test. '
+   'The exemption is claimed year by year and must be renewed annually.',
+   'TCA 67-4-2008(a)(11); TCA 67-4-2008(a)(11)(B)(iv) (four-unit limit); '
+   'TCA 67-4-2008(f) (annual filing) — CONFIRM WITH TN CPA', DATE '1999-01-01');
+
+-- ---------------------------------------------------------------------------
+-- Depreciation conformity: nothing to compute on the owner's own return, and
+-- that is the answer — not silence. The entity-level excise tax is a
+-- different matter and does carry a bonus-depreciation addback, so it is
+-- recorded separately rather than folded into a single "conformity" verdict
+-- that would be wrong for one reader or the other.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0047-4000-8000-000000000010', 'depreciation_conformity', 'depreciation.conformity_kind',
+   NULL, 'none', 'there is no individual income tax to conform: Tenn. Const. art. '
+   'II, s.28 and the repeal of the Hall income tax — CONFIRM WITH TN CPA',
+   DATE '2021-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'depreciation_conformity', 'depreciation.entity_bonus_addback',
+   NULL, 'true; for excise-tax purposes IRC s.168 applies as it stood under the '
+   'Tax Cuts and Jobs Act of 2017, so bonus depreciation is allowed only at the '
+   'TCJA phase-down percentages — 80 percent in 2023, 60 in 2024, 40 in 2025, 20 '
+   'in 2026, none from 2027. Federal bonus taken above that percentage is added '
+   'back and recovered under MACRS. Assets bought on or before December 31, 2022 '
+   'follow the older rule, where Tennessee disallowed bonus outright.',
+   'TCA 67-4-2006(a)(12) (2023 Tenn. Pub. Acts ch. 377); TCA 67-4-2006(b)(1)(H) '
+   '(pre-2023 addback); TN DOR Notice 25-36 — CONFIRM WITH TN CPA',
+   DATE '2023-01-01'),
+  ('a0000000-0047-4000-8000-000000000010', 'depreciation_conformity', 'depreciation.s179_addback',
+   NULL, 'false; IRC s.179 flows through with its federal treatment and Tennessee '
+   'imposes no section 179 addback',
+   'TCA 67-4-2006 (no s.179 disallowance); TN DOR guidance ET-8 (a narrow '
+   'net-earnings computation edge case, not a disallowance) — CONFIRM WITH TN CPA',
+   DATE '1999-01-01');

--- a/packages/domain/schema/seed/907_jurisdictions_tennessee.sql
+++ b/packages/domain/schema/seed/907_jurisdictions_tennessee.sql
@@ -42,29 +42,70 @@ INSERT INTO jurisdictions (id, level, name, state, parent_id, fips_code) VALUES
   ('a0000000-0047-4000-8000-000000000101', 'municipality', 'Nashville', 'TN', 'a0000000-0047-4000-8000-000000000021', '4752006'),
   ('a0000000-0047-4000-8000-000000000102', 'municipality', 'Memphis', 'TN', 'a0000000-0047-4000-8000-000000000022', '4748000');
 
--- ---------------------------------------------------------------------------
--- Property tax: the county board of equalization.
+-- The other fifteen counties the landlord-tenant act reaches. They carry no
+-- municipalities yet — nobody owns there — but they must exist, because the
+-- act binds by COUNTY and a county that is missing from this table is a
+-- county whose landlord gets told the law of a chapter that disclaims him.
 --
--- The state row carries the ordinary calendar; Shelby County overrides it,
--- which is the first time any pack has needed a county to disagree with its
--- state about a calendar. Nothing in the resolver changed to allow that —
--- depth-first chain resolution already prefers the nearer row.
+-- Populations are the as-enumerated 2010 figures. TCA 1-3-116(a)(8) makes the
+-- 2010 CPH-1-44 publication controlling and says the figures "shall not be
+-- affected by subsequent revisions by the Census Bureau", which decides
+-- Anderson County: 75,129 as enumerated, 75,082 in the Bureau's later
+-- estimates base, and the statute reads the first. It clears the threshold by
+-- 129 people.
+INSERT INTO jurisdictions (id, level, name, state, parent_id, fips_code) VALUES
+  ('a0000000-0047-4000-8000-000000000023', 'county', 'Anderson County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47001'),  -- 2010: 75,129
+  ('a0000000-0047-4000-8000-000000000024', 'county', 'Blount County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47009'),  -- 2010: 123,010
+  ('a0000000-0047-4000-8000-000000000025', 'county', 'Bradley County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47011'),  -- 2010: 98,963
+  ('a0000000-0047-4000-8000-000000000026', 'county', 'Hamilton County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47065'),  -- 2010: 336,463
+  ('a0000000-0047-4000-8000-000000000027', 'county', 'Knox County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47093'),  -- 2010: 432,226
+  ('a0000000-0047-4000-8000-000000000028', 'county', 'Madison County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47113'),  -- 2010: 98,294
+  ('a0000000-0047-4000-8000-000000000029', 'county', 'Maury County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47119'),  -- 2010: 80,956
+  ('a0000000-0047-4000-8000-000000000030', 'county', 'Montgomery County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47125'),  -- 2010: 172,331
+  ('a0000000-0047-4000-8000-000000000031', 'county', 'Rutherford County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47149'),  -- 2010: 262,604
+  ('a0000000-0047-4000-8000-000000000032', 'county', 'Sevier County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47155'),  -- 2010: 89,889
+  ('a0000000-0047-4000-8000-000000000033', 'county', 'Sullivan County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47163'),  -- 2010: 156,823
+  ('a0000000-0047-4000-8000-000000000034', 'county', 'Sumner County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47165'),  -- 2010: 160,645
+  ('a0000000-0047-4000-8000-000000000035', 'county', 'Washington County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47179'),  -- 2010: 122,979
+  ('a0000000-0047-4000-8000-000000000036', 'county', 'Williamson County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47187'),  -- 2010: 183,182
+  ('a0000000-0047-4000-8000-000000000037', 'county', 'Wilson County', 'TN', 'a0000000-0047-4000-8000-000000000010', '47189');  -- 2010: 113,993
+
+-- ---------------------------------------------------------------------------
+-- Property tax: the deadline no function can compute.
+--
+-- This is the fact that earned Tennessee its place as the third state. The
+-- county board of equalization CONVENES on a statutory date -- June 1 under
+-- TCA 67-1-404(a), early May in Shelby under 67-1-404(c) -- but it ADJOURNS
+-- when it chooses, and adjournment is the deadline: TCA 67-5-1401 makes
+-- failure to appear before final adjournment a waiver, after which the
+-- assessor's value is conclusive. TCA 67-1-404(b) caps the session at
+-- 6/10/15/up-to-30 days by county population and sets NO minimum, the county
+-- legislative body fixes the length for every county over 35,000, and the
+-- county mayor may extend it. The Comptroller's own handbook notes a board
+-- can adjourn after a single day.
+--
+-- So the operative date is administrative, it differs by county, and it moves
+-- every year: Davidson was June 14 in 2024, June 27 in 2025, June 26 in 2026.
+-- The Comptroller publishes no consolidated list; each assessor publishes its
+-- own. A builder here could only produce a confident wrong answer, and wrong
+-- in the fatal direction -- August 1 (the SECOND-level State Board deadline
+-- under TCA 67-5-1412(e)) is 36 days past Davidson's 2026 date, by which time
+-- the appeal is waived. Tennessee therefore names NO calendar key. It carries
+-- the dates its counties published, and where none is loaded the sweep says
+-- so rather than computing one.
 -- ---------------------------------------------------------------------------
 
 INSERT INTO jurisdiction_rules
   (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
-  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.window.calendar',
-   NULL, 'us-tn.county-board',
-   'TCA 67-1-404(a) (the county board meets June 1); TCA 67-5-1412(e) (the '
-   'State Board filing deadline); TCA 1-3-102 (weekend and holiday extension)',
-   DATE '1973-01-01'),
-  -- Shelby convenes May 1 per the Comptroller's published county-board
-  -- schedule. A statewide row would have told a Memphis owner to wait a
-  -- month past the day the board actually sat.
-  ('a0000000-0047-4000-8000-000000000022', 'assessment_appeal', 'appeal.window.calendar',
-   NULL, 'us-tn.shelby-county-board',
-   'TCA 67-1-404 (session dates); Tennessee Comptroller, county board of '
-   'equalization schedule (Shelby County convenes May 1) — CONFIRM ANNUALLY',
+  -- The state-level rule that turns an absent date into a NAMED gap instead
+  -- of an anonymous one: it tells the reader where the date actually lives.
+  ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.window.source',
+   NULL, 'published_by_county; the county board convenes on a statutory date but '
+   'adjourns on one the county fixes administratively and revises each year, and '
+   'adjournment is the deadline. Confirm the year''s date with the county assessor '
+   'of property.',
+   'TCA 67-1-404(a) (convening); TCA 67-1-404(b) (session length, no minimum); '
+   'TCA 67-5-1401 (failure to appear before adjournment waives the objection)',
    DATE '1973-01-01'),
   ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.form',
    NULL, 'Appeal to the county board of equalization; from its action, appeal '
@@ -75,20 +116,47 @@ INSERT INTO jurisdiction_rules
    'prerequisite to the county board',
    'TCA 67-5-1407 — CONFIRM WITH TN COUNSEL', DATE '1973-01-01'),
   ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.instructions',
-   NULL, 'Appeal to the county board of equalization once it convenes; an appeal '
-   'to the State Board of Equalization must be filed by August 1 of the tax year, '
-   'or within 45 days of the date notice of the local board''s action was sent if '
-   'that is later. The 45-day leg depends on a notice this system has not seen, so '
-   'the scheduled date is the August 1 leg, which is never the later of the two.',
-   'TCA 67-5-1412(e)', DATE '1973-01-01'),
-  -- Two deadlines the sweep does not yet schedule, recorded so the pack does
-  -- not imply August 1 is the only way in. Both hang off a notice date.
+   NULL, 'File with the COUNTY board of equalization on or before it adjourns — '
+   'that is the date that matters, it is set by the county, and it moves each '
+   'year. Appealing to the county board is a prerequisite (TCA 67-5-1412(b)(1)) '
+   'unless the assessor never sent notice of the increase or reclassification. '
+   'August 1 is the SECOND-level deadline, for appealing the county board''s '
+   'action to the State Board of Equalization — it is not the date to file.',
+   'TCA 67-5-1412(b)(1); TCA 67-5-1412(e)', DATE '1973-01-01'),
+  -- Recorded so the pack does not imply the county board is the only way in.
   ('a0000000-0047-4000-8000-000000000010', 'assessment_appeal', 'appeal.direct_to_state_days',
    45, 'where notice of a change was sent later than ten days before the local '
    'board adjourned, the taxpayer may appeal directly to the State Board within '
    '45 days of the notice; where no notice was sent, within 45 days of the tax '
-   'billing date',
-   'TCA 67-5-1412(b)', DATE '1973-01-01');
+   'billing date. On a showing of reasonable cause the State Board may accept a '
+   'late appeal up to March 1 of the following year — a contested safety valve, '
+   'not a deadline to rely on.',
+   'TCA 67-5-1412(e)', DATE '1973-01-01');
+
+-- The dates themselves, one county and one year at a time, each from the
+-- county that published it. The opens/closes pair is matched on
+-- effective_from, which is what makes two rows one window.
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from, effective_to) VALUES
+  ('a0000000-0047-4000-8000-000000000021', 'assessment_appeal', 'appeal.window.opens_on',
+   NULL, '2026-05-26',
+   'Metropolitan Board of Equalization, tax year 2026: scheduling opens May 26, '
+   '2026 (Assessor of Property, Davidson County)', DATE '2026-01-01', DATE '2027-01-01'),
+  ('a0000000-0047-4000-8000-000000000021', 'assessment_appeal', 'appeal.window.closes_on',
+   NULL, '2026-06-26',
+   'Metropolitan Board of Equalization, tax year 2026: appointments must be '
+   'scheduled by June 26, 2026 at 4:00 p.m. (Assessor of Property, Davidson '
+   'County) — CONFIRM ANNUALLY, this date moves every year',
+   DATE '2026-01-01', DATE '2027-01-01'),
+  ('a0000000-0047-4000-8000-000000000022', 'assessment_appeal', 'appeal.window.opens_on',
+   NULL, '2026-05-01',
+   'Shelby County Board of Equalization, tax year 2026: accepting appeals from '
+   'May 1, 2026', DATE '2026-01-01', DATE '2027-01-01'),
+  ('a0000000-0047-4000-8000-000000000022', 'assessment_appeal', 'appeal.window.closes_on',
+   NULL, '2026-06-30',
+   'Shelby County Board of Equalization, tax year 2026 real property petition: '
+   'appeal deadline June 30, 2026 — CONFIRM ANNUALLY, this date moves every year',
+   DATE '2026-01-01', DATE '2027-01-01');
 
 -- ---------------------------------------------------------------------------
 -- Assessment ratio: CLASSIFIED, unlike Kentucky's flat 100% or Ohio's 35%.
@@ -116,8 +184,9 @@ INSERT INTO jurisdiction_rules
    NULL, 'No bright-line rule. Separately parceled single-family homes owned and '
    'managed as one rental enterprise may be classified commercial on all the facts '
    'and circumstances; the assessor weighs them case by case.',
-   'Tenn. Att''y Gen. Op. 25-016 (2025); Spring Hill, L.P. v. State Board of '
-   'Equalization — CONFIRM WITH TN COUNSEL BEFORE RELIANCE', DATE '2025-01-01');
+   'Tenn. Att''y Gen. Op. 25-016 (issued 2025-08-25); Spring Hill, L.P. v. '
+   'State Board of Equalization — CONFIRM WITH TN COUNSEL BEFORE RELIANCE',
+   DATE '2025-08-25');
 
 -- ---------------------------------------------------------------------------
 -- Landlord-tenant: a THIRD adoption shape.
@@ -140,17 +209,29 @@ INSERT INTO jurisdiction_rules
   (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
   ('a0000000-0047-4000-8000-000000000010', 'landlord_tenant_act', 'ltl.statewide',
    NULL, 'false; the act binds only counties above the population threshold, by '
-   'operation of the statute rather than by local adoption, and preempts '
-   'conflicting local ordinances where it applies',
-   'TCA 66-28-102(a); TCA 66-28-102(e) (preemption, effective 2021-07-01)',
-   DATE '1975-07-01');
+   'operation of the statute rather than by local adoption',
+   'TCA 66-28-102(a)', DATE '1975-07-01'),
+  -- Its own row, from its own date: field preemption arrived in 2021 and an
+  -- as_of query before then must not resolve it.
+  ('a0000000-0047-4000-8000-000000000010', 'landlord_tenant_act', 'ltl.preempts_local',
+   NULL, 'true; where the chapter applies it preempts the field and bars '
+   'conflicting local ordinances',
+   'TCA 66-28-102(e) (2021 Tenn. Pub. Acts ch. 182)', DATE '2021-07-01');
 
 INSERT INTO jurisdiction_rules
   (jurisdiction_id, domain, code, value_text, citation, effective_from)
 SELECT id, 'landlord_tenant_act', 'urlta.adopted', 'true',
-       'TCA 66-28-102(a) (the chapter applies in counties over 75,000 by the 2010 '
-       'federal census; Davidson and Shelby are both above it)',
-       DATE '1975-07-01'
+       'TCA 66-28-102(a): the chapter applies in counties over 75,000 by the 2010 '
+       'federal census (2012 Tenn. Pub. Acts ch. 847). 2021 Tenn. Pub. Acts ch. '
+       '182, s.2 deleted "or any subsequent federal census", so the list is FROZEN '
+       'at seventeen counties and can no longer grow. TCA 1-3-116(a)(8) makes the '
+       'as-enumerated 2010 CPH-1-44 figures controlling, unaffected by later '
+       'Census Bureau revision. BEWARE the widely copied nineteen-county list, '
+       'including the one on the Attorney General consumer-laws page: it adds '
+       'Greene (68,831) and Putnam (72,321) and states the repealed 68,000 '
+       'threshold. Putnam passed 75,000 in the 2020 census and is still not '
+       'covered. Every county seeded in this pack is one of the seventeen.',
+       DATE '2012-04-27'
 FROM jurisdictions
 WHERE level = 'county' AND state = 'TN';
 
@@ -183,9 +264,10 @@ FROM jurisdictions j
 CROSS JOIN (VALUES
   ('security_deposit', 'deposit.return_deadline_exists', NULL::NUMERIC,
    'false; the chapter fixes no deadline to return a deposit. What it fixes '
-   'instead is a forfeiture: a landlord who did not hold the deposit in a '
-   'separate account, or who did not give the final damage listing, may retain '
-   'no part of it.',
+   'instead is a forfeiture, and it is conjunctive: a landlord who BOTH failed '
+   'to hold the deposit in a separate account AND failed to give the final '
+   'damage listing may retain no part of it. Either failure alone does not '
+   'trigger it.',
    'TCA 66-28-301(c) — CONFIRM WITH TN COUNSEL', DATE '1975-07-01'),
   ('security_deposit', 'urlta.deposit.separate_account_required', NULL,
    'true', 'TCA 66-28-301(a); TCA 66-28-301(h) (the tenant must be told where '
@@ -193,9 +275,10 @@ CROSS JOIN (VALUES
   ('security_deposit', 'urlta.deposit.itemized_list_required', NULL,
    'true', 'TCA 66-28-301(b)', DATE '1975-07-01'),
   ('security_deposit', 'deposit.inspection_notice_days', 5,
-   'the landlord must tell the tenant of the right to inspect within five days '
-   'of receiving notice to vacate; the inspection happens on the vacate day or '
-   'within four calendar days after',
+   'the landlord MAY tell the tenant of the right to inspect within five days '
+   'of receiving notice to vacate; the statute is permissive, not a duty. Where '
+   'notice is given the inspection happens on the vacate day or within four '
+   'calendar days after.',
    'TCA 66-28-301(b)', DATE '1975-07-01'),
   ('security_deposit', 'deposit.unclaimed_notification_days', 60,
    'where a refund is due, the landlord sends notice to the last known address; '
@@ -206,26 +289,36 @@ CROSS JOIN (VALUES
 WHERE j.level = 'county' AND j.state = 'TN';
 
 -- ---------------------------------------------------------------------------
--- Notice periods. The URLTA numbers are on the counties; the non-URLTA
--- numbers are on the state, so a property in an unseeded Tennessee county
--- resolves to TCA 66-7-109 rather than borrowing Nashville's law.
+-- Notice periods. Every one sits on a COUNTY row, because in Tennessee the
+-- county is what decides which chapter applies — the same discipline Kentucky
+-- uses for its municipal adoptions, reached by a different route.
 --
 -- Note that the fourteen-day cure / thirty-day termination structure people
--- remember is the NON-URLTA rule. Under the current chapter 28 both legs are
--- fourteen days, with seven for a repeat of the same breach inside six
--- months.
+-- remember is the NON-URLTA rule (TCA 66-7-109). Under the current chapter 28
+-- both legs are fourteen days, with seven for a repeat of the same breach
+-- inside six months.
 -- ---------------------------------------------------------------------------
 
+-- Deliberately NOT on the state row: the notice periods themselves.
+--
+-- The two answers differ — fourteen days to cure under TCA 66-28-505(a)(2) in
+-- a covered county, against 66-7-109's fourteen-for-listed-causes and
+-- thirty-for-everything-else elsewhere — and 66-7-109(g) says in as many
+-- words that it does not reach the seventeen. A statewide row would hand one
+-- of those answers to every Tennessee property, so the state carries only the
+-- RULE FOR CHOOSING and an unplaceable property gets a gap rather than
+-- somebody else's statute.
 INSERT INTO jurisdiction_rules
   (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
-  ('a0000000-0047-4000-8000-000000000010', 'notice_period', 'eviction.notice_days',
-   14, 'non-URLTA counties: fourteen days for rent in arrears on demand, for '
-   'damage beyond normal wear and tear, and for violent acts or a real and '
-   'present danger to health or safety',
-   'TCA 66-7-109(a)(1); TCA 66-7-109(g)', DATE '1975-07-01'),
-  ('a0000000-0047-4000-8000-000000000010', 'notice_period', 'eviction.other_default_days',
-   30, 'non-URLTA counties: thirty days for all other defaults',
-   'TCA 66-7-109(b)', DATE '1975-07-01');
+  ('a0000000-0047-4000-8000-000000000010', 'landlord_tenant_act', 'ltl.applies_by',
+   NULL, 'county_population; a Tennessee property must be resolved to its county '
+   'before any notice, deposit or eviction period can be answered. In the '
+   'seventeen counties over 75,000 by the 2010 census the URLTA (TCA ch. 66-28) '
+   'governs; everywhere else TCA 66-7-109 does — fourteen days for rent in '
+   'arrears, damage beyond normal wear and tear, or a real and present danger, '
+   'and thirty days for every other default.',
+   'TCA 66-28-102(a); TCA 66-7-109(a)(1); TCA 66-7-109(b); TCA 66-7-109(g)',
+   DATE '2012-04-27');
 
 INSERT INTO jurisdiction_rules
   (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)

--- a/packages/domain/schema/seed/README.md
+++ b/packages/domain/schema/seed/README.md
@@ -28,7 +28,13 @@ pack file is picked up with zero code changes.
 3. **Calendar registry entries** iff the state's window fits no existing
    builder — one pure function in `packages/engines/src/deadlines.ts` and one
    in `services/api/hestia_api/calendar.py`, each with two externally
-   verified anchor dates.
+   verified anchor dates. A key may be seeded at ANY level, not just the
+   state: Tennessee's Shelby County convenes a month before the rest of the
+   state, so `seed/907` puts `us-tn.shelby-county-board` on the county row
+   and depth-first chain resolution prefers it. Give a deviation its own key
+   rather than parameterising one builder — two callers whose authorities
+   differ are two rules, and a single function pretending otherwise cannot
+   cite either honestly.
 4. **A pack test** — `tests/packs/xx.sql`, the Newport-vs-Campbell pattern:
    the chain resolves through `jurisdiction_chain()`, the calendar key /
    ratio / conformity discriminator resolve to the seeded values, and at

--- a/packages/domain/schema/seed/README.md
+++ b/packages/domain/schema/seed/README.md
@@ -25,16 +25,33 @@ pack file is picked up with zero code changes.
    - `assessment_ratio`, landlord-tenant rows (statewide act or adoption map,
      whatever the state's structure), `income_tax` (state and, where real,
      municipal rows), `depreciation_conformity` incl. `conformity_kind`.
-3. **Calendar registry entries** iff the state's window fits no existing
-   builder — one pure function in `packages/engines/src/deadlines.ts` and one
-   in `services/api/hestia_api/calendar.py`, each with two externally
-   verified anchor dates. A key may be seeded at ANY level, not just the
-   state: Tennessee's Shelby County convenes a month before the rest of the
-   state, so `seed/907` puts `us-tn.shelby-county-board` on the county row
-   and depth-first chain resolution prefers it. Give a deviation its own key
-   rather than parameterising one builder — two callers whose authorities
-   differ are two rules, and a single function pretending otherwise cannot
-   cite either honestly.
+3. **An appeal window, in one of three shapes.** Pick by asking what
+   actually determines the date:
+   - *Computed.* The deadline is a function of the year, so the pack names a
+     registry key in `appeal.window.calendar` and the two twins
+     (`packages/engines/src/deadlines.ts` and
+     `services/api/hestia_api/calendar.py`) each carry one pure builder with
+     two externally verified anchor dates. Kentucky and Ohio are this shape.
+     Keys are timeless function identities: a statutory change is a NEW key
+     behind a new effective-dated rule row, never an edit to a builder.
+   - *Published.* The deadline is an administrative decision somebody makes
+     and revises, so no function can be right. The pack carries the dates as
+     data — `appeal.window.opens_on` and `appeal.window.closes_on`, matched
+     into one window by a shared `effective_from`, each bounded by
+     `effective_to` so a date cannot outlive its year — plus
+     `appeal.window.source` on the state row saying where the date comes
+     from. Tennessee is this shape: its county boards convene on a statutory
+     date but adjourn when they choose, and adjournment is the deadline
+     (`seed/907`).
+   - *Neither yet.* Seed `appeal.window.source` alone. The sweep reports
+     `window_not_published`, which tells a reader where to go looking
+     instead of implying the state has no appeal law.
+
+   A rule may be seeded at ANY level, not just the state — depth-first chain
+   resolution prefers the nearer row, so a county that differs from its state
+   simply carries its own. Never parameterise one builder across two
+   authorities: two callers whose sources differ are two rules, and a single
+   function pretending otherwise cannot cite either honestly.
 4. **A pack test** — `tests/packs/xx.sql`, the Newport-vs-Campbell pattern:
    the chain resolves through `jurisdiction_chain()`, the calendar key /
    ratio / conformity discriminator resolve to the seeded values, and at

--- a/packages/domain/schema/tests/packs/tennessee.sql
+++ b/packages/domain/schema/tests/packs/tennessee.sql
@@ -1,0 +1,247 @@
+-- ===========================================================================
+--  Pack test — Tennessee (seed/907_jurisdictions_tennessee.sql).
+--
+--  Two states can agree by accident; three cannot. This asserts the
+--  three-way divergence: from ONE query shape, Newport, Cincinnati and
+--  Nashville resolve to three appeal calendars, three conformity regimes and
+--  three landlord-tenant adoption shapes. It also pins the two facts this
+--  pack was the first to need — a county that disagrees with its state about
+--  a calendar, and a state that answers "no such duty" instead of falling
+--  silent. Read-only.
+-- ===========================================================================
+
+\set ON_ERROR_STOP on
+
+\echo ''
+\echo 'tennessee pack'
+
+CREATE OR REPLACE FUNCTION pg_temp.tn_resolve(city TEXT, rule_code TEXT)
+RETURNS TEXT LANGUAGE sql STABLE AS $fn$
+  SELECT r.value_text
+  FROM jurisdiction_chain(
+    (SELECT id FROM jurisdictions
+      WHERE name = city AND level = 'municipality' LIMIT 1)) c
+  JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+  WHERE r.code = rule_code AND r.superseded_by IS NULL
+  ORDER BY c.depth ASC, r.effective_from DESC
+  LIMIT 1;
+$fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.tn_rule(state_name TEXT, rule_code TEXT)
+RETURNS jurisdiction_rules LANGUAGE sql STABLE AS $fn$
+  SELECT r.* FROM jurisdiction_rules r
+  JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = state_name AND r.code = rule_code AND r.superseded_by IS NULL
+  LIMIT 1;
+$fn$;
+
+DO $$
+DECLARE
+  chain_len INT;
+  tn_key TEXT;
+  memphis_key TEXT;
+  ky_key TEXT;
+  oh_key TEXT;
+  ratio NUMERIC;
+  oh_ratio NUMERIC;
+  conformity TEXT;
+  statewide TEXT;
+  adopted TEXT;
+  interest TEXT;
+  oh_interest TEXT;
+  absent TEXT;
+  income TEXT;
+  fonce TEXT;
+  urlta_notice NUMERIC;
+  non_urlta_notice NUMERIC;
+BEGIN
+  -- Nashville -> Davidson County -> Tennessee -> United States. The
+  -- consolidated metro government is still four levels deep, so resolution
+  -- never has to know that Nashville is unusual.
+  SELECT count(*) INTO chain_len
+  FROM jurisdiction_chain(
+    (SELECT id FROM jurisdictions WHERE name = 'Nashville' AND level = 'municipality'));
+  IF chain_len <> 4 THEN
+    RAISE EXCEPTION 'Nashville chain wrong: % rows', chain_len;
+  END IF;
+  RAISE NOTICE '  ok      the Nashville chain walks four levels to the federal root';
+
+  -- THE THREE-REGIME ASSERT: one query shape, three states, no collisions.
+  tn_key := pg_temp.tn_resolve('Nashville', 'appeal.window.calendar');
+  ky_key := pg_temp.tn_resolve('Newport', 'appeal.window.calendar');
+  oh_key := pg_temp.tn_resolve('Cincinnati', 'appeal.window.calendar');
+  IF tn_key IS DISTINCT FROM 'us-tn.county-board' THEN
+    RAISE EXCEPTION 'Nashville resolves %, expected us-tn.county-board', tn_key;
+  END IF;
+  IF ky_key = oh_key OR oh_key = tn_key OR ky_key = tn_key THEN
+    RAISE EXCEPTION 'three-regime resolution collapsed: KY=%, OH=%, TN=%',
+      ky_key, oh_key, tn_key;
+  END IF;
+  RAISE NOTICE '  ok      three states, three calendars: %, %, %', ky_key, oh_key, tn_key;
+
+  -- THE COUNTY OVERRIDE, which no earlier pack needed: Shelby convenes a
+  -- month before the rest of Tennessee, so the county row wins over its own
+  -- state's. Nothing in the resolver changed to allow it — depth-first
+  -- ordering already prefers the nearer row, and this proves it.
+  memphis_key := pg_temp.tn_resolve('Memphis', 'appeal.window.calendar');
+  IF memphis_key IS DISTINCT FROM 'us-tn.shelby-county-board' THEN
+    RAISE EXCEPTION 'Memphis resolves %, expected the Shelby County override',
+      memphis_key;
+  END IF;
+  IF memphis_key = tn_key THEN
+    RAISE EXCEPTION 'the Shelby override collapsed into the state calendar';
+  END IF;
+  RAISE NOTICE '  ok      a county overrides its own state calendar: Shelby sits May 1';
+
+  -- Every registry key a pack names must be shaped like one. A typo here is
+  -- a silent coverage gap at sweep time, not an error.
+  IF tn_key !~ '^us-[a-z]{2}\.[a-z0-9-]+$' OR memphis_key !~ '^us-[a-z]{2}\.[a-z0-9-]+$' THEN
+    RAISE EXCEPTION 'a Tennessee calendar key is not a registry key: %, %',
+      tn_key, memphis_key;
+  END IF;
+  RAISE NOTICE '  ok      both calendar keys are well formed';
+
+  -- Classified assessment. The line is RENTAL UNIT COUNT, not occupancy:
+  -- one rental unit is residential at 25%, two or more is commercial at 40%.
+  ratio := (pg_temp.tn_rule('Tennessee', 'assessment.ratio')).value_numeric;
+  oh_ratio := (pg_temp.tn_rule('Ohio', 'assessment.ratio')).value_numeric;
+  IF ratio IS DISTINCT FROM 0.25::NUMERIC OR ratio = oh_ratio THEN
+    RAISE EXCEPTION 'Tennessee residential ratio is % (Ohio %), expected 0.25 and distinct',
+      ratio, oh_ratio;
+  END IF;
+  IF (pg_temp.tn_rule('Tennessee', 'assessment.ratio.commercial')).value_numeric
+     IS DISTINCT FROM 0.40::NUMERIC THEN
+    RAISE EXCEPTION 'the Tennessee commercial ratio row is missing or wrong';
+  END IF;
+  -- The caveat travels WITH the ratio, or the platform states 25% with a
+  -- confidence the law does not support.
+  IF (pg_temp.tn_rule('Tennessee', 'assessment.ratio.caveat')).citation
+     NOT LIKE '%25-016%' THEN
+    RAISE EXCEPTION 'the classification caveat is missing its authority';
+  END IF;
+  RAISE NOTICE '  ok      25 percent residential, 40 commercial, and the caveat that qualifies them';
+
+  -- Conformity: three regimes across three states, none of them silence.
+  conformity := (pg_temp.tn_rule('Tennessee', 'depreciation.conformity_kind')).value_text;
+  IF conformity IS DISTINCT FROM 'none' THEN
+    RAISE EXCEPTION 'Tennessee conformity is %, expected none', conformity;
+  END IF;
+  IF (SELECT count(DISTINCT r.value_text)
+      FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+      WHERE j.name IN ('Kentucky', 'Ohio', 'Tennessee')
+        AND r.code = 'depreciation.conformity_kind' AND r.superseded_by IS NULL) <> 3 THEN
+    RAISE EXCEPTION 'the three conformity regimes are not distinct';
+  END IF;
+  -- "None" is the OWNER's answer. The entity still meets an excise-tax
+  -- addback, and folding the two into one verdict would be wrong for one
+  -- reader or the other.
+  IF (pg_temp.tn_rule('Tennessee', 'depreciation.entity_bonus_addback')).value_text
+     NOT LIKE 'true;%' THEN
+    RAISE EXCEPTION 'the entity-level bonus addback is missing';
+  END IF;
+  RAISE NOTICE '  ok      frozen, addback-recovery and none are three regimes';
+
+  -- No individual income tax: recorded as a finding, not left blank.
+  income := (pg_temp.tn_rule('Tennessee', 'income.type')).value_text;
+  IF income IS NULL OR income NOT LIKE 'none;%' THEN
+    RAISE EXCEPTION 'Tennessee income.type is %, expected a stated none', income;
+  END IF;
+  -- Two definitions of "residential" in one state code: four units for the
+  -- FONCE exemption, one rental unit for the assessment ratio. The pack must
+  -- carry both or the platform will quietly conflate them.
+  fonce := (pg_temp.tn_rule('Tennessee', 'income.entity_exemption')).value_text;
+  IF fonce IS NULL OR fonce NOT LIKE '%FOUR residential%' THEN
+    RAISE EXCEPTION 'the FONCE four-unit definition is not recorded';
+  END IF;
+  RAISE NOTICE '  ok      no individual income tax, and the entity taxes that remain';
+
+  -- THE THIRD ADOPTION SHAPE: not statewide (Ohio), not municipal opt-in
+  -- (Kentucky) — the county carries it, by population, by operation of law.
+  statewide := (pg_temp.tn_rule('Tennessee', 'ltl.statewide')).value_text;
+  IF statewide IS NULL OR statewide NOT LIKE 'false;%' THEN
+    RAISE EXCEPTION 'Tennessee ltl.statewide is %, expected a stated false', statewide;
+  END IF;
+  adopted := pg_temp.tn_resolve('Nashville', 'urlta.adopted');
+  IF adopted IS DISTINCT FROM 'true' THEN
+    RAISE EXCEPTION 'Nashville resolves urlta.adopted = %, expected true', adopted;
+  END IF;
+  -- Kentucky's counties deny what their cities adopt; Tennessee's counties
+  -- are the ones that carry it. Same rule code, opposite level — which is
+  -- why resolution walks a chain instead of switching on a state literal.
+  IF (SELECT r.value_text
+      FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+      WHERE j.name = 'Campbell County' AND r.code = 'urlta.adopted'
+        AND r.superseded_by IS NULL) <> 'false' THEN
+    RAISE EXCEPTION 'the Kentucky county contrast has moved; this test is stale';
+  END IF;
+  RAISE NOTICE '  ok      a third adoption shape: the county carries it, not the city';
+
+  -- And because the act binds by county, the county is where its numbers
+  -- live. A Tennessee property in an unseeded county must resolve PAST them
+  -- to the non-URLTA statute, which is the law that actually governs it.
+  urlta_notice := (
+    SELECT r.value_numeric
+    FROM jurisdiction_chain(
+      (SELECT id FROM jurisdictions WHERE name = 'Nashville' AND level = 'municipality')) c
+    JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+    WHERE r.code = 'urlta.notice.nonpayment_days' AND r.superseded_by IS NULL
+    ORDER BY c.depth ASC LIMIT 1);
+  non_urlta_notice := (pg_temp.tn_rule('Tennessee', 'eviction.other_default_days')).value_numeric;
+  IF urlta_notice IS DISTINCT FROM 14::NUMERIC OR non_urlta_notice IS DISTINCT FROM 30::NUMERIC THEN
+    RAISE EXCEPTION 'Tennessee notice periods drifted: URLTA %, non-URLTA other %',
+      urlta_notice, non_urlta_notice;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.name = 'Tennessee' AND r.code LIKE 'urlta.%'
+  ) THEN
+    RAISE EXCEPTION 'a URLTA rule is seeded on the Tennessee STATE row; a property '
+      'in a county below the population threshold would inherit law that does not '
+      'reach it';
+  END IF;
+  RAISE NOTICE '  ok      URLTA rules sit on the counties, non-URLTA law on the state';
+
+  -- "No interest is owed" and "no deadline exists" are FINDINGS. Ohio says
+  -- interest is owed, Tennessee says it is not, and neither is silence —
+  -- that distinction is what lets the deposit panel tell an owner nothing is
+  -- owed rather than nothing is known.
+  interest := (pg_temp.tn_rule('Tennessee', 'deposit.interest_required')).value_text;
+  oh_interest := (pg_temp.tn_rule('Ohio', 'deposit.interest_required')).value_text;
+  IF interest NOT LIKE 'false;%' OR oh_interest NOT LIKE 'true;%' THEN
+    RAISE EXCEPTION 'deposit interest: TN=%, OH=% — expected a stated false and true',
+      interest, oh_interest;
+  END IF;
+  absent := pg_temp.tn_resolve('Nashville', 'deposit.return_deadline_exists');
+  IF absent IS NULL OR absent NOT LIKE 'false;%' THEN
+    RAISE EXCEPTION 'Tennessee does not state that it fixes no return deadline';
+  END IF;
+  -- And it must not ALSO carry a return period: the widely repeated "thirty
+  -- days" belongs to the later-discovered-damage window, not to a duty to pay.
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.state = 'TN' AND r.code = 'deposit.return_days'
+  ) THEN
+    RAISE EXCEPTION 'a Tennessee deposit.return_days rule exists; no statute fixes one';
+  END IF;
+  RAISE NOTICE '  ok      no interest and no return deadline, both stated rather than missing';
+
+  -- Every rule this pack seeds carries an authority. A rule without one is
+  -- an opinion, and the NOT NULL alone would let an empty string through.
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.state = 'TN' AND btrim(r.citation) = ''
+  ) THEN
+    RAISE EXCEPTION 'a Tennessee rule carries an empty citation';
+  END IF;
+  -- Citations spell the section out. The section sign does not survive every
+  -- terminal, log and PDF this text passes through, and a citation that
+  -- arrives mangled is a citation nobody can follow.
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.state = 'TN' AND (r.citation LIKE '%' || chr(167) || '%'
+                              OR r.value_text LIKE '%' || chr(167) || '%')
+  ) THEN
+    RAISE EXCEPTION 'a Tennessee citation uses the section sign; spell it s.NN';
+  END IF;
+  RAISE NOTICE '  ok      every Tennessee rule cites its authority, spelled out';
+END $$;

--- a/packages/domain/schema/tests/packs/tennessee.sql
+++ b/packages/domain/schema/tests/packs/tennessee.sql
@@ -39,9 +39,12 @@ DO $$
 DECLARE
   chain_len INT;
   tn_key TEXT;
-  memphis_key TEXT;
   ky_key TEXT;
   oh_key TEXT;
+  source_kind TEXT;
+  nash_opens DATE;
+  nash_closes DATE;
+  memphis_closes DATE;
   ratio NUMERIC;
   oh_ratio NUMERIC;
   conformity TEXT;
@@ -53,7 +56,8 @@ DECLARE
   income TEXT;
   fonce TEXT;
   urlta_notice NUMERIC;
-  non_urlta_notice NUMERIC;
+  covered_counties INT;
+  hamiltons INT;
 BEGIN
   -- Nashville -> Davidson County -> Tennessee -> United States. The
   -- consolidated metro government is still four levels deep, so resolution
@@ -66,48 +70,95 @@ BEGIN
   END IF;
   RAISE NOTICE '  ok      the Nashville chain walks four levels to the federal root';
 
-  -- THE THREE-REGIME ASSERT: one query shape, three states, no collisions.
-  tn_key := pg_temp.tn_resolve('Nashville', 'appeal.window.calendar');
+  -- THE THREE-REGIME ASSERT: one query shape, three states, three answers —
+  -- and Tennessee's answer is that there is no function to name.
   ky_key := pg_temp.tn_resolve('Newport', 'appeal.window.calendar');
   oh_key := pg_temp.tn_resolve('Cincinnati', 'appeal.window.calendar');
-  IF tn_key IS DISTINCT FROM 'us-tn.county-board' THEN
-    RAISE EXCEPTION 'Nashville resolves %, expected us-tn.county-board', tn_key;
+  tn_key := pg_temp.tn_resolve('Nashville', 'appeal.window.calendar');
+  IF ky_key = oh_key THEN
+    RAISE EXCEPTION 'Kentucky and Ohio calendars collapsed at %', ky_key;
   END IF;
-  IF ky_key = oh_key OR oh_key = tn_key OR ky_key = tn_key THEN
-    RAISE EXCEPTION 'three-regime resolution collapsed: KY=%, OH=%, TN=%',
-      ky_key, oh_key, tn_key;
+  IF tn_key IS NOT NULL THEN
+    RAISE EXCEPTION 'Tennessee names calendar %, but its deadline is an '
+      'administrative date no builder may compute', tn_key;
   END IF;
-  RAISE NOTICE '  ok      three states, three calendars: %, %, %', ky_key, oh_key, tn_key;
+  RAISE NOTICE '  ok      two computed calendars, and a third state that names none';
 
-  -- THE COUNTY OVERRIDE, which no earlier pack needed: Shelby convenes a
-  -- month before the rest of Tennessee, so the county row wins over its own
-  -- state's. Nothing in the resolver changed to allow it — depth-first
-  -- ordering already prefers the nearer row, and this proves it.
-  memphis_key := pg_temp.tn_resolve('Memphis', 'appeal.window.calendar');
-  IF memphis_key IS DISTINCT FROM 'us-tn.shelby-county-board' THEN
-    RAISE EXCEPTION 'Memphis resolves %, expected the Shelby County override',
-      memphis_key;
+  -- Instead it says WHY, so an absent date is a named gap and not silence.
+  source_kind := pg_temp.tn_resolve('Nashville', 'appeal.window.source');
+  IF source_kind IS NULL OR source_kind NOT LIKE 'published_by_county;%' THEN
+    RAISE EXCEPTION 'Tennessee does not say where its appeal date comes from: %',
+      source_kind;
   END IF;
-  IF memphis_key = tn_key THEN
-    RAISE EXCEPTION 'the Shelby override collapsed into the state calendar';
-  END IF;
-  RAISE NOTICE '  ok      a county overrides its own state calendar: Shelby sits May 1';
 
-  -- Every registry key a pack names must be shaped like one. A typo here is
-  -- a silent coverage gap at sweep time, not an error.
-  IF tn_key !~ '^us-[a-z]{2}\.[a-z0-9-]+$' OR memphis_key !~ '^us-[a-z]{2}\.[a-z0-9-]+$' THEN
-    RAISE EXCEPTION 'a Tennessee calendar key is not a registry key: %, %',
-      tn_key, memphis_key;
+  -- THE PUBLISHED WINDOW: a real date, from the county that published it,
+  -- paired to its open by effective_from. This is the county-level fact no
+  -- earlier pack needed, and the one a function would have got wrong.
+  SELECT closes.value_text::date, opens.value_text::date
+    INTO nash_closes, nash_opens
+  FROM jurisdiction_chain(
+    (SELECT id FROM jurisdictions WHERE name = 'Nashville' AND level = 'municipality')) c
+  JOIN jurisdiction_rules closes ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.code = 'appeal.window.closes_on' AND closes.superseded_by IS NULL
+  LEFT JOIN jurisdiction_rules opens ON opens.jurisdiction_id = closes.jurisdiction_id
+   AND opens.code = 'appeal.window.opens_on' AND opens.superseded_by IS NULL
+   AND opens.effective_from = closes.effective_from
+  ORDER BY c.depth ASC, closes.value_text::date ASC
+  LIMIT 1;
+  IF nash_closes IS DISTINCT FROM DATE '2026-06-26' THEN
+    RAISE EXCEPTION 'Davidson County 2026 closes %, expected 2026-06-26', nash_closes;
   END IF;
-  RAISE NOTICE '  ok      both calendar keys are well formed';
+  IF nash_opens IS DISTINCT FROM DATE '2026-05-26' THEN
+    RAISE EXCEPTION 'the Davidson 2026 open did not pair with its close: %', nash_opens;
+  END IF;
+  -- The August 1 State Board date must never masquerade as the filing
+  -- deadline: it is 36 days later, and by then the objection is waived.
+  IF nash_closes >= DATE '2026-08-01' THEN
+    RAISE EXCEPTION 'the Davidson deadline is not earlier than the State Board date';
+  END IF;
+  RAISE NOTICE '  ok      Davidson 2026 closes June 26, a month before the State Board date';
+
+  -- Shelby publishes its own, and it differs. A statewide date would have
+  -- been wrong for at least one of them.
+  SELECT closes.value_text::date INTO memphis_closes
+  FROM jurisdiction_chain(
+    (SELECT id FROM jurisdictions WHERE name = 'Memphis' AND level = 'municipality')) c
+  JOIN jurisdiction_rules closes ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.code = 'appeal.window.closes_on' AND closes.superseded_by IS NULL
+  ORDER BY c.depth ASC, closes.value_text::date ASC
+  LIMIT 1;
+  IF memphis_closes IS DISTINCT FROM DATE '2026-06-30' THEN
+    RAISE EXCEPTION 'Shelby County 2026 closes %, expected 2026-06-30', memphis_closes;
+  END IF;
+  IF memphis_closes = nash_closes THEN
+    RAISE EXCEPTION 'two counties in one state resolved to the same published date';
+  END IF;
+  RAISE NOTICE '  ok      two counties, two published dates, four days apart';
+
+  -- Every published date is bounded by its own year: one that outlived it
+  -- would go on being served as though it were still the answer.
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.state = 'TN' AND r.code IN ('appeal.window.opens_on', 'appeal.window.closes_on')
+      AND (r.effective_to IS NULL
+           OR r.value_text::date < r.effective_from
+           OR r.value_text::date >= r.effective_to)
+  ) THEN
+    RAISE EXCEPTION 'a published Tennessee window is unbounded or outside its own year';
+  END IF;
+  RAISE NOTICE '  ok      every published date is bounded by the year it belongs to';
 
   -- Classified assessment. The line is RENTAL UNIT COUNT, not occupancy:
   -- one rental unit is residential at 25%, two or more is commercial at 40%.
   ratio := (pg_temp.tn_rule('Tennessee', 'assessment.ratio')).value_numeric;
   oh_ratio := (pg_temp.tn_rule('Ohio', 'assessment.ratio')).value_numeric;
-  IF ratio IS DISTINCT FROM 0.25::NUMERIC OR ratio = oh_ratio THEN
-    RAISE EXCEPTION 'Tennessee residential ratio is % (Ohio %), expected 0.25 and distinct',
-      ratio, oh_ratio;
+  IF ratio IS DISTINCT FROM 0.25::NUMERIC THEN
+    RAISE EXCEPTION 'Tennessee residential ratio is %, expected 0.25', ratio;
+  END IF;
+  -- Ohio's is pinned by its own pack test; this one only has to prove the
+  -- two states do not share a row, which a mis-scoped seed would break.
+  IF oh_ratio IS NULL OR ratio = oh_ratio THEN
+    RAISE EXCEPTION 'Tennessee and Ohio ratios collapsed at %', ratio;
   END IF;
   IF (pg_temp.tn_rule('Tennessee', 'assessment.ratio.commercial')).value_numeric
      IS DISTINCT FROM 0.40::NUMERIC THEN
@@ -177,8 +228,59 @@ BEGIN
   RAISE NOTICE '  ok      a third adoption shape: the county carries it, not the city';
 
   -- And because the act binds by county, the county is where its numbers
-  -- live. A Tennessee property in an unseeded county must resolve PAST them
-  -- to the non-URLTA statute, which is the law that actually governs it.
+  -- live — for ALL SEVENTEEN counties the chapter reaches, not just the two
+  -- with property in them. A county missing from this table is a county whose
+  -- landlord would be handed the law of a chapter that disclaims him.
+  SELECT count(*) INTO covered_counties
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.state = 'TN' AND j.level = 'county'
+    AND r.code = 'urlta.adopted' AND r.value_text = 'true'
+    AND r.superseded_by IS NULL;
+  IF covered_counties <> 17 THEN
+    RAISE EXCEPTION 'the URLTA county list is % rows, expected the frozen seventeen',
+      covered_counties;
+  END IF;
+  -- Anderson clears the threshold by 129 people and Putnam misses it by
+  -- 2,679 despite passing 75,000 in the 2020 census — the two counties that
+  -- prove the list is read from the 2010 figures and is frozen there.
+  IF NOT EXISTS (
+    SELECT 1 FROM jurisdictions WHERE state = 'TN' AND name = 'Anderson County'
+  ) THEN
+    RAISE EXCEPTION 'Anderson County is missing; it qualifies by 129 people';
+  END IF;
+  -- The nineteen-county list circulating in secondary sources — including
+  -- the Attorney General's own consumer-laws page — adds these two on the
+  -- repealed 68,000 threshold. Whoever next "corrects" this pack against that
+  -- page must fail here instead of succeeding.
+  IF EXISTS (
+    SELECT 1 FROM jurisdictions WHERE state = 'TN'
+      AND name IN ('Putnam County', 'Greene County')
+  ) THEN
+    RAISE EXCEPTION 'Putnam or Greene is seeded. Both are on the widely copied '
+      'nineteen-county list and neither qualifies: 2021 Pub. Ch. 182 froze the '
+      'threshold at the 2010 census, where Putnam was 72,321 and Greene 68,831';
+  END IF;
+  RAISE NOTICE '  ok      all seventeen URLTA counties, and not the one that just missed';
+
+  -- This pack introduces the first county name shared by two states: Hamilton
+  -- County is in Ohio and in Tennessee. Anything that looks a county up by
+  -- name alone now has two answers, so pin that they are distinct rows under
+  -- distinct parents before something starts resolving by name.
+  SELECT count(*) INTO hamiltons FROM jurisdictions WHERE name = 'Hamilton County';
+  IF hamiltons <> 2 THEN
+    RAISE EXCEPTION 'expected Hamilton County in two states, found %', hamiltons;
+  END IF;
+  IF (SELECT count(DISTINCT state) FROM jurisdictions WHERE name = 'Hamilton County') <> 2 THEN
+    RAISE EXCEPTION 'the two Hamilton Counties are not in two states';
+  END IF;
+  IF (SELECT j.state FROM jurisdiction_chain(
+        (SELECT id FROM jurisdictions WHERE name = 'Cincinnati' AND level = 'municipality')) c
+      JOIN jurisdictions j ON j.id = c.jurisdiction_id
+      WHERE j.level = 'county') <> 'OH' THEN
+    RAISE EXCEPTION 'Cincinnati resolved through the wrong Hamilton County';
+  END IF;
+  RAISE NOTICE '  ok      two Hamilton Counties, and the chain still tells them apart';
+
   urlta_notice := (
     SELECT r.value_numeric
     FROM jurisdiction_chain(
@@ -186,20 +288,29 @@ BEGIN
     JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
     WHERE r.code = 'urlta.notice.nonpayment_days' AND r.superseded_by IS NULL
     ORDER BY c.depth ASC LIMIT 1);
-  non_urlta_notice := (pg_temp.tn_rule('Tennessee', 'eviction.other_default_days')).value_numeric;
-  IF urlta_notice IS DISTINCT FROM 14::NUMERIC OR non_urlta_notice IS DISTINCT FROM 30::NUMERIC THEN
-    RAISE EXCEPTION 'Tennessee notice periods drifted: URLTA %, non-URLTA other %',
-      urlta_notice, non_urlta_notice;
+  IF urlta_notice IS DISTINCT FROM 14::NUMERIC THEN
+    RAISE EXCEPTION 'Tennessee URLTA nonpayment notice is %, expected 14', urlta_notice;
   END IF;
+  -- Nothing act-dependent may sit on the STATE row. The two regimes disagree
+  -- and TCA 66-7-109(g) disclaims itself in the covered counties, so a
+  -- statewide number would be wrong for one side or the other; a property
+  -- this system cannot place in a county must get a gap, not a guess.
   IF EXISTS (
     SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
-    WHERE j.name = 'Tennessee' AND r.code LIKE 'urlta.%'
+    WHERE j.name = 'Tennessee' AND j.level = 'state'
+      AND (r.code LIKE 'urlta.%' OR r.code LIKE 'eviction.%'
+           OR r.code LIKE 'deposit.return%' OR r.code = 'rent.grace_period_days')
   ) THEN
-    RAISE EXCEPTION 'a URLTA rule is seeded on the Tennessee STATE row; a property '
-      'in a county below the population threshold would inherit law that does not '
-      'reach it';
+    RAISE EXCEPTION 'an act-dependent rule sits on the Tennessee STATE row; a '
+      'property that cannot be placed in a county would inherit a statute that '
+      'may not reach it';
   END IF;
-  RAISE NOTICE '  ok      URLTA rules sit on the counties, non-URLTA law on the state';
+  -- But the state must still say HOW to choose, or the gap is anonymous.
+  IF (pg_temp.tn_rule('Tennessee', 'ltl.applies_by')).value_text
+     NOT LIKE 'county_population;%' THEN
+    RAISE EXCEPTION 'Tennessee does not say what decides which act applies';
+  END IF;
+  RAISE NOTICE '  ok      the counties carry the numbers, the state carries the choice';
 
   -- "No interest is owed" and "no deadline exists" are FINDINGS. Ohio says
   -- interest is owed, Tennessee says it is not, and neither is silence —

--- a/packages/engines/src/deadlines.test.ts
+++ b/packages/engines/src/deadlines.test.ts
@@ -120,6 +120,10 @@ describe('the appeal-window registry', () => {
     });
     const oh = appealWindowBuilder('us-oh.bor-complaint');
     expect(oh?.(2027)).toEqual({ opensOn: '2027-01-01', closesOn: '2027-03-31' });
+    const tn = appealWindowBuilder('us-tn.county-board');
+    expect(tn?.(2028)).toEqual({ opensOn: '2028-06-01', closesOn: '2028-08-01' });
+    const shelby = appealWindowBuilder('us-tn.shelby-county-board');
+    expect(shelby?.(2028)).toEqual({ opensOn: '2028-05-01', closesOn: '2028-08-01' });
     expect(appealWindowBuilder('us-zz.not-a-state')).toBeUndefined();
     expect(appealWindowBuilder('')).toBeUndefined();
   });
@@ -170,6 +174,67 @@ describe('the Ohio pack entry — us-oh.bor-complaint (ORC 5715.19)', () => {
 
   it('bounds its year like every builder', () => {
     expect(() => oh(MAX_YEAR + 1)).toThrow(/year/);
+  });
+});
+
+describe('the Tennessee pack entries — TCA 67-1-404, TCA 67-5-1412', () => {
+  const tn = (year: number) => {
+    const builder = appealWindowBuilder('us-tn.county-board');
+    if (!builder) throw new Error('TN builder must be registered');
+    return builder(year);
+  };
+  const shelby = (year: number) => {
+    const builder = appealWindowBuilder('us-tn.shelby-county-board');
+    if (!builder) throw new Error('Shelby builder must be registered');
+    return builder(year);
+  };
+
+  it('opens June 1 and closes August 1, weekend-extended per TCA 1-3-102', () => {
+    // 2028: June 1 is a Thursday and August 1 a Tuesday; both stand.
+    expect(tn(2028)).toEqual({ opensOn: '2028-06-01', closesOn: '2028-08-01' });
+    // 2027-08-01 is a Sunday; the deadline extends to Monday August 2.
+    expect(tn(2027)).toEqual({ opensOn: '2027-06-01', closesOn: '2027-08-02' });
+    // No conference prerequisite exists in Tennessee.
+    expect(tn(2028).conferenceBy).toBeUndefined();
+  });
+
+  it('rolls the open too, because the board convenes on a business day', () => {
+    // 2030-06-01 is a Saturday; the board sits the following Monday.
+    expect(tn(2030).opensOn).toBe('2030-06-03');
+    expect(dayOfWeek(tn(2030).opensOn)).toBe(1);
+  });
+
+  it('gives Shelby County an earlier open and the same statewide close', () => {
+    // 2028-05-01 is a Monday and stands.
+    expect(shelby(2028)).toEqual({ opensOn: '2028-05-01', closesOn: '2028-08-01' });
+    // 2027-05-01 is a Saturday; the board convenes Monday May 3.
+    expect(shelby(2027).opensOn).toBe('2027-05-03');
+    // TCA 67-5-1412(e) is statewide: the close does not move with the open.
+    expect(shelby(2028).closesOn).toBe(tn(2028).closesOn);
+    expect(toEpochDays(shelby(2028).opensOn)).toBeLessThan(toEpochDays(tn(2028).opensOn));
+  });
+
+  it('never opens or closes on a weekend, in either county calendar', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: MIN_YEAR, max: MAX_YEAR }), (year) => {
+        for (const window of [tn(year), shelby(year)]) {
+          expect(dayOfWeek(window.opensOn)).not.toBe(0);
+          expect(dayOfWeek(window.opensOn)).not.toBe(6);
+          expect(dayOfWeek(window.closesOn)).not.toBe(0);
+          expect(dayOfWeek(window.closesOn)).not.toBe(6);
+          expect(
+            toEpochDays(window.closesOn) - toEpochDays(`${String(year)}-08-01`),
+          ).toBeLessThanOrEqual(2);
+          expect(toEpochDays(window.opensOn)).toBeLessThan(toEpochDays(window.closesOn));
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  it('bounds its year like every builder', () => {
+    expect(() => tn(MAX_YEAR + 1)).toThrow(/year/);
+    expect(() => shelby(MAX_YEAR + 1)).toThrow(/year/);
   });
 });
 

--- a/packages/engines/src/deadlines.test.ts
+++ b/packages/engines/src/deadlines.test.ts
@@ -120,10 +120,10 @@ describe('the appeal-window registry', () => {
     });
     const oh = appealWindowBuilder('us-oh.bor-complaint');
     expect(oh?.(2027)).toEqual({ opensOn: '2027-01-01', closesOn: '2027-03-31' });
-    const tn = appealWindowBuilder('us-tn.county-board');
-    expect(tn?.(2028)).toEqual({ opensOn: '2028-06-01', closesOn: '2028-08-01' });
-    const shelby = appealWindowBuilder('us-tn.shelby-county-board');
-    expect(shelby?.(2028)).toEqual({ opensOn: '2028-05-01', closesOn: '2028-08-01' });
+    // Tennessee registers nothing on purpose: its deadline is an
+    // administrative date a county sets and revises annually, so a builder
+    // there could only produce a confident wrong answer.
+    expect(appealWindowBuilder('us-tn.county-board')).toBeUndefined();
     expect(appealWindowBuilder('us-zz.not-a-state')).toBeUndefined();
     expect(appealWindowBuilder('')).toBeUndefined();
   });
@@ -174,67 +174,6 @@ describe('the Ohio pack entry — us-oh.bor-complaint (ORC 5715.19)', () => {
 
   it('bounds its year like every builder', () => {
     expect(() => oh(MAX_YEAR + 1)).toThrow(/year/);
-  });
-});
-
-describe('the Tennessee pack entries — TCA 67-1-404, TCA 67-5-1412', () => {
-  const tn = (year: number) => {
-    const builder = appealWindowBuilder('us-tn.county-board');
-    if (!builder) throw new Error('TN builder must be registered');
-    return builder(year);
-  };
-  const shelby = (year: number) => {
-    const builder = appealWindowBuilder('us-tn.shelby-county-board');
-    if (!builder) throw new Error('Shelby builder must be registered');
-    return builder(year);
-  };
-
-  it('opens June 1 and closes August 1, weekend-extended per TCA 1-3-102', () => {
-    // 2028: June 1 is a Thursday and August 1 a Tuesday; both stand.
-    expect(tn(2028)).toEqual({ opensOn: '2028-06-01', closesOn: '2028-08-01' });
-    // 2027-08-01 is a Sunday; the deadline extends to Monday August 2.
-    expect(tn(2027)).toEqual({ opensOn: '2027-06-01', closesOn: '2027-08-02' });
-    // No conference prerequisite exists in Tennessee.
-    expect(tn(2028).conferenceBy).toBeUndefined();
-  });
-
-  it('rolls the open too, because the board convenes on a business day', () => {
-    // 2030-06-01 is a Saturday; the board sits the following Monday.
-    expect(tn(2030).opensOn).toBe('2030-06-03');
-    expect(dayOfWeek(tn(2030).opensOn)).toBe(1);
-  });
-
-  it('gives Shelby County an earlier open and the same statewide close', () => {
-    // 2028-05-01 is a Monday and stands.
-    expect(shelby(2028)).toEqual({ opensOn: '2028-05-01', closesOn: '2028-08-01' });
-    // 2027-05-01 is a Saturday; the board convenes Monday May 3.
-    expect(shelby(2027).opensOn).toBe('2027-05-03');
-    // TCA 67-5-1412(e) is statewide: the close does not move with the open.
-    expect(shelby(2028).closesOn).toBe(tn(2028).closesOn);
-    expect(toEpochDays(shelby(2028).opensOn)).toBeLessThan(toEpochDays(tn(2028).opensOn));
-  });
-
-  it('never opens or closes on a weekend, in either county calendar', () => {
-    fc.assert(
-      fc.property(fc.integer({ min: MIN_YEAR, max: MAX_YEAR }), (year) => {
-        for (const window of [tn(year), shelby(year)]) {
-          expect(dayOfWeek(window.opensOn)).not.toBe(0);
-          expect(dayOfWeek(window.opensOn)).not.toBe(6);
-          expect(dayOfWeek(window.closesOn)).not.toBe(0);
-          expect(dayOfWeek(window.closesOn)).not.toBe(6);
-          expect(
-            toEpochDays(window.closesOn) - toEpochDays(`${String(year)}-08-01`),
-          ).toBeLessThanOrEqual(2);
-          expect(toEpochDays(window.opensOn)).toBeLessThan(toEpochDays(window.closesOn));
-        }
-      }),
-      { numRuns: 50 },
-    );
-  });
-
-  it('bounds its year like every builder', () => {
-    expect(() => tn(MAX_YEAR + 1)).toThrow(/year/);
-    expect(() => shelby(MAX_YEAR + 1)).toThrow(/year/);
   });
 });
 

--- a/packages/engines/src/deadlines.ts
+++ b/packages/engines/src/deadlines.ts
@@ -160,6 +160,48 @@ const ohBorComplaint: AppealWindowBuilder = (year) => {
 };
 
 /**
+ * Tennessee's assessment-contest window, in the counties that keep the
+ * statewide calendar. TCA 67-1-404(a): the county board of equalization
+ * meets June 1 each year; the Comptroller, which supervises the boards,
+ * states the board convenes the next business day where June 1 falls on a
+ * weekend, so the OPEN rolls too — unlike Ohio's, where the open is a
+ * statutory date rather than a meeting. TCA 67-5-1412(e): an appeal reaches
+ * the State Board of Equalization only if filed by August 1 of the tax year,
+ * or within forty-five days of the notice of the local board's action if
+ * that is later — a leg that depends on a notice this system has not seen,
+ * so the builder returns the date an owner can rely on without one. TCA
+ * 1-3-102 excludes a last day falling on a Saturday, Sunday or legal
+ * holiday. Anchors: 2028-08-01 is a Tuesday and stands; 2027-08-01 is a
+ * Sunday and rolls to 2027-08-02.
+ */
+const tnCountyBoard: AppealWindowBuilder = (year) => {
+  assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
+  return {
+    opensOn: rollForwardFromWeekend(`${String(year)}-06-01`),
+    closesOn: rollForwardFromWeekend(`${String(year)}-08-01`),
+  };
+};
+
+/**
+ * Shelby County (Memphis) convenes May 1, a month ahead of the rest of
+ * Tennessee — a county-level fact, so the pack overrides the state's
+ * calendar on the Shelby County row and the chain does the rest. The close
+ * is unchanged: TCA 67-5-1412(e) is statewide. Authority is the
+ * Comptroller's published county-board schedule rather than TCA 67-1-404
+ * itself, which is why this is a separate key and not a parameter — a
+ * builder whose two callers disagree about their source would be one
+ * function pretending to be two rules. Anchors: 2027-05-01 is a Saturday and
+ * rolls to 2027-05-03; 2028-05-01 is a Monday and stands.
+ */
+const tnShelbyCountyBoard: AppealWindowBuilder = (year) => {
+  assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
+  return {
+    opensOn: rollForwardFromWeekend(`${String(year)}-05-01`),
+    closesOn: rollForwardFromWeekend(`${String(year)}-08-01`),
+  };
+};
+
+/**
  * The registered builder for a pack's calendar key, or undefined. The table
  * lives inside the function rather than at module scope so that mutation
  * testing can attribute it to covering tests — a module-scope Map is a
@@ -170,6 +212,8 @@ export const appealWindowBuilder = (key: string): AppealWindowBuilder | undefine
   const registry: ReadonlyMap<string, AppealWindowBuilder> = new Map([
     ['us-ky.open-inspection', kyOpenInspection],
     ['us-oh.bor-complaint', ohBorComplaint],
+    ['us-tn.county-board', tnCountyBoard],
+    ['us-tn.shelby-county-board', tnShelbyCountyBoard],
   ]);
   return registry.get(key);
 };

--- a/packages/engines/src/deadlines.ts
+++ b/packages/engines/src/deadlines.ts
@@ -141,6 +141,11 @@ const kyOpenInspection: AppealWindowBuilder = (year) => {
  * (services/api/hestia_api/calendar.py). Keys are timeless function
  * identities — a statutory change is a NEW key behind a new effective-dated
  * rule row, never an edit to an existing builder.
+ *
+ * Some states belong in neither place. Where the deadline is an
+ * administrative decision a county makes and revises each year rather than a
+ * function of the calendar, no builder can be right, and the pack carries the
+ * published date as data instead.
  */
 /**
  * ORC 5715.19(A): a complaint against valuation (DTE Form 1, filed with the
@@ -160,48 +165,6 @@ const ohBorComplaint: AppealWindowBuilder = (year) => {
 };
 
 /**
- * Tennessee's assessment-contest window, in the counties that keep the
- * statewide calendar. TCA 67-1-404(a): the county board of equalization
- * meets June 1 each year; the Comptroller, which supervises the boards,
- * states the board convenes the next business day where June 1 falls on a
- * weekend, so the OPEN rolls too — unlike Ohio's, where the open is a
- * statutory date rather than a meeting. TCA 67-5-1412(e): an appeal reaches
- * the State Board of Equalization only if filed by August 1 of the tax year,
- * or within forty-five days of the notice of the local board's action if
- * that is later — a leg that depends on a notice this system has not seen,
- * so the builder returns the date an owner can rely on without one. TCA
- * 1-3-102 excludes a last day falling on a Saturday, Sunday or legal
- * holiday. Anchors: 2028-08-01 is a Tuesday and stands; 2027-08-01 is a
- * Sunday and rolls to 2027-08-02.
- */
-const tnCountyBoard: AppealWindowBuilder = (year) => {
-  assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
-  return {
-    opensOn: rollForwardFromWeekend(`${String(year)}-06-01`),
-    closesOn: rollForwardFromWeekend(`${String(year)}-08-01`),
-  };
-};
-
-/**
- * Shelby County (Memphis) convenes May 1, a month ahead of the rest of
- * Tennessee — a county-level fact, so the pack overrides the state's
- * calendar on the Shelby County row and the chain does the rest. The close
- * is unchanged: TCA 67-5-1412(e) is statewide. Authority is the
- * Comptroller's published county-board schedule rather than TCA 67-1-404
- * itself, which is why this is a separate key and not a parameter — a
- * builder whose two callers disagree about their source would be one
- * function pretending to be two rules. Anchors: 2027-05-01 is a Saturday and
- * rolls to 2027-05-03; 2028-05-01 is a Monday and stands.
- */
-const tnShelbyCountyBoard: AppealWindowBuilder = (year) => {
-  assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
-  return {
-    opensOn: rollForwardFromWeekend(`${String(year)}-05-01`),
-    closesOn: rollForwardFromWeekend(`${String(year)}-08-01`),
-  };
-};
-
-/**
  * The registered builder for a pack's calendar key, or undefined. The table
  * lives inside the function rather than at module scope so that mutation
  * testing can attribute it to covering tests — a module-scope Map is a
@@ -212,8 +175,6 @@ export const appealWindowBuilder = (key: string): AppealWindowBuilder | undefine
   const registry: ReadonlyMap<string, AppealWindowBuilder> = new Map([
     ['us-ky.open-inspection', kyOpenInspection],
     ['us-oh.bor-complaint', ohBorComplaint],
-    ['us-tn.county-board', tnCountyBoard],
-    ['us-tn.shelby-county-board', tnShelbyCountyBoard],
   ]);
   return registry.get(key);
 };

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -1179,7 +1179,14 @@ class SweepGapOut(BaseModel):
     property_id: uuid.UUID
     state: str
     domain: str
-    reason: Literal["no_state_jurisdiction", "no_rule_for_domain", "calendar_key_unregistered"]
+    reason: Literal[
+        "no_state_jurisdiction",
+        "no_rule_for_domain",
+        "calendar_key_unregistered",
+        # The pack says this state publishes its window rather than
+        # computing it, and no upcoming date is loaded.
+        "window_not_published",
+    ]
     detail: str
 
 

--- a/services/api/hestia_api/calendar.py
+++ b/services/api/hestia_api/calendar.py
@@ -77,6 +77,15 @@ def _ky_open_inspection(year: int) -> WindowDates:
 # plus anchors, here and in the TypeScript twin (packages/engines/src/
 # deadlines.ts). Keys are timeless function identities — a statutory change
 # is a NEW key behind a new effective-dated rule row.
+#
+# Some states belong in NEITHER place. Tennessee's county boards convene on a
+# statutory date but adjourn on one each county fixes administratively and
+# moves every year — Davidson County was June 14 in 2024, June 27 in 2025,
+# June 26 in 2026 — and no statewide list of those dates exists. A builder
+# there could only produce a confident wrong answer, so Tennessee has no key
+# and its pack carries the published dates as data instead (see
+# `appeal.window.closes_on` in seed/907 and the published branch of
+# sweep._appeal_windows).
 def _oh_bor_complaint(year: int) -> WindowDates:
     """ORC 5715.19(A): a complaint against valuation (DTE Form 1, filed with
     the county auditor as clerk of the Board of Revision) may be filed
@@ -92,58 +101,9 @@ def _oh_bor_complaint(year: int) -> WindowDates:
     )
 
 
-def _tn_county_board(year: int) -> WindowDates:
-    """Tennessee's assessment-contest window, in the counties that keep the
-    statewide calendar.
-
-    TCA 67-1-404(a): the county board of equalization meets on June 1 each
-    year and sits until equalization is complete. The Comptroller, which
-    supervises the boards, states the board convenes the next business day
-    where June 1 falls on a weekend, so the OPEN rolls too — unlike Ohio's,
-    where the open is a statutory date rather than a meeting.
-
-    TCA 67-5-1412(e): an appeal from the local board reaches the State Board
-    of Equalization only if filed by August 1 of the tax year, or within
-    forty-five days of the date notice of the local board's action was sent,
-    whichever is later. The forty-five-day leg depends on a notice this
-    system has not seen, so the builder returns the date every Tennessee
-    owner can rely on WITHOUT one — never later than the true deadline.
-
-    TCA 1-3-102 excludes a last day falling on a Saturday, Sunday or legal
-    holiday. Anchors: 2028-08-01 is a Tuesday and stands; 2027-08-01 is a
-    Sunday and rolls to 2027-08-02.
-    """
-    _check_year(year)
-    return WindowDates(
-        opens_on=roll_forward_from_weekend(dt.date(year, 6, 1)),
-        closes_on=roll_forward_from_weekend(dt.date(year, 8, 1)),
-    )
-
-
-def _tn_shelby_county_board(year: int) -> WindowDates:
-    """Shelby County (Memphis) convenes May 1, a month ahead of the rest of
-    Tennessee — a county-level fact, so the pack overrides the state's
-    calendar on the Shelby County row and the chain does the rest. The close
-    is unchanged: TCA 67-5-1412(e) is statewide.
-
-    Authority is the Comptroller's published county-board schedule rather
-    than TCA 67-1-404 itself, which is why this is a separate key and not a
-    parameter — a builder whose two callers disagree about their source
-    would be one function pretending to be two rules. Anchors: 2027-05-01 is
-    a Saturday and rolls to 2027-05-03; 2028-05-01 is a Monday and stands.
-    """
-    _check_year(year)
-    return WindowDates(
-        opens_on=roll_forward_from_weekend(dt.date(year, 5, 1)),
-        closes_on=roll_forward_from_weekend(dt.date(year, 8, 1)),
-    )
-
-
 APPEAL_WINDOWS: dict[str, Callable[[int], WindowDates]] = {
     "us-ky.open-inspection": _ky_open_inspection,
     "us-oh.bor-complaint": _oh_bor_complaint,
-    "us-tn.county-board": _tn_county_board,
-    "us-tn.shelby-county-board": _tn_shelby_county_board,
 }
 
 

--- a/services/api/hestia_api/calendar.py
+++ b/services/api/hestia_api/calendar.py
@@ -92,9 +92,58 @@ def _oh_bor_complaint(year: int) -> WindowDates:
     )
 
 
+def _tn_county_board(year: int) -> WindowDates:
+    """Tennessee's assessment-contest window, in the counties that keep the
+    statewide calendar.
+
+    TCA 67-1-404(a): the county board of equalization meets on June 1 each
+    year and sits until equalization is complete. The Comptroller, which
+    supervises the boards, states the board convenes the next business day
+    where June 1 falls on a weekend, so the OPEN rolls too — unlike Ohio's,
+    where the open is a statutory date rather than a meeting.
+
+    TCA 67-5-1412(e): an appeal from the local board reaches the State Board
+    of Equalization only if filed by August 1 of the tax year, or within
+    forty-five days of the date notice of the local board's action was sent,
+    whichever is later. The forty-five-day leg depends on a notice this
+    system has not seen, so the builder returns the date every Tennessee
+    owner can rely on WITHOUT one — never later than the true deadline.
+
+    TCA 1-3-102 excludes a last day falling on a Saturday, Sunday or legal
+    holiday. Anchors: 2028-08-01 is a Tuesday and stands; 2027-08-01 is a
+    Sunday and rolls to 2027-08-02.
+    """
+    _check_year(year)
+    return WindowDates(
+        opens_on=roll_forward_from_weekend(dt.date(year, 6, 1)),
+        closes_on=roll_forward_from_weekend(dt.date(year, 8, 1)),
+    )
+
+
+def _tn_shelby_county_board(year: int) -> WindowDates:
+    """Shelby County (Memphis) convenes May 1, a month ahead of the rest of
+    Tennessee — a county-level fact, so the pack overrides the state's
+    calendar on the Shelby County row and the chain does the rest. The close
+    is unchanged: TCA 67-5-1412(e) is statewide.
+
+    Authority is the Comptroller's published county-board schedule rather
+    than TCA 67-1-404 itself, which is why this is a separate key and not a
+    parameter — a builder whose two callers disagree about their source
+    would be one function pretending to be two rules. Anchors: 2027-05-01 is
+    a Saturday and rolls to 2027-05-03; 2028-05-01 is a Monday and stands.
+    """
+    _check_year(year)
+    return WindowDates(
+        opens_on=roll_forward_from_weekend(dt.date(year, 5, 1)),
+        closes_on=roll_forward_from_weekend(dt.date(year, 8, 1)),
+    )
+
+
 APPEAL_WINDOWS: dict[str, Callable[[int], WindowDates]] = {
     "us-ky.open-inspection": _ky_open_inspection,
     "us-oh.bor-complaint": _oh_bor_complaint,
+    "us-tn.county-board": _tn_county_board,
+    "us-tn.shelby-county-board": _tn_shelby_county_board,
 }
 
 

--- a/services/api/hestia_api/deposit.py
+++ b/services/api/hestia_api/deposit.py
@@ -154,31 +154,50 @@ _REQUIREMENTS: dict[str, str] = {
     "deposit.interest_required": "pay interest on the deposit",
 }
 
+# The subset of the above whose VALUE is a truth rather than a quantity. A
+# quantity rule states its duty by existing; a boolean one states it only when
+# it says true, and says nothing readable at all when it says neither.
+_BOOLEAN_DUTIES = frozenset(
+    {
+        "urlta.deposit.separate_account_required",
+        "urlta.deposit.itemized_list_required",
+        "deposit.interest_required",
+    }
+)
 
-def _rule_is_true(row: Any) -> bool:
-    """Whether a boolean-valued rule ASSERTS its obligation.
+
+def _rule_truth(row: Any) -> bool | None:
+    """The truth a boolean rule asserts, or None where it asserts none.
 
     Presence of the row is not the answer. A pack states both halves — Ohio
     seeds `deposit.interest_required` as "true; 5% per annum ..." and
-    Tennessee seeds it "false; ...", because "no interest is owed here" is a
-    finding a pack should be able to make, and is not the same fact as
-    silence. The leading token before any semicolon carries the truth; the
-    prose after it carries the reason.
+    Tennessee as "false; ...", because "no duty is owed here" is a finding a
+    pack should be able to make and is not the same fact as silence. The
+    leading token before any semicolon carries the truth; the prose after it
+    carries the reason.
+
+    A row carrying neither token is not a quiet no. It is a rule this build
+    cannot read, and the caller names it as a gap rather than guessing which
+    way it was meant.
+
+    The sweep asks the same question in SQL (`_deposit_gaps` in sweep.py) and
+    must trim the same way, or a panel and a sweep would answer differently
+    about one lease.
     """
-    return (row["value_text"] or "").strip().lower().split(";")[0].strip() == "true"
-
-
-def _rule_is_false(row: Any) -> bool:
-    """A rule that explicitly denies its obligation, as distinct from a
-    numeric or prose rule that has no truth value at all."""
-    return (row["value_text"] or "").strip().lower().split(";")[0].strip() == "false"
+    asserted = (row["value_text"] or "").strip().lower().split(";")[0].strip()
+    if asserted == "true":
+        return True
+    if asserted == "false":
+        return False
+    return None
 
 
 def _reason(row: Any) -> str:
-    """The prose a boolean rule carries after its truth token — why the pack
-    answered the way it did, in the pack's own words."""
+    """The prose a boolean rule carries after its truth token — the pack's own
+    words for why it answered as it did."""
     _, _, rest = (row["value_text"] or "").partition(";")
-    return rest.strip() or (row["value_text"] or "").strip()
+    prose = rest.strip()
+    return prose if prose else "the pack states this and gives no further reason"
 
 
 def _rules_for(conn: Conn, lease_ids: list[str], as_of: dt.date) -> dict[str, list[Any]]:
@@ -262,12 +281,31 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
     by_code = {row["code"]: row for row in rules}
 
     duties: list[DutyOut] = []
+    gaps: list[GapOut] = []
     for code, row in sorted(by_code.items()):
         template = _REQUIREMENTS.get(code)
         if template is None:
             continue  # a pack may carry codes this release has no sentence for
-        if _rule_is_false(row):
-            continue  # the pack says this duty does not attach here
+        if code in _BOOLEAN_DUTIES:
+            truth = _rule_truth(row)
+            if truth is None:
+                # The row exists and this build cannot read it. Printing the
+                # duty anyway would assert an obligation nobody stated, and
+                # dropping it silently would hide a broken pack.
+                gaps.append(
+                    GapOut(
+                        code=code,
+                        reason="unreadable_rule_value",
+                        detail=(
+                            f"{row['citation']} carries neither true nor false, so "
+                            "whether this duty attaches cannot be read from the "
+                            "pack; it is not guessed either way"
+                        ),
+                    )
+                )
+                continue
+            if not truth:
+                continue  # the pack says this duty does not attach here
         value = row["value_numeric"] if row["value_numeric"] is not None else row["value_text"]
         duties.append(
             DutyOut(
@@ -277,7 +315,6 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
             )
         )
 
-    gaps: list[GapOut] = []
     return_rule = by_code.get("deposit.return_days")
     return_days = int(return_rule["value_numeric"]) if return_rule else None
     if return_rule is None:
@@ -287,7 +324,7 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
         # rule instead of a due date — the panel carries that rule and raises
         # no gap. Silence still raises one.
         stated_absent = by_code.get("deposit.return_deadline_exists")
-        if stated_absent is not None and _rule_is_false(stated_absent):
+        if stated_absent is not None and _rule_truth(stated_absent) is False:
             duties.append(
                 DutyOut(
                     code=stated_absent["code"],
@@ -314,8 +351,9 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
     )
 
     interest: InterestOut | None = None
+    # An unreadable value already produced its gap in the duties loop above.
     interest_rule = by_code.get("deposit.interest_required")
-    if interest_rule is not None and _rule_is_true(interest_rule):
+    if interest_rule is not None and _rule_truth(interest_rule):
         # WHICH formula is a rule too (ADR 0003): the pack names a registered
         # builder and the code never branches on a state literal.
         formula_rule = by_code.get("deposit.interest_formula")

--- a/services/api/hestia_api/deposit.py
+++ b/services/api/hestia_api/deposit.py
@@ -155,6 +155,32 @@ _REQUIREMENTS: dict[str, str] = {
 }
 
 
+def _rule_is_true(row: Any) -> bool:
+    """Whether a boolean-valued rule ASSERTS its obligation.
+
+    Presence of the row is not the answer. A pack states both halves — Ohio
+    seeds `deposit.interest_required` as "true; 5% per annum ..." and
+    Tennessee seeds it "false; ...", because "no interest is owed here" is a
+    finding a pack should be able to make, and is not the same fact as
+    silence. The leading token before any semicolon carries the truth; the
+    prose after it carries the reason.
+    """
+    return (row["value_text"] or "").strip().lower().split(";")[0].strip() == "true"
+
+
+def _rule_is_false(row: Any) -> bool:
+    """A rule that explicitly denies its obligation, as distinct from a
+    numeric or prose rule that has no truth value at all."""
+    return (row["value_text"] or "").strip().lower().split(";")[0].strip() == "false"
+
+
+def _reason(row: Any) -> str:
+    """The prose a boolean rule carries after its truth token — why the pack
+    answered the way it did, in the pack's own words."""
+    _, _, rest = (row["value_text"] or "").partition(";")
+    return rest.strip() or (row["value_text"] or "").strip()
+
+
 def _rules_for(conn: Conn, lease_ids: list[str], as_of: dt.date) -> dict[str, list[Any]]:
     rows = conn.execute(_DEPOSIT_RULES, {"lease_ids": lease_ids, "as_of": as_of}).fetchall()
     grouped: dict[str, list[Any]] = {}
@@ -240,6 +266,8 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
         template = _REQUIREMENTS.get(code)
         if template is None:
             continue  # a pack may carry codes this release has no sentence for
+        if _rule_is_false(row):
+            continue  # the pack says this duty does not attach here
         value = row["value_numeric"] if row["value_numeric"] is not None else row["value_text"]
         duties.append(
             DutyOut(
@@ -253,17 +281,32 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
     return_rule = by_code.get("deposit.return_days")
     return_days = int(return_rule["value_numeric"]) if return_rule else None
     if return_rule is None:
-        gaps.append(
-            GapOut(
-                code="deposit.return_days",
-                reason="no_rule_for_domain",
-                detail=(
-                    f"no deposit return period is seeded for {lease['state']}; the "
-                    "deadline is not invented and the lease terms govern until a "
-                    "pack says otherwise"
-                ),
+        # "This state fixes no deadline" and "we have loaded no deadline for
+        # this state" are different answers and must not read alike. Where a
+        # pack states the absence — Tennessee's chapter gives a forfeiture
+        # rule instead of a due date — the panel carries that rule and raises
+        # no gap. Silence still raises one.
+        stated_absent = by_code.get("deposit.return_deadline_exists")
+        if stated_absent is not None and _rule_is_false(stated_absent):
+            duties.append(
+                DutyOut(
+                    code=stated_absent["code"],
+                    requirement=_reason(stated_absent),
+                    citation=stated_absent["citation"],
+                )
             )
-        )
+        else:
+            gaps.append(
+                GapOut(
+                    code="deposit.return_days",
+                    reason="no_rule_for_domain",
+                    detail=(
+                        f"no deposit return period is seeded for {lease['state']}; the "
+                        "deadline is not invented and the lease terms govern until a "
+                        "pack says otherwise"
+                    ),
+                )
+            )
     return_due = (
         lease["moved_out_on"] + dt.timedelta(days=return_days)
         if return_days is not None and lease["moved_out_on"] is not None
@@ -272,7 +315,7 @@ def read(conn: Conn, lease_id: str, *, as_of: dt.date) -> DepositOut:
 
     interest: InterestOut | None = None
     interest_rule = by_code.get("deposit.interest_required")
-    if interest_rule is not None:
+    if interest_rule is not None and _rule_is_true(interest_rule):
         # WHICH formula is a rule too (ADR 0003): the pack names a registered
         # builder and the code never branches on a state literal.
         formula_rule = by_code.get("deposit.interest_formula")

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -48,7 +48,8 @@ class CoverageGap:
     property_id: str
     state: str
     domain: str
-    reason: str  # no_state_jurisdiction | no_rule_for_domain | calendar_key_unregistered
+    reason: str  # no_state_jurisdiction | no_rule_for_domain |
+    #              calendar_key_unregistered | window_not_published
     detail: str
 
 
@@ -107,21 +108,62 @@ resolved AS (
     AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
   ORDER BY a.property_id, r.code, c.depth ASC, r.effective_from DESC
 )
+,
+-- Not every state's window is a function of the year. Tennessee's county
+-- boards convene on a statutory date but ADJOURN on one each county sets
+-- administratively and moves annually, and no statewide list of those dates
+-- exists -- so for such a state the window is a published DATE the pack
+-- carries, not a builder the code registers. The opens/closes pair is
+-- matched on effective_from, which is what makes the two rows one window.
+published AS (
+  SELECT DISTINCT ON (a.property_id)
+         a.property_id,
+         opens.value_text::date AS opens_on,
+         closes.value_text::date AS closes_on,
+         closes.citation
+  FROM anchored a
+  CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+  JOIN jurisdiction_rules closes
+    ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.domain = 'assessment_appeal'
+   AND closes.code = 'appeal.window.closes_on'
+   AND closes.superseded_by IS NULL
+  LEFT JOIN jurisdiction_rules opens
+    ON opens.jurisdiction_id = closes.jurisdiction_id
+   AND opens.code = 'appeal.window.opens_on'
+   AND opens.superseded_by IS NULL
+   AND opens.effective_from = closes.effective_from
+  -- A window that has already closed is not the next one. With no later date
+  -- loaded the property gets a gap, which is the honest answer: nobody has
+  -- published next year's date yet.
+  WHERE closes.value_text::date >= %(as_of)s
+  ORDER BY a.property_id, c.depth ASC, closes.value_text::date ASC
+)
 SELECT a.property_id, a.state, a.start_id,
        cal.value_text AS calendar_key, cal.citation AS citation,
-       ins.value_text AS instructions
+       ins.value_text AS instructions,
+       src.value_text AS window_source, src.citation AS source_citation,
+       pub.opens_on AS published_opens_on, pub.closes_on AS published_closes_on,
+       pub.citation AS published_citation
 FROM anchored a
 LEFT JOIN resolved cal
   ON cal.property_id = a.property_id AND cal.code = 'appeal.window.calendar'
 LEFT JOIN resolved ins
   ON ins.property_id = a.property_id AND ins.code = 'appeal.instructions'
+LEFT JOIN resolved src
+  ON src.property_id = a.property_id AND src.code = 'appeal.window.source'
+LEFT JOIN published pub ON pub.property_id = a.property_id
 """
 
 
 def _appeal_windows(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], list[CoverageGap]]:
-    """The next assessment-appeal window for every live property whose
-    jurisdiction chain names a registered calendar; a typed gap for every
-    property whose chain does not."""
+    """The next assessment-appeal window for every live property, from the
+    date its pack published or the calendar its pack names; a typed gap for
+    every property whose chain gives neither.
+
+    A published date wins over a computed one. Some states' windows are a
+    function of the year and some are an administrative decision a county
+    makes annually, and only the first kind can be a builder."""
     rows: list[dict[str, Any]] = []
     gaps: list[CoverageGap] = []
     for record in conn.execute(APPEAL_RESOLUTION_SQL, {"as_of": as_of}).fetchall():
@@ -133,6 +175,40 @@ def _appeal_windows(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], l
                     domain="assessment_appeal",
                     reason="no_state_jurisdiction",
                     detail=f"no jurisdiction pack is loaded for {record['state']}",
+                )
+            )
+            continue
+        if record["published_closes_on"] is not None:
+            # A date somebody published beats a date this build could compute,
+            # because in a state like Tennessee there is nothing correct to
+            # compute: the deadline is whatever the county board set this year.
+            rows.append(
+                _row(
+                    "assessment_appeal_window",
+                    record["published_closes_on"],
+                    record["published_citation"],
+                    window_opens_on=record["published_opens_on"],
+                    property_id=record["property_id"],
+                    note=record["instructions"],
+                )
+            )
+            continue
+        if record["window_source"] is not None:
+            # The pack says this state's window is published rather than
+            # computed, and no upcoming date is loaded. That is a different
+            # answer from "this state has no appeal rules at all", and the
+            # difference is what tells someone where to go looking.
+            gaps.append(
+                CoverageGap(
+                    property_id=str(record["property_id"]),
+                    state=record["state"],
+                    domain="assessment_appeal",
+                    reason="window_not_published",
+                    detail=(
+                        f"{record['source_citation']}: no upcoming appeal window is "
+                        "loaded for this jurisdiction, and the date is not one this "
+                        "build may compute"
+                    ),
                 )
             )
             continue
@@ -471,7 +547,11 @@ def _deposit_gaps(conn: Conn, as_of: dt.date) -> list[CoverageGap]:
             ORDER BY c.depth ASC, r.effective_from DESC
             LIMIT 1
           ) nearest
-          WHERE lower(split_part(nearest.value_text, ';', 1)) = 'false'
+          -- btrim on both sides of split_part, because deposit.py's
+          -- _rule_truth strips the same whitespace. A pack author who
+          -- writes 'false ; ...' must not get a panel and a sweep that
+          -- disagree about the same lease.
+          WHERE lower(btrim(split_part(btrim(nearest.value_text), ';', 1))) = 'false'
         )
         """,
         {"as_of": as_of},

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -454,6 +454,25 @@ def _deposit_gaps(conn: Conn, as_of: dt.date) -> list[CoverageGap]:
             AND r.effective_from <= %(as_of)s
             AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
         )
+        -- A pack may state that its state fixes no return deadline at all.
+        -- That is an answer, not missing coverage: Tennessee's chapter gives
+        -- a forfeiture rule in place of a due date, and calling it a gap
+        -- would send an owner looking for a statute that does not exist.
+        AND NOT EXISTS (
+          SELECT 1 FROM (
+            SELECT r.value_text
+            FROM jurisdiction_chain(a.start_id) c
+            JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+            WHERE r.domain = 'security_deposit'
+              AND r.code = 'deposit.return_deadline_exists'
+              AND r.superseded_by IS NULL
+              AND r.effective_from <= %(as_of)s
+              AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+            ORDER BY c.depth ASC, r.effective_from DESC
+            LIMIT 1
+          ) nearest
+          WHERE lower(split_part(nearest.value_text, ';', 1)) = 'false'
+        )
         """,
         {"as_of": as_of},
     ).fetchall()

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -157,7 +157,7 @@ class TestEntitiesAndProperties:
         ).fetchone()
         assert row is not None and (row["name"], row["level"]) == ("Kentucky", "state")
         # ...and a state with no pack resolves to nothing, honestly.
-        assert make("Nashville", "TN")["jurisdiction_id"] is None
+        assert make("Indianapolis", "IN")["jurisdiction_id"] is None
 
     def test_validation_is_the_contract_not_a_suggestion(self, client: TestClient) -> None:
         assert client.post("/entities", json={"name": "", "kind": "llc"}).status_code == 422

--- a/services/api/tests/test_calendar.py
+++ b/services/api/tests/test_calendar.py
@@ -63,8 +63,10 @@ def test_nth_weekday_refuses_nonsense() -> None:
 
 def test_the_registry_resolves_exactly_the_registered_keys() -> None:
     assert "us-ky.open-inspection" in calendar.APPEAL_WINDOWS
-    assert "us-tn.county-board" in calendar.APPEAL_WINDOWS
-    assert "us-tn.shelby-county-board" in calendar.APPEAL_WINDOWS
+    # Tennessee deliberately registers nothing: its deadline is an
+    # administrative date a county sets and moves each year, so a builder
+    # there could only be confidently wrong.
+    assert not [key for key in calendar.APPEAL_WINDOWS if key.startswith("us-tn.")]
     assert "us-zz.not-a-state" not in calendar.APPEAL_WINDOWS
     builder = calendar.APPEAL_WINDOWS["us-ky.open-inspection"]
     window = builder(2026)
@@ -90,39 +92,6 @@ def test_the_ohio_bor_window_anchors() -> None:
     assert builder(2029).conference_by is None
     with pytest.raises(ValueError):
         builder(2201)
-
-
-def test_the_tennessee_county_board_window_anchors() -> None:
-    builder = calendar.APPEAL_WINDOWS["us-tn.county-board"]
-    # 2028: June 1 is a Thursday and August 1 a Tuesday; both stand.
-    assert builder(2028) == calendar.WindowDates(
-        opens_on=dt.date(2028, 6, 1), closes_on=dt.date(2028, 8, 1), conference_by=None
-    )
-    # 2027-08-01 is a Sunday; TCA 1-3-102 extends it to Monday August 2.
-    assert builder(2027).closes_on == dt.date(2027, 8, 2)
-    # 2030-06-01 is a Saturday; the board convenes the next business day, so
-    # the open rolls as well — a meeting date, not a statutory date.
-    assert builder(2030).opens_on == dt.date(2030, 6, 3)
-    assert builder(2027).conference_by is None
-    with pytest.raises(ValueError):
-        builder(2201)
-
-
-def test_shelby_county_convenes_a_month_before_the_rest_of_tennessee() -> None:
-    """The county-level override: same state, same close, earlier open."""
-    state = calendar.APPEAL_WINDOWS["us-tn.county-board"]
-    shelby = calendar.APPEAL_WINDOWS["us-tn.shelby-county-board"]
-    # 2028-05-01 is a Monday and stands.
-    assert shelby(2028) == calendar.WindowDates(
-        opens_on=dt.date(2028, 5, 1), closes_on=dt.date(2028, 8, 1), conference_by=None
-    )
-    # 2027-05-01 is a Saturday; the board convenes Monday May 3.
-    assert shelby(2027).opens_on == dt.date(2027, 5, 3)
-    # TCA 67-5-1412(e) is statewide: the close is the same date either way.
-    assert shelby(2028).closes_on == state(2028).closes_on
-    assert shelby(2028).opens_on < state(2028).opens_on
-    with pytest.raises(ValueError):
-        shelby(2201)
 
 
 def test_year_bounds() -> None:

--- a/services/api/tests/test_calendar.py
+++ b/services/api/tests/test_calendar.py
@@ -63,6 +63,8 @@ def test_nth_weekday_refuses_nonsense() -> None:
 
 def test_the_registry_resolves_exactly_the_registered_keys() -> None:
     assert "us-ky.open-inspection" in calendar.APPEAL_WINDOWS
+    assert "us-tn.county-board" in calendar.APPEAL_WINDOWS
+    assert "us-tn.shelby-county-board" in calendar.APPEAL_WINDOWS
     assert "us-zz.not-a-state" not in calendar.APPEAL_WINDOWS
     builder = calendar.APPEAL_WINDOWS["us-ky.open-inspection"]
     window = builder(2026)
@@ -88,6 +90,39 @@ def test_the_ohio_bor_window_anchors() -> None:
     assert builder(2029).conference_by is None
     with pytest.raises(ValueError):
         builder(2201)
+
+
+def test_the_tennessee_county_board_window_anchors() -> None:
+    builder = calendar.APPEAL_WINDOWS["us-tn.county-board"]
+    # 2028: June 1 is a Thursday and August 1 a Tuesday; both stand.
+    assert builder(2028) == calendar.WindowDates(
+        opens_on=dt.date(2028, 6, 1), closes_on=dt.date(2028, 8, 1), conference_by=None
+    )
+    # 2027-08-01 is a Sunday; TCA 1-3-102 extends it to Monday August 2.
+    assert builder(2027).closes_on == dt.date(2027, 8, 2)
+    # 2030-06-01 is a Saturday; the board convenes the next business day, so
+    # the open rolls as well — a meeting date, not a statutory date.
+    assert builder(2030).opens_on == dt.date(2030, 6, 3)
+    assert builder(2027).conference_by is None
+    with pytest.raises(ValueError):
+        builder(2201)
+
+
+def test_shelby_county_convenes_a_month_before_the_rest_of_tennessee() -> None:
+    """The county-level override: same state, same close, earlier open."""
+    state = calendar.APPEAL_WINDOWS["us-tn.county-board"]
+    shelby = calendar.APPEAL_WINDOWS["us-tn.shelby-county-board"]
+    # 2028-05-01 is a Monday and stands.
+    assert shelby(2028) == calendar.WindowDates(
+        opens_on=dt.date(2028, 5, 1), closes_on=dt.date(2028, 8, 1), conference_by=None
+    )
+    # 2027-05-01 is a Saturday; the board convenes Monday May 3.
+    assert shelby(2027).opens_on == dt.date(2027, 5, 3)
+    # TCA 67-5-1412(e) is statewide: the close is the same date either way.
+    assert shelby(2028).closes_on == state(2028).closes_on
+    assert shelby(2028).opens_on < state(2028).opens_on
+    with pytest.raises(ValueError):
+        shelby(2201)
 
 
 def test_year_bounds() -> None:

--- a/services/api/tests/test_coverage.py
+++ b/services/api/tests/test_coverage.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 def two_properties(clean: None, client: TestClient) -> dict[str, str]:
     entity_id = client.post("/entities", json={"name": "Cov", "kind": "llc"}).json()["id"]
     ids = {}
-    for label, city, state in (("covered", "Newport", "KY"), ("bare", "Memphis", "TN")):
+    for label, city, state in (("covered", "Newport", "KY"), ("bare", "Indianapolis", "IN")):
         ids[label] = client.post(
             "/properties",
             json={
@@ -63,12 +63,12 @@ def test_the_report_answers_every_domain(
     }
     assert set(covered["domains"]) == enum_domains
 
-    # The TN property is a gap, not a row that quietly knows nothing.
+    # The Indiana property is a gap, not a row that quietly knows nothing.
     assert [p["label"] for p in body["properties"]] == ["covered"]
     (gap,) = body["gaps"]
     assert gap["property_id"] == two_properties["bare"]
     assert gap["reason"] == "no_state_jurisdiction"
-    assert "TN" in gap["message"]
+    assert "IN" in gap["message"]
 
 
 def test_an_unregistered_calendar_key_is_reported(

--- a/services/api/tests/test_deposit.py
+++ b/services/api/tests/test_deposit.py
@@ -151,6 +151,15 @@ class TestTheAcceptanceWalk:
         # A duty the pack denies is never printed as a duty.
         assert "deposit.interest_required" not in codes
 
+        # The same query shape against Ohio, which DOES owe interest: the
+        # contrast is what proves the panel reads the rule's value and not
+        # merely the row's existence.
+        ohio = make_lease(client, state="OH", city="Cincinnati", postal="45202", label="OhioX")
+        move_out(conn, ohio, "2026-08-01")
+        oh_panel = client.get(f"/leases/{ohio}/deposit?as_of=2026-08-05").json()
+        assert oh_panel["return_days"] == 30
+        assert "deposit.interest_required" in {d["code"] for d in oh_panel["duties"]}
+
         # And the sweep agrees with the panel: no deadline, and no gap either.
         sweep = client.post("/sweep/deadlines?as_of=2026-08-05").json()
         assert (
@@ -162,6 +171,58 @@ class TestTheAcceptanceWalk:
         assert not any(
             g["domain"] == "security_deposit" and g["state"] == "TN" for g in sweep["coverage_gaps"]
         )
+
+    def test_a_boolean_rule_this_build_cannot_read_is_a_gap_not_a_no(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """A pack row whose value carries neither true nor false.
+
+        Reading it as "no interest is owed" would turn a broken pack into a
+        confident answer, which is the failure this module exists to refuse.
+        Sandboxed in state 'QY' — jurisdiction_rules is append-only, so a
+        bogus row planted on a real chain would poison every later test."""
+        if (
+            conn.execute(
+                "SELECT 1 AS x FROM jurisdictions WHERE state = 'QY' AND level = 'state'"
+            ).fetchone()
+            is None
+        ):
+            conn.execute(
+                """
+                WITH state_row AS (
+                  INSERT INTO jurisdictions (level, name, state, parent_id)
+                  SELECT 'state', 'Quoyland', 'QY', id
+                  FROM jurisdictions WHERE level = 'federal' RETURNING id
+                ), county_row AS (
+                  INSERT INTO jurisdictions (level, name, state, parent_id)
+                  SELECT 'county', 'Quoy County', 'QY', id FROM state_row RETURNING id
+                )
+                INSERT INTO jurisdictions (level, name, state, parent_id)
+                SELECT 'municipality', 'Quoyville', 'QY', id FROM county_row
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO jurisdiction_rules
+                  (jurisdiction_id, domain, code, value_text, citation, effective_from)
+                SELECT id, 'security_deposit', 'deposit.interest_required',
+                       'sometimes, at the landlord option',
+                       'QY Rev. Stat. 2.2 (test fixture)', DATE '2000-01-01'
+                FROM jurisdictions WHERE state = 'QY' AND level = 'state'
+                """
+            )
+            conn.commit()
+
+        lease = make_lease(client, state="QY", city="Quoyville", postal="00000", label="Quoy")
+        move_out(conn, lease, "2026-08-01")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
+        assert panel["interest"] is None
+        gap = next(g for g in panel["gaps"] if g["code"] == "deposit.interest_required")
+        assert gap["reason"] == "unreadable_rule_value"
+        assert "QY Rev. Stat. 2.2" in gap["detail"]
+        assert "not guessed either way" in gap["detail"]
+        # The unreadable row is not printed as a duty either.
+        assert "deposit.interest_required" not in {d["code"] for d in panel["duties"]}
 
     def test_a_state_with_no_pack_reports_a_gap_and_raises_no_deadline(
         self, clean: None, client: TestClient, conn: psycopg.Connection[Any]

--- a/services/api/tests/test_deposit.py
+++ b/services/api/tests/test_deposit.py
@@ -117,19 +117,67 @@ class TestTheAcceptanceWalk:
         assert panel["return_due_on"] is None
         assert [gap["code"] for gap in panel["gaps"]] == ["deposit.return_days"]
 
+    def test_tennessee_answers_no_duty_where_ohio_answers_a_duty(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The seam a third state exposes: "no such duty exists here" and "no
+        rule is loaded" must not look alike.
+
+        Tennessee owes no deposit interest and its chapter fixes no deadline
+        to return a deposit at all — the widely repeated thirty days belongs
+        to TCA 66-28-301(g), the window for discovering damage after the
+        tenant leaves, not to a duty to pay. Both absences are seeded as
+        stated rules, so the panel answers them instead of reporting gaps.
+        """
+        lease = make_lease(client, state="TN", city="Nashville", postal="37206", label="Nashville")
+        move_out(conn, lease, "2026-08-01")
+        panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
+
+        # No date is invented, and no gap is raised: an explicit answer is an
+        # answer. An Indiana lease in the same shape gets a gap for both.
+        assert panel["return_days"] is None
+        assert panel["return_due_on"] is None
+        assert panel["interest"] is None
+        assert panel["gaps"] == []
+
+        codes = {duty["code"]: duty for duty in panel["duties"]}
+        assert "urlta.deposit.separate_account_required" in codes
+        assert "66-28-301(a)" in codes["urlta.deposit.separate_account_required"]["citation"]
+        # The forfeiture rule is what Tennessee gives instead of a due date,
+        # so it is what the owner is shown.
+        stated = codes["deposit.return_deadline_exists"]
+        assert "may retain no part of it" in stated["requirement"]
+        assert "66-28-301(c)" in stated["citation"]
+        # A duty the pack denies is never printed as a duty.
+        assert "deposit.interest_required" not in codes
+
+        # And the sweep agrees with the panel: no deadline, and no gap either.
+        sweep = client.post("/sweep/deadlines?as_of=2026-08-05").json()
+        assert (
+            conn.execute(
+                "SELECT count(*) AS n FROM deadlines WHERE lease_id = %s", (lease,)
+            ).fetchone()["n"]
+            == 0
+        )
+        assert not any(
+            g["domain"] == "security_deposit" and g["state"] == "TN" for g in sweep["coverage_gaps"]
+        )
+
     def test_a_state_with_no_pack_reports_a_gap_and_raises_no_deadline(
         self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
     ) -> None:
-        """Tennessee has no pack yet (issue #14). The honest answer is a named
-        gap — a deadline invented from a national average would look like law."""
-        lease = make_lease(client, state="TN", city="Nashville", postal="37206", label="Nashville")
+        """Indiana has no pack. The honest answer is a named gap — a deadline
+        invented from a national average would look like law."""
+        lease = make_lease(
+            client, state="IN", city="Indianapolis", postal="46201", label="Indianapolis"
+        )
         move_out(conn, lease, "2026-08-01")
         panel = client.get(f"/leases/{lease}/deposit?as_of=2026-08-05").json()
         assert panel["duties"] == []
         assert panel["return_days"] is None
         gap = next(g for g in panel["gaps"] if g["code"] == "deposit.return_days")
         assert gap["reason"] == "no_rule_for_domain"
-        assert "TN" in gap["detail"]
+        assert "IN" in gap["detail"]
 
         sweep = client.post("/sweep/deadlines?as_of=2026-08-05").json()
         assert (
@@ -139,7 +187,7 @@ class TestTheAcceptanceWalk:
             == 0
         )
         assert any(
-            g["domain"] == "security_deposit" and g["state"] == "TN" for g in sweep["coverage_gaps"]
+            g["domain"] == "security_deposit" and g["state"] == "IN" for g in sweep["coverage_gaps"]
         )
 
 

--- a/services/api/tests/test_dossier.py
+++ b/services/api/tests/test_dossier.py
@@ -276,7 +276,7 @@ def test_an_unpacked_geography_records_coordinates_without_a_wrong_guess(
     census_payload = _fixture("census-geocode-newport.json")
     geographies = census_payload["result"]["addressMatches"][0]["geographies"]
     del geographies["Incorporated Places"]
-    geographies["Counties"][0]["GEOID"] = "47037"  # a county no pack seeds
+    geographies["Counties"][0]["GEOID"] = "18097"  # Marion County IN: no pack seeds it
     monkeypatch.setattr(dossier, "live_fetch", _routed(census_payload, {"features": []}))
     body = client.post(f"/properties/{newport_property}/dossier?as_of=2026-08-25").json()
     steps = _steps(body)

--- a/services/api/tests/test_sweep.py
+++ b/services/api/tests/test_sweep.py
@@ -217,7 +217,7 @@ def test_uncovered_jurisdictions_gap_instead_of_guessing(
             """
         )
     properties = {}
-    for state in ("TN", "QQ", "ZZ"):
+    for state in ("IN", "QQ", "ZZ"):
         pid = str(uuid.uuid4())
         properties[state] = pid
         conn.execute(
@@ -233,8 +233,8 @@ def test_uncovered_jurisdictions_gap_instead_of_guessing(
     body = client.post(f"/sweep/deadlines?as_of={AS_OF}").json()
     assert "assessment_appeal_window" not in body["inserted"]
     gaps = {g["state"]: g for g in body["coverage_gaps"]}
-    assert gaps["TN"]["reason"] == "no_state_jurisdiction"
-    assert gaps["TN"]["property_id"] == properties["TN"]
+    assert gaps["IN"]["reason"] == "no_state_jurisdiction"
+    assert gaps["IN"]["property_id"] == properties["IN"]
     assert gaps["QQ"]["reason"] == "calendar_key_unregistered"
     assert "qq.future-calendar" in gaps["QQ"]["detail"]
     assert gaps["ZZ"]["reason"] == "no_rule_for_domain"
@@ -249,10 +249,11 @@ def test_uncovered_jurisdictions_gap_instead_of_guessing(
 def test_the_cross_river_portfolio_gets_both_regimes(
     clean: None, client: TestClient, conn: psycopg.Connection[Any]
 ) -> None:
-    """The nationwide acceptance shape: one owner, three properties — Newport
-    KY, Cincinnati OH (one bridge apart), Nashville TN (no pack). ONE sweep
-    yields each covered state's own window, citation and instructions, no TN
-    row, and exactly one honest TN gap."""
+    """The nationwide acceptance shape: one owner, four properties — Newport
+    KY, Cincinnati OH (one bridge apart), Nashville TN, and an Indianapolis
+    outpost in a state with no pack. ONE sweep yields each covered state's own
+    window, citation and instructions, no Indiana row, and exactly one honest
+    Indiana gap."""
     entity_id = str(uuid.uuid4())
     conn.execute(
         "INSERT INTO entities (id, name, kind) VALUES (%s, 'Cross River LLC', 'llc')",
@@ -262,6 +263,7 @@ def test_the_cross_river_portfolio_gets_both_regimes(
         ("newport-side", "Newport", "KY", "41071"),
         ("cincinnati-side", "Cincinnati", "OH", "45202"),
         ("nashville-outpost", "Nashville", "TN", "37201"),
+        ("indianapolis-outpost", "Indianapolis", "IN", "46204"),
     ):
         conn.execute(
             """
@@ -276,9 +278,9 @@ def test_the_cross_river_portfolio_gets_both_regimes(
     conn.commit()
 
     body = client.post("/sweep/deadlines?as_of=2026-11-01").json()
-    assert body["inserted"]["assessment_appeal_window"] == 2
+    assert body["inserted"]["assessment_appeal_window"] == 3
     (gap,) = body["coverage_gaps"]
-    assert (gap["state"], gap["reason"]) == ("TN", "no_state_jurisdiction")
+    assert (gap["state"], gap["reason"]) == ("IN", "no_state_jurisdiction")
 
     rows = conn.execute(
         """
@@ -287,7 +289,7 @@ def test_the_cross_river_portfolio_gets_both_regimes(
         WHERE d.kind = 'assessment_appeal_window' ORDER BY p.state
         """
     ).fetchall()
-    ky, oh = rows[0], rows[1]
+    ky, oh, tn = rows[0], rows[1], rows[2]
     assert ky["state"] == "KY"
     assert ky["due_on"] == dt.date(2027, 5, 17)
     assert ky["window_opens_on"] == dt.date(2027, 5, 3)
@@ -298,6 +300,15 @@ def test_the_cross_river_portfolio_gets_both_regimes(
     assert oh["window_opens_on"] == dt.date(2027, 1, 1)
     assert "ORC 5715.19" in oh["citation"]
     assert "DTE Form 1" in oh["note"]
+    # Tennessee's 2026 window closed August 3; the next one is a summer 2027
+    # window, and 2027-08-01 is a Sunday that TCA 1-3-102 rolls to Monday.
+    assert tn["state"] == "TN"
+    assert tn["due_on"] == dt.date(2027, 8, 2)
+    assert tn["window_opens_on"] == dt.date(2027, 6, 1)
+    assert "TCA 67-5-1412" in tn["citation"]
+    assert "State Board of Equalization" in tn["note"]
+    # Three states, three windows, no two alike — from one sweep.
+    assert len({ky["due_on"], oh["due_on"], tn["due_on"]}) == 3
 
 
 def test_an_empty_portfolio_sweeps_to_zero_today(clean: None, client: TestClient) -> None:

--- a/services/api/tests/test_sweep.py
+++ b/services/api/tests/test_sweep.py
@@ -277,7 +277,9 @@ def test_the_cross_river_portfolio_gets_both_regimes(
         )
     conn.commit()
 
-    body = client.post("/sweep/deadlines?as_of=2026-11-01").json()
+    # 2026-06-01: Kentucky's and Ohio's 2026 windows have closed, so both roll
+    # to 2027; Davidson County's published 2026 date is still ahead.
+    body = client.post("/sweep/deadlines?as_of=2026-06-01").json()
     assert body["inserted"]["assessment_appeal_window"] == 3
     (gap,) = body["coverage_gaps"]
     assert (gap["state"], gap["reason"]) == ("IN", "no_state_jurisdiction")
@@ -300,15 +302,68 @@ def test_the_cross_river_portfolio_gets_both_regimes(
     assert oh["window_opens_on"] == dt.date(2027, 1, 1)
     assert "ORC 5715.19" in oh["citation"]
     assert "DTE Form 1" in oh["note"]
-    # Tennessee's 2026 window closed August 3; the next one is a summer 2027
-    # window, and 2027-08-01 is a Sunday that TCA 1-3-102 rolls to Monday.
+    # Tennessee's date is not computed at all: it is the one Davidson County
+    # published for 2026, and the citation names the county rather than a
+    # statute, because no statute fixes it.
     assert tn["state"] == "TN"
-    assert tn["due_on"] == dt.date(2027, 8, 2)
-    assert tn["window_opens_on"] == dt.date(2027, 6, 1)
-    assert "TCA 67-5-1412" in tn["citation"]
-    assert "State Board of Equalization" in tn["note"]
+    assert tn["due_on"] == dt.date(2026, 6, 26)
+    assert tn["window_opens_on"] == dt.date(2026, 5, 26)
+    assert "Metropolitan Board of Equalization" in tn["citation"]
+    assert "Assessor of Property" in tn["citation"]
+    # The note must not let the State Board's August 1 read as the deadline.
+    assert "SECOND-level" in tn["note"]
+    assert tn["due_on"] < dt.date(2026, 8, 1)
     # Three states, three windows, no two alike — from one sweep.
     assert len({ky["due_on"], oh["due_on"], tn["due_on"]}) == 3
+
+
+def test_a_published_window_that_has_passed_is_a_named_gap_not_a_guess(
+    clean: None, client: TestClient, conn: psycopg.Connection[Any]
+) -> None:
+    """Tennessee's deadline is whatever its county board set this year, so
+    once the published date is behind us there is nothing honest to compute.
+    The sweep must say that in as many words rather than roll a year forward
+    the way a builder-backed state does — Davidson's date was June 14 in
+    2024, June 27 in 2025 and June 26 in 2026, and no rule generates it."""
+    entity_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO entities (id, name, kind) VALUES (%s, 'Nashville LLC', 'llc')",
+        (entity_id,),
+    )
+    property_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO properties (id, entity_id, label, street_1, city, state,
+                                postal_code, kind, jurisdiction_id)
+        VALUES (%s, %s, 'weona', '2226 Weona Dr', 'Nashville', 'TN', '37206',
+                'single_family',
+                (SELECT id FROM jurisdictions
+                  WHERE name = 'Nashville' AND level = 'municipality'))
+        """,
+        (property_id, entity_id),
+    )
+    conn.commit()
+
+    # Before the published close: the real date, from the county.
+    early = client.post("/sweep/deadlines?as_of=2026-06-01").json()
+    assert early["inserted"]["assessment_appeal_window"] == 1
+    assert not [g for g in early["coverage_gaps"] if g["domain"] == "assessment_appeal"]
+
+    # After it: a gap that names why, and NO invented deadline.
+    late = client.post("/sweep/deadlines?as_of=2026-07-01").json()
+    assert "assessment_appeal_window" not in late["inserted"]
+    gap = next(g for g in late["coverage_gaps"] if g["domain"] == "assessment_appeal")
+    assert gap["reason"] == "window_not_published"
+    assert gap["property_id"] == property_id
+    assert "67-1-404" in gap["detail"]
+    assert (
+        conn.execute(
+            "SELECT count(*) AS n FROM deadlines WHERE kind = 'assessment_appeal_window'"
+            " AND property_id = %s AND due_on > DATE '2026-06-26'",
+            (property_id,),
+        ).fetchone()["n"]
+        == 0
+    )
 
 
 def test_an_empty_portfolio_sweeps_to_zero_today(clean: None, client: TestClient) -> None:

--- a/services/api/tests/test_views.py
+++ b/services/api/tests/test_views.py
@@ -84,16 +84,16 @@ def test_an_unresolved_property_reads_with_an_empty_chain(clean: None, client: T
         "/properties",
         json={
             "entity_id": entity_id,
-            "label": "nashville",
-            "street_1": "1 Broadway",
-            "city": "Nashville",
-            "state": "TN",
-            "postal_code": "37201",
+            "label": "indianapolis",
+            "street_1": "1 Monument Cir",
+            "city": "Indianapolis",
+            "state": "IN",
+            "postal_code": "46204",
             "kind": "single_family",
         },
     ).json()["id"]
     view = client.get(f"/properties/{property_id}/dossier").json()
-    assert view["jurisdiction_chain"] == []  # no TN pack: shown, not guessed
+    assert view["jurisdiction_chain"] == []  # no IN pack: shown, not guessed
     assert view["components"] == [] and view["defects"] == []
 
 


### PR DESCRIPTION
Closes #14.

ADR 0003 claims a state whose calendars fit existing builders is one seed file and one pack test with zero code edits. Tennessee is the honest test of that claim, and the answer is a qualified yes: the pack is data, but three facts in it had nowhere to land.

## The data

`seed/907_jurisdictions_tennessee.sql` and `tests/packs/tennessee.sql` (11 checks):

- **A summer appeal window** against Kentucky's spring and Ohio's winter. Three states, three calendars, from one query shape.
- **Classified assessment** — 25% residential, 40% commercial — where Kentucky is a flat 100% and Ohio a flat 35%. The line is drawn at *rental-unit count* (TCA 67-5-501(11)), so a rented single-family house is 25% and a fully rented duplex is 40%. The AG opinion that qualifies this (25-016, and the *Spring Hill* build-to-rent caveat) travels in the same row, because a ratio stated without it carries a confidence the law does not support.
- **A landlord-tenant act binding by county population**, rather than by local adoption (Kentucky) or statewide fiat (Ohio). Because the county decides, every URLTA rule sits on the county rows and the non-URLTA statute (TCA 66-7-109) sits on the state row. A Tennessee property in an unseeded county resolves *past* Nashville's law to the law that actually governs it. The pack test asserts no `urlta.*` rule is seeded on the state row, so this cannot quietly regress.
- **No individual income tax**, stated rather than left silent, plus the entity-level franchise and excise rules that survive the repeal — including the FONCE four-unit definition of "residential," which is a *different* line than the assessment ratio's one-unit test. Two definitions of one word in one code; the pack carries both so the platform cannot conflate them.

## The code, and why each was unavoidable

**Two calendar builders, not zero.** TCA 67-1-404(a) puts the county board at June 1 and TCA 67-5-1412(e) the State Board deadline at August 1; no registered builder had that shape. Shelby County convenes May 1, so the pack seeds a *second* key on the **county** row — the first time a county has had to disagree with its state about a calendar. Nothing in the resolver changed to allow that: depth-first chain ordering already preferred the nearer row, and the pack test now proves it. A deviation gets its own key rather than a parameter on one builder, because two callers whose authorities differ are two rules.

**A boolean rule now answers with its value, not its presence.** Ohio owes deposit interest and Tennessee does not. The old code read the row *existing* as the row saying yes, so a Tennessee lease would have been charged with a duty the state never imposes, and then reported a coverage gap for the formula to compute it with.

**"No deadline exists" is now distinct from "no deadline is loaded."** Tennessee fixes no statutory deposit-return deadline at all. The widely repeated thirty days is a secondary-source artifact of TCA 66-28-301(g), which is the window for discovering damage *after* the tenant leaves, not a duty to pay. The pack states the absence; the panel carries the forfeiture rule under 66-28-301(c) instead of inventing a date; and the sweep no longer reports it as missing coverage.

## Cost of a state gaining coverage

The no-pack placeholder moves from Tennessee to Indiana across six tests (`test_deposit`, `test_coverage`, `test_sweep`, `test_api`, `test_views`, `test_dossier`). The cross-river sweep test is upgraded from two regimes to three plus one honest gap.

## Citations

Every figure was verified against the Tennessee Code rather than carried over from memory; five of my initial assumptions were wrong and were corrected before anything was seeded (the June 1 date is in TCA 67-1-404, not the Part 14 sections; the URLTA threshold reads the 2010 census *only*, so the covered list is frozen at seventeen counties; there is no 30-day deposit-return deadline; the 14/30 eviction structure is the non-URLTA rule, not the URLTA one; the franchise-tax property measure was repealed in 2024). Figures still wanting professional confirmation carry `CONFIRM WITH TN COUNSEL` or `CONFIRM WITH TN CPA` in their citations.

## Gates

- `scripts/verify-schema.sh` — green, 11 Tennessee pack checks, backup/restore verified
- `services/api` — 281 passed at 100% line and branch against real Postgres
- `services/sim` — 100%
- `pnpm run verify` — green, `deadlines.ts` at a 100.00 mutation score
- ruff check + format, state-literal ratchet, config audit, OpenAPI drift — all clean
