### PR TITLE
The register stops shoving the page

### DIFF
--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Skeleton } from '@hestia/design';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TransactionsTable } from '../../components/TransactionsTable';
 import { api, type LedgerEntryIn, type LedgerRegister, type PropertySummary } from '../../lib/api';
@@ -141,29 +142,22 @@ export default function TransactionsPage() {
             ))}
           </select>
         </div>
-        {register ? (
-          <p className="muted">
-            In {formatTotal(register.total_in)} · Out {formatTotal(register.total_out)} · Net{' '}
-            <strong className={Number(register.net) < 0 ? 'error-note' : ''}>
-              {Number(register.net) < 0 ? '−' : ''}
-              {formatTotal(register.net)}
-            </strong>
-          </p>
-        ) : null}
+        {/* Rendered from first paint, placeholders and all: a totals line
+            that pops in later shifts the whole row (the CLS gate, #86). */}
+        <p className="muted">
+          {register ? (
+            <>
+              In {formatTotal(register.total_in)} · Out {formatTotal(register.total_out)} · Net{' '}
+              <strong className={Number(register.net) < 0 ? 'error-note' : ''}>
+                {Number(register.net) < 0 ? '−' : ''}
+                {formatTotal(register.net)}
+              </strong>
+            </>
+          ) : (
+            'In — · Out — · Net —'
+          )}
+        </p>
       </div>
-
-      <section className="section">
-        {register ? (
-          <TransactionsTable
-            events={register.events}
-            onReverse={(uuid) => {
-              void reverse(uuid);
-            }}
-          />
-        ) : (
-          <p className="muted">Loading…</p>
-        )}
-      </section>
 
       <section className="section">
         <h2 className="section__title">Record a transaction</h2>
@@ -301,6 +295,23 @@ export default function TransactionsPage() {
             {busy ? 'Recording…' : 'Record'}
           </button>
         </form>
+      </section>
+
+      {/* The register comes LAST in the DOM on purpose: it arrives late and
+          grows without bound, and content below it would be shoved down by
+          its full height — CLS 0.83 on a data-rich database (#86). Last,
+          it can shift nothing. */}
+      <section className="section">
+        {register ? (
+          <TransactionsTable
+            events={register.events}
+            onReverse={(uuid) => {
+              void reverse(uuid);
+            }}
+          />
+        ) : (
+          <Skeleton lines={6} />
+        )}
       </section>
     </>
   );


### PR DESCRIPTION
Closes #86.

The #6 Lighthouse gate, two days old, caught its first post-merge defect on PR #85's run: /transactions at 0.88 performance on CI — and the whole gap was **CLS 0.827** (0.76 perf against a data-rich local database; every other weighted metric 1.0). The register table arrived late and pushed the record form down by its full height, so the bigger the ledger, the worse the shove.

**Fix**: content that arrives late and grows without bound comes last in the DOM, where it can shift nothing — the record form moves above the register (it is also the page's primary action); the In/Out/Net totals line renders from first paint with placeholders; the loading state becomes a Skeleton (polish, not the fix).

**Measured after, against the same database that scored 0.76**: performance 1.0, CLS 0. 22/22 e2e green (the transactions walk survives the reorder), full verify green.

PR #85 (screening) rebases onto this once merged and reruns its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)