### PR TITLE
Screening: the record, the duty, and the checklist

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -180,6 +180,64 @@ test('a closing statement walks upload, ratification and apply', async ({ page }
   await expect(page.getByRole('row', { name: /Acquisition Cost/ }).first()).toBeVisible();
 });
 
+test('screening: the decision is recorded once and the FCRA checklist appears', async ({
+  page,
+}) => {
+  // This walk OWNS its applicant and its screening. The resident and the
+  // screening are arranged through the API because the web deliberately has
+  // no "open screening" affordance yet: no read surface exposes resident ids
+  // (noted to the API side). An applicant who is denied is, by definition,
+  // not a resident on any lease — the panel lists by property.
+  const properties = await (await page.request.get('http://localhost:8000/properties')).json();
+  const propertyId = (properties as { id: string }[])[0]?.id;
+  if (!propertyId) throw new Error('the portfolio walk runs first and creates a property');
+  const applicant = `Avery Applicant ${String(Date.now())}`;
+  const residentResponse = await page.request.post('http://localhost:8000/residents', {
+    data: { full_name: applicant },
+  });
+  expect(residentResponse.ok()).toBe(true);
+  const resident = (await residentResponse.json()) as { id: string };
+  const screeningResponse = await page.request.post('http://localhost:8000/screening', {
+    data: { resident_id: resident.id, property_id: propertyId },
+  });
+  expect(screeningResponse.ok()).toBe(true);
+
+  // The lease is created through the UI, on the SAME property the screening
+  // is on — picked by id, not by whatever order the select happens to hold.
+  await page.goto('/leases');
+  const unitLabel = `Screening Walk ${String(Date.now())}`;
+  await page.locator('#ls-property').selectOption(propertyId);
+  await page.getByLabel('Unit label').fill(unitLabel);
+  await page.getByLabel('Starts').fill('2026-08-01');
+  await page.getByLabel('Monthly rent').fill('1200.00');
+  await page.getByRole('button', { name: 'Add lease & bill this month' }).click();
+  await page
+    .getByRole('row', { name: new RegExp(unitLabel) })
+    .getByRole('link')
+    .click();
+
+  // The applicant's card, scoped: a long-lived database may hold others.
+  const card = page.locator('.screening .card', { hasText: applicant });
+  await expect(card.getByText('pending')).toBeVisible();
+  await card.getByLabel('Decision').selectOption('denied');
+  await card.getByLabel('Basis').fill('income below threshold');
+  await card.getByLabel(/Based on a consumer report/).check();
+  await card.getByRole('button', { name: 'Record the decision' }).click();
+
+  // Honest transition proof: the form leaves, the record takes its place,
+  // and the statute's checklist arrives with its stamps.
+  await expect(card.getByRole('button', { name: 'Record the decision' })).toHaveCount(0);
+  await expect(card.getByText(/income below threshold · based on a consumer report/)).toBeVisible();
+  await expect(card.getByText('adverse-action notice owed')).toBeVisible();
+  await expect(card.getByText('State the adverse action taken')).toBeVisible();
+  await expect(card.getByText('15 U.S.C. 1681m(a)').first()).toBeVisible();
+
+  await card.getByLabel('Sent on').fill('2026-08-28');
+  await card.getByRole('button', { name: 'Record the notice' }).click();
+  await expect(card.getByText(/notice sent Aug 28, 2026/)).toBeVisible();
+  await expect(card.getByText('State the adverse action taken')).toHaveCount(0);
+});
+
 test('a work order completes and the vendor calendar knows its certificate', async ({ page }) => {
   // A vendor with a certificate that expires: the day it lapses is a deadline.
   await page.goto('/vendors');

--- a/apps/web/src/app/lease/[id]/page.tsx
+++ b/apps/web/src/app/lease/[id]/page.tsx
@@ -2,14 +2,24 @@
 
 import { use, useCallback, useEffect, useState } from 'react';
 import { RenewalCard } from '../../../components/RenewalCard';
+import { ScreeningPanel } from '../../../components/ScreeningPanel';
 import { formatMoney } from '../../../components/TransactionsTable';
-import { ApiError, api, type LeaseDetail, type RenewalContextOut } from '../../../lib/api';
+import {
+  ApiError,
+  api,
+  type DecisionIn,
+  type LeaseDetail,
+  type NoticeIn,
+  type RenewalContextOut,
+  type ScreeningOut,
+} from '../../../lib/api';
 import { formatDate, localIsoDate } from '../../../lib/format';
 
 export default function LeasePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const [detail, setDetail] = useState<LeaseDetail | null>(null);
   const [context, setContext] = useState<RenewalContextOut | null>(null);
+  const [screenings, setScreenings] = useState<ScreeningOut[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [amount, setAmount] = useState('');
@@ -22,8 +32,13 @@ export default function LeasePage({ params }: { params: Promise<{ id: string }> 
         api.leaseDetail(id),
         api.renewalContext(id),
       ]);
+      // Screenings are property-scoped: an applicant who was denied is,
+      // by definition, not a resident on this lease — and the adverse-action
+      // duty is owed to exactly that person.
+      const screeningList = await api.listScreenings({ propertyId: leaseDetail.property_id });
       setDetail(leaseDetail);
       setContext(renewalContext);
+      setScreenings(screeningList);
       setError(null);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -76,6 +91,26 @@ export default function LeasePage({ params }: { params: Promise<{ id: string }> 
       }
     } finally {
       setCollecting(false);
+    }
+  };
+
+  const decide = async (screeningId: string, body: DecisionIn) => {
+    setError(null);
+    try {
+      await api.decideScreening(screeningId, body);
+      await load();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const recordNotice = async (screeningId: string, body: NoticeIn) => {
+    setError(null);
+    try {
+      await api.recordAdverseAction(screeningId, body);
+      await load();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
     }
   };
 
@@ -227,6 +262,21 @@ export default function LeasePage({ params }: { params: Promise<{ id: string }> 
             context={context}
             onOffer={(newRent) => {
               void offer(newRent);
+            }}
+          />
+        </section>
+      ) : null}
+
+      {screenings.length > 0 ? (
+        <section className="section">
+          <h2 className="section__title">Applicant screening</h2>
+          <ScreeningPanel
+            screenings={screenings}
+            onDecide={(screeningId, body) => {
+              void decide(screeningId, body);
+            }}
+            onNotice={(screeningId, body) => {
+              void recordNotice(screeningId, body);
             }}
           />
         </section>

--- a/apps/web/src/components/ScreeningPanel.tsx
+++ b/apps/web/src/components/ScreeningPanel.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { Button, CitationChip, Pill, type PillTone } from '@hestia/design';
+import { useState } from 'react';
+import type { DecisionIn, NoticeIn, ScreeningOut } from '../lib/api';
+import { formatDate } from '../lib/format';
+
+/**
+ * Applicant screening: the record, the duty, and the checklist. The server
+ * decides when an adverse-action notice is owed and what the letter must
+ * contain — the browser displays what it is told; it does not know the law.
+ * A decision is recorded once: it is the reason someone did or did not get
+ * a home, and re-deciding it would rewrite that record.
+ */
+const DECISION_TONE: Record<string, PillTone> = {
+  pending: 'neutral',
+  approved: 'ok',
+  conditional: 'flag',
+  denied: 'flag',
+  withdrawn: 'skipped',
+};
+
+const DECISIONS = ['approved', 'conditional', 'denied', 'withdrawn'] as const;
+
+function DecisionForm({
+  screening,
+  onDecide,
+}: {
+  screening: ScreeningOut;
+  onDecide: (screeningId: string, body: DecisionIn) => void;
+}) {
+  const [decision, setDecision] = useState<DecisionIn['decision']>('approved');
+  const [decidedOn, setDecidedOn] = useState('');
+  const [basis, setBasis] = useState('');
+  const [consumerReport, setConsumerReport] = useState(false);
+  return (
+    <form
+      className="form-row"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onDecide(screening.id, {
+          decision,
+          decided_on: decidedOn === '' ? null : decidedOn,
+          decision_basis: basis === '' ? null : basis,
+          based_on_consumer_report: consumerReport,
+        });
+      }}
+    >
+      <div className="field">
+        <label htmlFor={`sc-decision-${screening.id}`}>Decision</label>
+        <select
+          id={`sc-decision-${screening.id}`}
+          value={decision}
+          onChange={(event) => {
+            setDecision(event.target.value as DecisionIn['decision']);
+          }}
+        >
+          {DECISIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="field">
+        <label htmlFor={`sc-decided-${screening.id}`}>Decided on</label>
+        <input
+          id={`sc-decided-${screening.id}`}
+          type="date"
+          value={decidedOn}
+          onChange={(event) => {
+            setDecidedOn(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`sc-basis-${screening.id}`}>Basis</label>
+        <input
+          id={`sc-basis-${screening.id}`}
+          value={basis}
+          onChange={(event) => {
+            setBasis(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`sc-report-${screening.id}`}>
+          <input
+            id={`sc-report-${screening.id}`}
+            type="checkbox"
+            checked={consumerReport}
+            onChange={(event) => {
+              setConsumerReport(event.target.checked);
+            }}
+          />{' '}
+          Based on a consumer report
+        </label>
+      </div>
+      <Button type="submit">Record the decision</Button>
+    </form>
+  );
+}
+
+function NoticeBlock({
+  screening,
+  onNotice,
+}: {
+  screening: ScreeningOut;
+  onNotice: (screeningId: string, body: NoticeIn) => void;
+}) {
+  const [sentOn, setSentOn] = useState('');
+  if (!screening.adverse_action_required) {
+    return null;
+  }
+  if (screening.adverse_action_sent_on !== null) {
+    return (
+      <p>
+        <Pill tone="ok">notice sent {formatDate(screening.adverse_action_sent_on)}</Pill>
+      </p>
+    );
+  }
+  return (
+    <div className="screening__notice">
+      <p>
+        <Pill tone="flag">adverse-action notice owed</Pill>{' '}
+        {screening.citation ? <CitationChip cite={screening.citation} /> : null}
+      </p>
+      <ul>
+        {screening.notice_contents.map((item) => (
+          <li key={item['citation']}>
+            {item['requirement']}{' '}
+            {item['citation'] ? <CitationChip cite={item['citation']} /> : null}
+          </li>
+        ))}
+      </ul>
+      <form
+        className="form-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onNotice(screening.id, { sent_on: sentOn === '' ? null : sentOn });
+        }}
+      >
+        <div className="field">
+          <label htmlFor={`sc-sent-${screening.id}`}>Sent on</label>
+          <input
+            id={`sc-sent-${screening.id}`}
+            type="date"
+            value={sentOn}
+            onChange={(event) => {
+              setSentOn(event.target.value);
+            }}
+          />
+        </div>
+        <Button type="submit">Record the notice</Button>
+      </form>
+    </div>
+  );
+}
+
+type ScreeningPanelProps = {
+  screenings: readonly ScreeningOut[];
+  onDecide: (screeningId: string, body: DecisionIn) => void;
+  onNotice: (screeningId: string, body: NoticeIn) => void;
+};
+
+export function ScreeningPanel({ screenings, onDecide, onNotice }: ScreeningPanelProps) {
+  if (screenings.length === 0) {
+    return null;
+  }
+  return (
+    <div className="screening">
+      {screenings.map((screening) => (
+        <div className="card" key={screening.id}>
+          <p>
+            <strong>{screening.resident_name}</strong>
+            {screening.unit_label ? ` · ${screening.unit_label}` : ''} · {screening.provider} ·
+            requested {formatDate(screening.requested_on)}{' '}
+            <Pill tone={DECISION_TONE[screening.decision] ?? 'neutral'}>{screening.decision}</Pill>
+          </p>
+          {screening.decision === 'pending' ? (
+            <DecisionForm screening={screening} onDecide={onDecide} />
+          ) : (
+            <p className="muted">
+              {screening.decided_on ? `Decided ${formatDate(screening.decided_on)}` : 'Decided'}
+              {screening.decision_basis ? ` — ${screening.decision_basis}` : ''}
+              {screening.based_on_consumer_report ? ' · based on a consumer report' : ''}
+            </p>
+          )}
+          <NoticeBlock screening={screening} onNotice={onNotice} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -41,6 +41,10 @@ export type ReceiptIn = components['schemas']['ReceiptIn'];
 export type ReceiptOut = components['schemas']['ReceiptOut'];
 export type RenewalContextOut = components['schemas']['RenewalContextOut'];
 export type CollectOut = components['schemas']['CollectOut'];
+export type ScreeningOut = components['schemas']['ScreeningOut'];
+export type ScreeningIn = components['schemas']['ScreeningIn'];
+export type DecisionIn = components['schemas']['DecisionIn'];
+export type NoticeIn = components['schemas']['NoticeIn'];
 export type DocumentSummary = components['schemas']['DocumentSummary'];
 export type DocumentDetail = components['schemas']['DocumentDetail'];
 export type DocumentField = components['schemas']['FieldOut'];
@@ -277,5 +281,26 @@ export const api = {
     request<CollectOut>(`/leases/${leaseId}/collect`, {
       method: 'POST',
       body: JSON.stringify({}),
+    }),
+  listScreenings: (params?: { propertyId?: string; residentId?: string; noticeOwed?: boolean }) => {
+    const query = new URLSearchParams();
+    if (params?.propertyId) query.set('property_id', params.propertyId);
+    if (params?.residentId) query.set('resident_id', params.residentId);
+    if (params?.noticeOwed) query.set('notice_owed', 'true');
+    const suffix = query.size > 0 ? `?${query.toString()}` : '';
+    return request<ScreeningOut[]>(`/screening${suffix}`);
+  },
+  openScreening: (body: ScreeningIn) =>
+    request<ScreeningOut>('/screening', { method: 'POST', body: JSON.stringify(body) }),
+  readScreening: (screeningId: string) => request<ScreeningOut>(`/screening/${screeningId}`),
+  decideScreening: (screeningId: string, body: DecisionIn) =>
+    request<ScreeningOut>(`/screening/${screeningId}/decision`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  recordAdverseAction: (screeningId: string, body: NoticeIn) =>
+    request<ScreeningOut>(`/screening/${screeningId}/adverse-action`, {
+      method: 'POST',
+      body: JSON.stringify(body),
     }),
 };

--- a/apps/web/tests/api.test.ts
+++ b/apps/web/tests/api.test.ts
@@ -310,6 +310,51 @@ describe('the API client', () => {
     expect(api.documentContentUrl('d1')).toBe('http://localhost:8000/documents/d1/content');
   });
 
+  it('walks the screening paths against the contract', async () => {
+    const fetchMock = vi.fn().mockImplementation(jsonResponse(200, []));
+    vi.stubGlobal('fetch', fetchMock);
+    await api.listScreenings();
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening',
+      expect.anything(),
+    );
+    await api.listScreenings({ propertyId: 'p1' });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening?property_id=p1',
+      expect.anything(),
+    );
+    await api.listScreenings({ residentId: 'r1', noticeOwed: true });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening?resident_id=r1&notice_owed=true',
+      expect.anything(),
+    );
+    await api.openScreening({ resident_id: 'r1', property_id: 'p1' });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    await api.readScreening('s1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening/s1',
+      expect.anything(),
+    );
+    await api.decideScreening('s1', {
+      decision: 'denied',
+      decided_on: '2026-08-28',
+      decision_basis: 'income below threshold',
+      based_on_consumer_report: true,
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening/s1/decision',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    await api.recordAdverseAction('s1', { sent_on: '2026-08-28' });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/screening/s1/adverse-action',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
   it('uploads documents as multipart and surfaces refusals', async () => {
     const file = new File(['%PDF fake'], 'closing.pdf', { type: 'application/pdf' });
     const fetchMock = vi

--- a/apps/web/tests/screening-panel.test.tsx
+++ b/apps/web/tests/screening-panel.test.tsx
@@ -1,0 +1,221 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScreeningPanel } from '../src/components/ScreeningPanel';
+import type { ScreeningOut } from '../src/lib/api';
+
+afterEach(cleanup);
+
+const base: ScreeningOut = {
+  id: 's1',
+  resident_id: 'r1',
+  resident_name: 'Avery Quinn',
+  property_id: 'p1',
+  property_label: '998 Monmouth St',
+  unit_id: null,
+  unit_label: null,
+  provider: 'manual',
+  requested_on: '2026-08-20',
+  decision: 'pending',
+  decided_on: null,
+  decision_basis: null,
+  based_on_consumer_report: false,
+  adverse_action_required: false,
+  adverse_action_sent_on: null,
+  citation: null,
+  notice_contents: [],
+  notes: null,
+};
+
+describe('ScreeningPanel', () => {
+  it('renders nothing when there is nothing to screen', () => {
+    const { container } = render(
+      <ScreeningPanel screenings={[]} onDecide={vi.fn()} onNotice={vi.fn()} />,
+    );
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it('a pending screening offers the decision form and records it', () => {
+    const onDecide = vi.fn();
+    render(<ScreeningPanel screenings={[base]} onDecide={onDecide} onNotice={vi.fn()} />);
+    expect(screen.getByText('Avery Quinn')).toBeDefined();
+    expect(screen.getByText('pending').className).toBe('pill');
+    fireEvent.change(screen.getByLabelText('Decision'), { target: { value: 'denied' } });
+    fireEvent.change(screen.getByLabelText('Decided on'), { target: { value: '2026-08-28' } });
+    fireEvent.change(screen.getByLabelText('Basis'), { target: { value: 'income threshold' } });
+    fireEvent.click(screen.getByLabelText(/Based on a consumer report/));
+    fireEvent.click(screen.getByRole('button', { name: 'Record the decision' }));
+    expect(onDecide).toHaveBeenCalledWith('s1', {
+      decision: 'denied',
+      decided_on: '2026-08-28',
+      decision_basis: 'income threshold',
+      based_on_consumer_report: true,
+    });
+  });
+
+  it('empty date and basis are sent as null, not empty strings', () => {
+    const onDecide = vi.fn();
+    render(<ScreeningPanel screenings={[base]} onDecide={onDecide} onNotice={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Record the decision' }));
+    expect(onDecide).toHaveBeenCalledWith('s1', {
+      decision: 'approved',
+      decided_on: null,
+      decision_basis: null,
+      based_on_consumer_report: false,
+    });
+  });
+
+  it('a decided screening shows the record, not a form', () => {
+    render(
+      <ScreeningPanel
+        screenings={[
+          {
+            ...base,
+            unit_label: 'Unit B',
+            decision: 'approved',
+            decided_on: '2026-08-25',
+            decision_basis: 'clean record',
+            based_on_consumer_report: true,
+          },
+        ]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('approved').className).toBe('pill pill--ok');
+    expect(screen.queryByRole('button', { name: 'Record the decision' })).toBeNull();
+    expect(
+      screen.getByText(/Decided Aug 25, 2026 — clean record · based on a consumer report/),
+    ).toBeDefined();
+    expect(screen.getByText(/Unit B/)).toBeDefined();
+  });
+
+  it('a decided screening without a date still reads as decided', () => {
+    render(
+      <ScreeningPanel
+        screenings={[{ ...base, decision: 'withdrawn', decided_on: null }]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('withdrawn').className).toBe('pill pill--skipped');
+    expect(screen.getByText('Decided')).toBeDefined();
+  });
+
+  it('an owed notice renders the statutory checklist and records the send', () => {
+    const onNotice = vi.fn();
+    render(
+      <ScreeningPanel
+        screenings={[
+          {
+            ...base,
+            decision: 'denied',
+            decided_on: '2026-08-26',
+            based_on_consumer_report: true,
+            adverse_action_required: true,
+            citation: '15 U.S.C. 1681m(a)',
+            notice_contents: [
+              { requirement: 'State the adverse action taken', citation: '15 U.S.C. 1681m(a)' },
+              {
+                requirement: 'Tell the consumer of their right to dispute',
+                citation: '15 U.S.C. 1681i',
+              },
+            ],
+          },
+        ]}
+        onDecide={vi.fn()}
+        onNotice={onNotice}
+      />,
+    );
+    expect(screen.getByText('adverse-action notice owed').className).toBe('pill pill--flag');
+    // The checklist is the server's law, item for item, each with its stamp.
+    expect(screen.getByText('State the adverse action taken')).toBeDefined();
+    expect(screen.getByText('Tell the consumer of their right to dispute')).toBeDefined();
+    expect(screen.getAllByText('15 U.S.C. 1681m(a)')).toHaveLength(2);
+    fireEvent.change(screen.getByLabelText('Sent on'), { target: { value: '2026-08-28' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record the notice' }));
+    expect(onNotice).toHaveBeenCalledWith('s1', { sent_on: '2026-08-28' });
+  });
+
+  it('an unset sent-on date goes as null so the server dates it', () => {
+    const onNotice = vi.fn();
+    render(
+      <ScreeningPanel
+        screenings={[
+          {
+            ...base,
+            decision: 'denied',
+            adverse_action_required: true,
+            notice_contents: [{ requirement: 'State the adverse action taken', citation: 'x' }],
+          },
+        ]}
+        onDecide={vi.fn()}
+        onNotice={onNotice}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Record the notice' }));
+    expect(onNotice).toHaveBeenCalledWith('s1', { sent_on: null });
+  });
+
+  it('a sent notice shows the date and asks for nothing more', () => {
+    render(
+      <ScreeningPanel
+        screenings={[
+          {
+            ...base,
+            decision: 'denied',
+            adverse_action_required: true,
+            adverse_action_sent_on: '2026-08-27',
+          },
+        ]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/notice sent Aug 27, 2026/).className).toBe('pill pill--ok');
+    expect(screen.queryByRole('button', { name: 'Record the notice' })).toBeNull();
+  });
+
+  it('an unknown decision word still renders, neutrally', () => {
+    render(
+      <ScreeningPanel
+        screenings={[{ ...base, decision: 'under_review' }]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    // The contract types decision as a plain string; a word this client has
+    // never met must not crash the panel or claim a tone it cannot justify.
+    expect(screen.getByText('under_review').className).toBe('pill');
+  });
+
+  it('a checklist item without a citation renders bare, never a blank stamp', () => {
+    render(
+      <ScreeningPanel
+        screenings={[
+          {
+            ...base,
+            decision: 'denied',
+            adverse_action_required: true,
+            notice_contents: [{ requirement: 'State the adverse action taken' }],
+          },
+        ]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('State the adverse action taken')).toBeDefined();
+    expect(document.querySelector('.citation-chip')).toBeNull();
+  });
+
+  it('no notice block appears when no notice is owed', () => {
+    render(
+      <ScreeningPanel
+        screenings={[{ ...base, decision: 'approved', decided_on: '2026-08-25' }]}
+        onDecide={vi.fn()}
+        onNotice={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/adverse-action notice owed/)).toBeNull();
+    expect(screen.queryByText(/notice sent/)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #84 — the web half of #3 (E1 screening), per the co-dev handoff.

**The panel** lives on the lease view, property-scoped on purpose: an applicant who was denied is, by definition, not a resident on any lease — and the adverse-action duty is owed to exactly that person.

**The decision** is recorded once from a pending screening (approved / conditional / denied / withdrawn, date, basis, whether a consumer report was used); the server refuses re-decisions and the panel shows the record, not a form, once one exists.

**The checklist**: when a notice is owed and unsent, the panel renders `notice_contents` exactly as the server enumerates it — each FCRA requirement carrying its citation as a stamp. No client-side legal logic anywhere. Recording the send resolves the duty.

**Ladder**: 209 unit tests / 100% statements+branches+functions, api client walks all five contract paths with URL/method assertions, 23/23 e2e against the live stack (new walk owns its applicant and screening and proves the honest transitions), full verify green.

**Known gap, noted to the API side**: no read surface exposes resident ids, so the web has no "open screening" affordance yet — the walk arranges its screening through the API and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)