### PR TITLE
Commit before answering: a response is a promise about durable state

### DIFF
--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -82,7 +82,12 @@ def get_conn() -> Iterator[psycopg.Connection[dict[str, Any]]]:
     yield from db.connection_for(config.database_url())
 
 
-Conn = Annotated[psycopg.Connection[dict[str, Any]], Depends(get_conn)]
+# scope="function" is load-bearing, not decoration. It puts the connection on
+# the exit stack FastAPI unwinds BEFORE sending the response, rather than the
+# default one it unwinds after — so the commit finishes while the caller is
+# still waiting, and the answer it gets describes state that already exists.
+# Issue #83; see db.connection_for and tests/test_transaction_boundary.py.
+Conn = Annotated[psycopg.Connection[dict[str, Any]], Depends(get_conn, scope="function")]
 Actor = Annotated[str, Header(alias="x-actor")]
 
 

--- a/services/api/hestia_api/db.py
+++ b/services/api/hestia_api/db.py
@@ -4,6 +4,10 @@ One connection per request, context-managed; every mutating endpoint records
 what it did in audit_log with the request's correlation id, in the SAME
 transaction as the change — an audit trail that can miss writes is a story,
 not a trail.
+
+WHEN the transaction settles is part of the contract: a response is a promise
+about durable state, and a promise made before the commit is a promise made
+before it is true. See connection_for below.
 """
 
 from __future__ import annotations
@@ -22,7 +26,20 @@ def open_connection(url: str) -> psycopg.Connection[dict[str, Any]]:
 
 def connection_for(url: str) -> Iterator[psycopg.Connection[dict[str, Any]]]:
     """FastAPI dependency: yield a connection, commit on success, roll back on
-    any exception, always close."""
+    any exception, always close.
+
+    WHEN this exit code runs is part of the API's contract, and it is not the
+    default. FastAPI keeps two exit stacks per request
+    (fastapi.routing.request_response): a function stack that unwinds BEFORE
+    the response is sent, and a request stack that unwinds after it. A
+    yield-dependency lands on the late one unless its `Depends` carries
+    `scope="function"`, which is why the `Conn` alias in app.py does.
+
+    Without it the commit happens once the client already holds its 201, so a
+    caller acting on the id it was just handed can get a 404 for a row that
+    exists, and a form that re-reads after submitting can miss its own write.
+    That was issue #83. tests/test_transaction_boundary.py holds the line.
+    """
     conn = open_connection(url)
     try:
         yield conn

--- a/services/api/tests/test_transaction_boundary.py
+++ b/services/api/tests/test_transaction_boundary.py
@@ -1,0 +1,215 @@
+"""When the transaction settles, relative to when the response is sent.
+
+The API's answer is a promise about durable state. If the commit lands after
+the response, the promise is made before it is true: a client that acts on an
+id it was just handed can get a 404 for a row that exists, and a form that
+re-reads after it submits can miss its own write. Issue #83 caught exactly
+that in the wild — a vendor was created, the POST returned 201, and a GET
+issued one millisecond later returned the list without it.
+
+The ordering is only observable from inside the ASGI protocol. TestClient
+hides it, and a real server shows it only as flakiness under load, which is
+how it survived this long. So these tests drive the application directly with
+their own `send` and watch both events on one timeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+from typing import Any
+
+import psycopg
+import pytest
+from hestia_api import db
+
+
+class _Timeline:
+    """Every database settle and every ASGI send, in the order they happen."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self._tick = itertools.count()
+
+    def record(self, name: str) -> None:
+        self.events.append(name)
+        next(self._tick)
+
+    def index(self, name: str) -> int:
+        return self.events.index(name)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self.events
+
+
+class _Watched:
+    """A connection that announces when it settles, and is otherwise itself."""
+
+    def __init__(self, inner: Any, timeline: _Timeline) -> None:
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_timeline", timeline)
+
+    def commit(self) -> Any:
+        result = self._inner.commit()
+        self._timeline.record("commit")
+        return result
+
+    def rollback(self) -> Any:
+        result = self._inner.rollback()
+        self._timeline.record("rollback")
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._inner, name, value)
+
+
+@pytest.fixture
+def timeline(monkeypatch: pytest.MonkeyPatch) -> _Timeline:
+    recorded = _Timeline()
+    real_open = db.open_connection
+
+    def watched_open(url: str) -> Any:
+        return _Watched(real_open(url), recorded)
+
+    monkeypatch.setattr(db, "open_connection", watched_open)
+    return recorded
+
+
+def _call(timeline: _Timeline, method: str, path: str, body: dict[str, Any] | None) -> int:
+    """One request, driven through the raw ASGI interface."""
+    from hestia_api.app import app
+
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "scheme": "http",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(raw)).encode()),
+        ],
+        "client": ("127.0.0.1", 1),
+        "server": ("testserver", 80),
+    }
+    status: dict[str, int] = {}
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": raw, "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+            timeline.record("response.start")
+
+    asyncio.run(app(scope, receive, send))
+    return status["code"]
+
+
+def test_the_transaction_commits_before_the_response_is_sent(
+    clean: None, timeline: _Timeline
+) -> None:
+    """The defect in #83, as a property rather than a symptom.
+
+    A 201 that arrives before its own commit is a receipt for a row nobody
+    else can see yet. Whoever reads next — the same form, another tab, the
+    sweep — is entitled to find what the response just described."""
+    status = _call(timeline, "POST", "/entities", {"name": "Boundary", "kind": "llc"})
+    assert status == 201
+    assert "commit" in timeline, "the request never committed at all"
+    assert timeline.index("commit") < timeline.index("response.start"), (
+        "the response was sent before the transaction committed; a client acting on "
+        f"this response can miss its own write (timeline: {timeline.events})"
+    )
+
+
+def test_a_refused_mutation_rolls_back_before_the_response_is_sent(
+    clean: None, timeline: _Timeline
+) -> None:
+    """The same promise on the failing path: by the time the client is told
+    no, there must be nothing left half-written behind the answer."""
+    status = _call(timeline, "POST", "/entities", {"name": "", "kind": "llc"})
+    assert status == 422
+    settled = [event for event in timeline.events if event in {"commit", "rollback"}]
+    if settled:
+        assert timeline.index(settled[-1]) < timeline.index("response.start"), (
+            f"the refusal was sent before the transaction settled: {timeline.events}"
+        )
+
+
+def test_the_row_is_readable_by_another_connection_once_the_response_exists(
+    clean: None, timeline: _Timeline, database_url: str
+) -> None:
+    """The consequence, stated in the terms a caller cares about: a separate
+    connection — a different request, in production — sees the row the moment
+    the response describing it exists."""
+    status = _call(timeline, "POST", "/entities", {"name": "Readable", "kind": "llc"})
+    assert status == 201
+    with psycopg.connect(database_url, row_factory=psycopg.rows.dict_row) as other:
+        found = other.execute(
+            "SELECT count(*) AS n FROM entities WHERE name = 'Readable'"
+        ).fetchone()
+    assert found is not None and found["n"] == 1
+
+
+def test_the_connection_dependency_settles_before_the_response() -> None:
+    """The fix is one line, so it is one line away from being lost.
+
+    Every route reaches the database through the same `Conn` alias, and that
+    alias settles early only because its `Depends` carries scope="function".
+    Drop the argument, or add a second database dependency without it, and
+    the commit silently moves back to after the send — which is #83, and
+    which nothing else in the suite would notice."""
+    from typing import get_args
+
+    from hestia_api import app as app_module
+
+    marker = get_args(app_module.Conn)[1]
+    assert marker.scope == "function", (
+        "Conn lost scope='function': its transaction would commit after the "
+        "response is sent, and a caller acting on the response could miss its "
+        "own write"
+    )
+
+    # And no route may reach the database by some other, later dependency.
+    late = [
+        f"{route.path} -> {dependency.call.__name__}"
+        for route in app_module.app.routes
+        for dependency in getattr(getattr(route, "dependant", None), "dependencies", [])
+        if dependency.call is app_module.get_conn and dependency.scope != "function"
+    ]
+    assert late == [], f"these routes would commit after their response: {late}"
+
+
+def test_the_dependency_rolls_back_and_closes_when_the_endpoint_raises() -> None:
+    """Rollback and close are unconditional, whatever the endpoint did."""
+    from hestia_api import config, db
+
+    connections: list[Any] = []
+    real_open = db.open_connection
+
+    def remember(url: str) -> Any:
+        conn = real_open(url)
+        connections.append(conn)
+        return conn
+
+    db.open_connection = remember
+    try:
+        generator = db.connection_for(config.database_url())
+        next(generator)
+        with pytest.raises(RuntimeError, match="the endpoint blew up"):
+            generator.throw(RuntimeError("the endpoint blew up"))
+    finally:
+        db.open_connection = real_open
+    assert len(connections) == 1
+    assert connections[0].closed


### PR DESCRIPTION
Closes #83.

Every mutating endpoint — 41 of them — returned 200/201 describing a row that was not yet committed. A client acting on the response could miss its own write. This is a correctness property, not a test problem: the API's answer is a promise about durable state, and it was being made before the state was durable.

## The cause, from the installed source

`fastapi.routing.request_response` keeps **two** exit stacks per request:

```python
async with AsyncExitStack() as request_stack:          # fastapi_inner_astack
    async with AsyncExitStack() as function_stack:    # fastapi_function_astack
        response = await f(request)                    # endpoint runs
    # function_stack closes HERE — before the send
    await response(scope, receive, send)               # response SENT
# request_stack closes here — after the client has the answer
```

And `fastapi/dependencies/utils.py` chooses between them:

```python
use_astack = request_astack
if sub_dependant.scope == "function":
    use_astack = function_astack
```

The default is the late stack, so `conn.commit()` in the dependency's exit code ran after the response had gone out.

## Three proofs

1. **The CI trace** that started this. `POST /vendors` → 201; a `GET /vendors` issued 1ms later spent **22.8ms of server wait** — not a cache hit — and returned the list without the new vendor. `apps/web/src/lib/api.ts` awaits `response.json()`, so the GET genuinely followed the POST. The browser was never at fault.

2. **Widen the window and it is deterministic.** With `commit()` slowed to 250ms, `POST /entities` returns 201 and the next `POST /vendors` using that id returns **404 unknown entity**, 5/5.

3. **In-process, no sleeping.** Driving the ASGI app with an instrumented `send`: `response.start → response.body → commit`.

## The fix

The argument FastAPI provides for exactly this:

```python
Conn = Annotated[psycopg.Connection[dict[str, Any]], Depends(get_conn, scope="function")]
```

documented as ending the dependency after the path operation function but *before* the response is sent. One line. No endpoint touched, no new abstraction, no new branch to cover.

**On the way here I built something worse and am saying so.** My first version was a custom `APIRoute` subclass that settled the transaction around the handler. It worked and CI was green on it — but it was forty lines, it carried its own quiet failure mode (a route registered outside the class would serve traffic, open a connection and never commit), and it reimplemented something the framework already exposes. This replaces it.

## What a one-liner needs instead

A guard, because one line is one line away from being deleted. `services/api/tests/test_transaction_boundary.py`:

- asserts the ordering directly, by driving the ASGI app with its own `send` — `TestClient` hides this, and a real server shows it only as flakiness under load, which is how it survived this long;
- asserts that no route reaches the database through a dependency lacking `scope="function"`, so a second dependency added later cannot silently reintroduce the bug.

Both fail if the argument is removed — verified by removing it.

The same slow-commit probe that failed 5/5 now passes 5/5, with the 250ms **inside** the POST's own latency where it belongs: the caller waits for durability instead of being told it already happened.

This is also the real cause of the CI flakiness that the CI-only 15s Playwright `expect` timeout in #78 was treating. That budget may now be reducible, but `apps/web/playwright.config.ts` is the other agent's surface and I have not touched it.

## Gates

- `services/api` — 286 passed at 100% line and branch against real Postgres
- `services/sim`, `services/ingest` — 100%
- `pnpm run verify` — green
- ruff check + format, state-literal ratchet, config audit, OpenAPI drift — all clean
