### PR TITLE
Debt: the record beside the what-if

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -238,6 +238,37 @@ test('screening: the decision is recorded once and the FCRA checklist appears', 
   await expect(card.getByText('State the adverse action taken')).toHaveCount(0);
 });
 
+test('the debt record: a mortgage, the engine split, and the counters move', async ({ page }) => {
+  // This walk OWNS its note — a unique lender per run, all assertions scoped
+  // to that lender's card, because a long-lived database accumulates notes.
+  await page.goto('/');
+  await page.getByText('998 Monmouth St, Newport, KY 41071').first().click();
+  const lender = `Walk Federal ${String(Date.now())}`;
+  await page.getByLabel('Lender').fill(lender);
+  await page.getByLabel('Original principal').fill('190000.00');
+  await page.getByLabel(/Annual rate/).fill('0.0625');
+  await page.getByLabel('Term (months)').fill('360');
+  await page.getByLabel('Originated').fill('2024-02-01');
+  await page.getByRole('button', { name: 'Record the mortgage' }).click();
+
+  const card = page.locator('.debt-panel .card', { hasText: lender });
+  await expect(card.getByText(/0 payments — \$0\.00 principal, \$0\.00 interest/)).toBeVisible();
+  await expect(card.getByText(/at 6\.250% over 360 months/)).toBeVisible();
+
+  // The engine's split arrives as the suggestion, and the recorder is
+  // pre-filled with it — the exact figures, not a rounding of them.
+  await expect(card.getByText(/Next per the engine: month \d+/)).toBeVisible();
+  const interest = card.getByLabel('Interest');
+  await expect(interest).not.toHaveValue('');
+  await card.getByRole('button', { name: 'Record the payment' }).click();
+  await expect(card.getByText(/1 payments — /)).toBeVisible();
+
+  // The schedule unfolds under its citation.
+  await card.getByRole('button', { name: /The schedule/ }).click();
+  await expect(card.getByText(/hestia_sim\.finance\.amortization/).first()).toBeVisible();
+  await expect(card.getByText(/of interest over the remaining term/)).toBeVisible();
+});
+
 test('a work order completes and the vendor calendar knows its certificate', async ({ page }) => {
   // A vendor with a certificate that expires: the day it lapses is a deadline.
   await page.goto('/vendors');

--- a/apps/web/src/app/property/[id]/page.tsx
+++ b/apps/web/src/app/property/[id]/page.tsx
@@ -5,6 +5,7 @@ import { CapexFanChart, HoldSellCard, InsuranceCard } from '../../../components/
 import { AmortizationExplorer } from '../../../components/AmortizationExplorer';
 import { ComponentsTable } from '../../../components/ComponentsTable';
 import { DeadlineList } from '../../../components/DeadlineList';
+import { DebtPanel } from '../../../components/DebtPanel';
 import { DefectRegister } from '../../../components/DefectRegister';
 import { ExitTimeline } from '../../../components/ExitTimeline';
 import { HazardCard } from '../../../components/HazardCard';
@@ -112,12 +113,19 @@ export default function PropertyPage({ params }: { params: Promise<{ id: string 
         </section>
       )}
 
-      {financials !== null && financials.debts.length > 0 ? (
-        <section className="section">
-          <h2 className="section__title">The debt</h2>
+      <section className="section">
+        <h2 className="section__title">The debt</h2>
+        {financials !== null && financials.debts.length > 0 ? (
           <AmortizationExplorer debts={financials.debts} today={today} />
-        </section>
-      ) : null}
+        ) : null}
+        <DebtPanel
+          propertyId={id}
+          today={today}
+          onChanged={() => {
+            void load();
+          }}
+        />
+      </section>
 
       <button
         className="button"

--- a/apps/web/src/components/DebtPanel.tsx
+++ b/apps/web/src/components/DebtPanel.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+import { Button, CitationChip, Disclosure, KeyValue, Pill } from '@hestia/design';
+import { rate, rateToPercentString } from '@hestia/domain';
+import { useCallback, useEffect, useState } from 'react';
+import { api, type DebtOut, type ScheduleOut } from '../lib/api';
+import { formatDate } from '../lib/format';
+import { formatMoney } from './TransactionsTable';
+
+/**
+ * The record beside the what-if: the explorer above scrubs futures, this
+ * panel is what actually happened — every note with its recorded payments,
+ * the engine's schedule under its citation, and a payment recorder
+ * pre-filled with the engine's split for the period. A payment stating its
+ * own figures records what the lender applied; one that states none takes
+ * the engine's, to the cent, server-side.
+ */
+const KINDS = [
+  'conventional_mortgage',
+  'portfolio_loan',
+  'dscr_loan',
+  'agency_multifamily',
+  'bridge',
+  'hard_money',
+  'heloc',
+  'seller_financing',
+  'private_note',
+] as const;
+
+function ScheduleTable({ schedule }: { schedule: ScheduleOut }) {
+  return (
+    <>
+      <p>
+        <CitationChip cite={schedule.citation} />{' '}
+        <span className="muted">
+          {formatMoney(schedule.total_interest)} of interest over the remaining term
+        </span>
+      </p>
+      <div className="card card--flush" style={{ maxHeight: 280, overflowY: 'auto' }}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Month</th>
+              <th style={{ textAlign: 'right' }}>Payment</th>
+              <th style={{ textAlign: 'right' }}>Interest</th>
+              <th style={{ textAlign: 'right' }}>Principal</th>
+              <th style={{ textAlign: 'right' }}>Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {schedule.rows.map((row) => (
+              <tr key={row.month}>
+                <td>{row.month}</td>
+                <td style={{ textAlign: 'right' }}>{formatMoney(row.payment)}</td>
+                <td style={{ textAlign: 'right' }}>{formatMoney(row.interest)}</td>
+                <td style={{ textAlign: 'right' }}>{formatMoney(row.principal)}</td>
+                <td style={{ textAlign: 'right' }}>{formatMoney(row.balance)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function PaymentForm({
+  debt,
+  schedule,
+  today,
+  onRecord,
+}: {
+  debt: DebtOut;
+  schedule: ScheduleOut | null;
+  today: string;
+  onRecord: (debtId: string, body: Parameters<typeof api.recordDebtPayment>[1]) => void;
+}) {
+  const [paidOn, setPaidOn] = useState(today);
+  const [interest, setInterest] = useState<string | null>(null);
+  const [principal, setPrincipal] = useState<string | null>(null);
+  const [extraPrincipal, setExtraPrincipal] = useState('0');
+  const [postToLedger, setPostToLedger] = useState(true);
+  // The engine's split for the period is the suggestion; a cleared field
+  // means "take the engine's figure", which is also what the server does.
+  const interestValue = interest ?? schedule?.next_interest ?? '';
+  const principalValue = principal ?? schedule?.next_principal ?? '';
+  return (
+    <form
+      className="form-row"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onRecord(debt.id, {
+          paid_on: paidOn,
+          interest: interestValue === '' ? null : interestValue,
+          principal: principalValue === '' ? null : principalValue,
+          extra_principal: extraPrincipal === '' ? '0' : extraPrincipal,
+          // Escrow stays out of the v1 form; the default it means is zero.
+          escrow: '0',
+          post_to_ledger: postToLedger,
+        });
+      }}
+    >
+      <div className="field">
+        <label htmlFor={`dp-date-${debt.id}`}>Paid on</label>
+        <input
+          id={`dp-date-${debt.id}`}
+          type="date"
+          required
+          value={paidOn}
+          onChange={(event) => {
+            setPaidOn(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`dp-interest-${debt.id}`}>Interest</label>
+        <input
+          id={`dp-interest-${debt.id}`}
+          inputMode="decimal"
+          value={interestValue}
+          onChange={(event) => {
+            setInterest(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`dp-principal-${debt.id}`}>Principal</label>
+        <input
+          id={`dp-principal-${debt.id}`}
+          inputMode="decimal"
+          value={principalValue}
+          onChange={(event) => {
+            setPrincipal(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`dp-extra-${debt.id}`}>Extra principal</label>
+        <input
+          id={`dp-extra-${debt.id}`}
+          inputMode="decimal"
+          value={extraPrincipal}
+          onChange={(event) => {
+            setExtraPrincipal(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor={`dp-ledger-${debt.id}`}>
+          <input
+            id={`dp-ledger-${debt.id}`}
+            type="checkbox"
+            checked={postToLedger}
+            onChange={(event) => {
+              setPostToLedger(event.target.checked);
+            }}
+          />{' '}
+          Post to the ledger
+        </label>
+      </div>
+      <Button type="submit">Record the payment</Button>
+    </form>
+  );
+}
+
+function NoteCard({
+  debt,
+  today,
+  onRecord,
+  onPayoff,
+}: {
+  debt: DebtOut;
+  today: string;
+  onRecord: (debtId: string, body: Parameters<typeof api.recordDebtPayment>[1]) => void;
+  onPayoff: (debtId: string, paidOffOn: string) => void;
+}) {
+  const [schedule, setSchedule] = useState<ScheduleOut | null>(null);
+  const retired = debt.paid_off_on !== null;
+  const amortizing = debt.scheduled_payment !== null;
+  useEffect(() => {
+    if (!amortizing || retired) return;
+    // The schedule is a suggestion surface; the record stands without it.
+    api
+      .debtSchedule(debt.id)
+      .then(setSchedule)
+      .catch(() => {
+        setSchedule(null);
+      });
+  }, [debt.id, amortizing, retired]);
+
+  return (
+    <div className="card">
+      <p>
+        <strong>{debt.lender ?? 'Unnamed lender'}</strong>{' '}
+        <Pill>{debt.kind.replaceAll('_', ' ')}</Pill>{' '}
+        {retired ? <Pill tone="ok">paid off {formatDate(debt.paid_off_on as string)}</Pill> : null}
+      </p>
+      <KeyValue
+        items={[
+          {
+            key: 'The note',
+            value: `${formatMoney(debt.original_principal)} at ${rateToPercentString(
+              rate(debt.interest_rate),
+            )} over ${debt.term_months} months — originated ${formatDate(debt.originated_on)}`,
+          },
+          {
+            key: 'Scheduled payment',
+            value: amortizing
+              ? `${formatMoney(debt.scheduled_payment as string)}/mo`
+              : `none — a ${debt.amortization.replaceAll('_', ' ')} note gets no inferred split`,
+          },
+          {
+            key: 'Recorded',
+            value: `${debt.payments_recorded} payments — ${formatMoney(
+              debt.principal_paid,
+            )} principal, ${formatMoney(debt.interest_paid)} interest`,
+          },
+        ]}
+      />
+      {schedule ? (
+        <>
+          {schedule.next_interest !== null && schedule.next_principal !== null ? (
+            <p className="muted">
+              Next per the engine: month {schedule.next_month} —{' '}
+              {formatMoney(schedule.next_interest)} interest, {formatMoney(schedule.next_principal)}{' '}
+              principal.
+            </p>
+          ) : null}
+          <Disclosure summary="The schedule">
+            <ScheduleTable schedule={schedule} />
+          </Disclosure>
+        </>
+      ) : null}
+      {retired ? null : (
+        <>
+          <PaymentForm debt={debt} schedule={schedule} today={today} onRecord={onRecord} />
+          <p>
+            <Button
+              variant="quiet"
+              type="button"
+              onClick={() => {
+                onPayoff(debt.id, today);
+              }}
+            >
+              Record payoff as of {formatDate(today)}
+            </Button>
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function EntryForm({
+  onCreate,
+}: {
+  onCreate: (body: Parameters<typeof api.createDebt>[0]) => void;
+}) {
+  const [lender, setLender] = useState('');
+  const [kind, setKind] = useState<(typeof KINDS)[number]>('conventional_mortgage');
+  const [principal, setPrincipal] = useState('');
+  const [interestRate, setInterestRate] = useState('');
+  const [termMonths, setTermMonths] = useState('360');
+  const [originatedOn, setOriginatedOn] = useState('');
+  return (
+    <form
+      className="form-row"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onCreate({
+          lender: lender === '' ? null : lender,
+          kind,
+          original_principal: principal,
+          interest_rate: interestRate,
+          term_months: Number(termMonths),
+          originated_on: originatedOn,
+          // What the form does not ask, it states as the default it means —
+          // the long tail of DebtIn is deliberately out of the v1 form.
+          amortization: 'fully_amortizing',
+          lien_position: 1,
+          is_recourse: true,
+          has_due_on_sale: true,
+          prepayment: 'none',
+          escrows_taxes: false,
+          escrows_insurance: false,
+          // property_id is the panel's; it completes the body.
+          property_id: '',
+        });
+      }}
+    >
+      <div className="field">
+        <label htmlFor="db-lender">Lender</label>
+        <input
+          id="db-lender"
+          value={lender}
+          onChange={(event) => {
+            setLender(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="db-kind">Kind</label>
+        <select
+          id="db-kind"
+          value={kind}
+          onChange={(event) => {
+            setKind(event.target.value as (typeof KINDS)[number]);
+          }}
+        >
+          {KINDS.map((option) => (
+            <option key={option} value={option}>
+              {option.replaceAll('_', ' ')}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="field">
+        <label htmlFor="db-principal">Original principal</label>
+        <input
+          id="db-principal"
+          required
+          inputMode="decimal"
+          value={principal}
+          onChange={(event) => {
+            setPrincipal(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="db-rate">Annual rate (decimal, e.g. 0.0625)</label>
+        <input
+          id="db-rate"
+          required
+          inputMode="decimal"
+          value={interestRate}
+          onChange={(event) => {
+            setInterestRate(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="db-term">Term (months)</label>
+        <input
+          id="db-term"
+          required
+          inputMode="numeric"
+          value={termMonths}
+          onChange={(event) => {
+            setTermMonths(event.target.value);
+          }}
+        />
+      </div>
+      <div className="field">
+        <label htmlFor="db-originated">Originated</label>
+        <input
+          id="db-originated"
+          type="date"
+          required
+          value={originatedOn}
+          onChange={(event) => {
+            setOriginatedOn(event.target.value);
+          }}
+        />
+      </div>
+      <Button type="submit">Record the mortgage</Button>
+    </form>
+  );
+}
+
+type DebtPanelProps = {
+  propertyId: string;
+  today: string;
+  onChanged?: () => void;
+};
+
+export function DebtPanel({ propertyId, today, onChanged }: DebtPanelProps) {
+  const [debts, setDebts] = useState<DebtOut[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setDebts(await api.listDebts({ propertyId, includePaidOff: true }));
+      setError(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [propertyId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const act = async (action: () => Promise<unknown>) => {
+    setError(null);
+    try {
+      await action();
+      await load();
+      onChanged?.();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <div className="debt-panel">
+      {error ? <p className="error-note">{error}</p> : null}
+      {debts === null ? (
+        <p className="muted">Loading…</p>
+      ) : (
+        <>
+          {debts.map((debt) => (
+            <NoteCard
+              key={debt.id}
+              debt={debt}
+              today={today}
+              onRecord={(debtId, body) => {
+                void act(() => api.recordDebtPayment(debtId, body));
+              }}
+              onPayoff={(debtId, paidOffOn) => {
+                void act(() => api.payoffDebt(debtId, { paid_off_on: paidOffOn }));
+              }}
+            />
+          ))}
+          {debts.length === 0 ? (
+            <p className="muted">No notes on record — the mortgage goes here.</p>
+          ) : null}
+          <div className="card">
+            <strong>Record a mortgage</strong>
+            <EntryForm
+              onCreate={(body) => {
+                void act(() => api.createDebt({ ...body, property_id: propertyId }));
+              }}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -45,6 +45,13 @@ export type ScreeningOut = components['schemas']['ScreeningOut'];
 export type ScreeningIn = components['schemas']['ScreeningIn'];
 export type DecisionIn = components['schemas']['DecisionIn'];
 export type NoticeIn = components['schemas']['NoticeIn'];
+export type DebtOut = components['schemas']['DebtOut'];
+export type DebtIn = components['schemas']['DebtIn'];
+export type PaymentIn = components['schemas']['PaymentIn'];
+export type PaymentOut = components['schemas']['PaymentOut'];
+export type PayoffIn = components['schemas']['PayoffIn'];
+export type ScheduleOut = components['schemas']['ScheduleOut'];
+export type ScheduleRow = components['schemas']['ScheduleRow'];
 export type DocumentSummary = components['schemas']['DocumentSummary'];
 export type DocumentDetail = components['schemas']['DocumentDetail'];
 export type DocumentField = components['schemas']['FieldOut'];
@@ -303,4 +310,23 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+  listDebts: (params?: { propertyId?: string; includePaidOff?: boolean }) => {
+    const query = new URLSearchParams();
+    if (params?.propertyId) query.set('property_id', params.propertyId);
+    if (params?.includePaidOff) query.set('include_paid_off', 'true');
+    const suffix = query.size > 0 ? `?${query.toString()}` : '';
+    return request<DebtOut[]>(`/debts${suffix}`);
+  },
+  createDebt: (body: DebtIn) =>
+    request<DebtOut>('/debts', { method: 'POST', body: JSON.stringify(body) }),
+  readDebt: (debtId: string) => request<DebtOut>(`/debts/${debtId}`),
+  debtSchedule: (debtId: string, asOf?: string) =>
+    request<ScheduleOut>(`/debts/${debtId}/schedule${asOf ? `?as_of=${asOf}` : ''}`),
+  recordDebtPayment: (debtId: string, body: PaymentIn) =>
+    request<PaymentOut>(`/debts/${debtId}/payments`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  payoffDebt: (debtId: string, body: PayoffIn) =>
+    request<DebtOut>(`/debts/${debtId}/payoff`, { method: 'POST', body: JSON.stringify(body) }),
 };

--- a/apps/web/tests/api.test.ts
+++ b/apps/web/tests/api.test.ts
@@ -355,6 +355,57 @@ describe('the API client', () => {
     );
   });
 
+  it('walks the debt paths against the contract', async () => {
+    const fetchMock = vi.fn().mockImplementation(jsonResponse(200, []));
+    vi.stubGlobal('fetch', fetchMock);
+    await api.listDebts();
+    expect(fetchMock).toHaveBeenLastCalledWith('http://localhost:8000/debts', expect.anything());
+    await api.listDebts({ propertyId: 'p1', includePaidOff: true });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts?property_id=p1&include_paid_off=true',
+      expect.anything(),
+    );
+    await api.createDebt({
+      property_id: 'p1',
+      lender: 'First Federal',
+      original_principal: '190000.00',
+      interest_rate: '0.0625',
+      term_months: 360,
+      originated_on: '2024-02-01',
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    await api.readDebt('n1');
+    expect(fetchMock).toHaveBeenLastCalledWith('http://localhost:8000/debts/n1', expect.anything());
+    await api.debtSchedule('n1');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts/n1/schedule',
+      expect.anything(),
+    );
+    await api.debtSchedule('n1', '2026-08-28');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts/n1/schedule?as_of=2026-08-28',
+      expect.anything(),
+    );
+    await api.recordDebtPayment('n1', {
+      paid_on: '2026-08-28',
+      extra_principal: '0',
+      escrow: '0',
+      post_to_ledger: true,
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts/n1/payments',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    await api.payoffDebt('n1', { paid_off_on: '2026-08-28' });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/debts/n1/payoff',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
   it('uploads documents as multipart and surfaces refusals', async () => {
     const file = new File(['%PDF fake'], 'closing.pdf', { type: 'application/pdf' });
     const fetchMock = vi

--- a/apps/web/tests/debt-panel.test.tsx
+++ b/apps/web/tests/debt-panel.test.tsx
@@ -1,0 +1,334 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DebtPanel } from '../src/components/DebtPanel';
+import { api, type DebtOut, type ScheduleOut } from '../src/lib/api';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const TODAY = '2026-08-28';
+
+const NOTE: DebtOut = {
+  id: 'n1',
+  property_id: 'p1',
+  property_label: '998 Monmouth St',
+  entity_id: 'e1',
+  lender: 'First Federal',
+  kind: 'conventional_mortgage',
+  lien_position: 1,
+  original_principal: '190000.00',
+  interest_rate: '0.06250000',
+  term_months: 360,
+  originated_on: '2024-02-01',
+  first_payment_on: null,
+  matures_on: null,
+  amortization: 'fully_amortizing',
+  amortization_months: null,
+  scheduled_payment: '1169.79',
+  payments_recorded: 2,
+  principal_paid: '360.00',
+  interest_paid: '1979.58',
+  paid_off_on: null,
+  is_recourse: true,
+  has_due_on_sale: true,
+  prepayment: 'none',
+  prepayment_terms: null,
+  rate_index: null,
+  rate_adjusts_on: null,
+  escrows_taxes: false,
+  escrows_insurance: false,
+  document_id: null,
+};
+
+const SCHEDULE: ScheduleOut = {
+  debt_id: 'n1',
+  scheduled_payment: '1169.79',
+  citation: 'engines/amortization',
+  total_interest: '200934.62',
+  next_month: 32,
+  next_interest: '985.61',
+  next_principal: '184.18',
+  rows: [
+    {
+      month: 31,
+      payment: '1169.79',
+      interest: '986.57',
+      principal: '183.22',
+      balance: '189261.42',
+    },
+    {
+      month: 32,
+      payment: '1169.79',
+      interest: '985.61',
+      principal: '184.18',
+      balance: '189077.24',
+    },
+  ],
+};
+
+const arrange = (debts: DebtOut[], schedule: ScheduleOut | null = SCHEDULE) => {
+  vi.spyOn(api, 'listDebts').mockResolvedValue(debts);
+  const scheduleSpy = vi.spyOn(api, 'debtSchedule');
+  if (schedule === null) {
+    scheduleSpy.mockRejectedValue(new Error('no schedule'));
+  } else {
+    scheduleSpy.mockResolvedValue(schedule);
+  }
+  return { scheduleSpy };
+};
+
+describe('DebtPanel', () => {
+  it('renders the record: the note, the counters, and the engine suggestion', async () => {
+    arrange([NOTE]);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    expect(screen.getByText('Loading…')).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText('First Federal')).toBeDefined();
+    });
+    expect(screen.getByText('conventional mortgage', { selector: '.pill' })).toBeDefined();
+    expect(
+      screen.getByText(/\$190,000\.00 at 6\.250% over 360 months — originated Feb 1, 2024/),
+    ).toBeDefined();
+    expect(screen.getByText('$1,169.79/mo')).toBeDefined();
+    expect(
+      screen.getByText(/2 payments — \$360\.00 principal, \$1,979\.58 interest/),
+    ).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByText(/month 32 — \$985\.61 interest, \$184\.18 principal/)).toBeDefined();
+    });
+  });
+
+  it('opens the schedule under its citation with the rows and the total', async () => {
+    arrange([NOTE]);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /The schedule/ })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /The schedule/ }));
+    expect(screen.getByText('engines/amortization')).toBeDefined();
+    expect(screen.getByText(/\$200,934\.62 of interest over the remaining term/)).toBeDefined();
+    expect(screen.getByText('$189,077.24')).toBeDefined();
+  });
+
+  it('pre-fills the payment from the engine split and records an edited one', async () => {
+    arrange([NOTE]);
+    const record = vi.spyOn(api, 'recordDebtPayment').mockResolvedValue({} as never);
+    const onChanged = vi.fn();
+    render(<DebtPanel propertyId="p1" today={TODAY} onChanged={onChanged} />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Interest')).toBeDefined();
+    });
+    await waitFor(() => {
+      expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('985.61');
+    });
+    expect((screen.getByLabelText('Principal') as HTMLInputElement).value).toBe('184.18');
+    fireEvent.change(screen.getByLabelText('Principal'), { target: { value: '200.00' } });
+    fireEvent.change(screen.getByLabelText('Paid on'), { target: { value: '2026-09-01' } });
+    fireEvent.change(screen.getByLabelText('Extra principal'), { target: { value: '100.00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record the payment' }));
+    await waitFor(() => {
+      expect(record).toHaveBeenCalledWith('n1', {
+        paid_on: '2026-09-01',
+        interest: '985.61',
+        principal: '200.00',
+        extra_principal: '100.00',
+        escrow: '0',
+        post_to_ledger: true,
+      });
+    });
+    await waitFor(() => {
+      expect(onChanged).toHaveBeenCalled();
+    });
+  });
+
+  it('a cleared split travels as null so the engine decides, and the ledger opt-out holds', async () => {
+    arrange([NOTE]);
+    const record = vi.spyOn(api, 'recordDebtPayment').mockResolvedValue({} as never);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('985.61');
+    });
+    fireEvent.change(screen.getByLabelText('Interest'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Principal'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Extra principal'), { target: { value: '' } });
+    fireEvent.click(screen.getByLabelText(/Post to the ledger/));
+    fireEvent.click(screen.getByRole('button', { name: 'Record the payment' }));
+    await waitFor(() => {
+      expect(record).toHaveBeenCalledWith('n1', {
+        paid_on: TODAY,
+        interest: null,
+        principal: null,
+        extra_principal: '0',
+        escrow: '0',
+        post_to_ledger: false,
+      });
+    });
+  });
+
+  it('records a payoff dated today', async () => {
+    arrange([NOTE]);
+    const payoff = vi.spyOn(api, 'payoffDebt').mockResolvedValue({} as never);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Record payoff as of Aug 28, 2026/ }),
+      ).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record payoff as of Aug 28, 2026/ }));
+    await waitFor(() => {
+      expect(payoff).toHaveBeenCalledWith('n1', { paid_off_on: TODAY });
+    });
+  });
+
+  it('an interest-only note states its honest gap and never fetches a schedule', async () => {
+    const { scheduleSpy } = arrange([
+      { ...NOTE, id: 'n2', amortization: 'interest_only', scheduled_payment: null },
+    ]);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText(/none — a interest only note gets no inferred split/)).toBeDefined();
+    });
+    expect(scheduleSpy).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Next per the engine/)).toBeNull();
+  });
+
+  it('a paid-off note is a record, not a workbench', async () => {
+    const { scheduleSpy } = arrange([{ ...NOTE, paid_off_on: '2026-06-30' }]);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText('paid off Jun 30, 2026').className).toBe('pill pill--ok');
+    });
+    expect(scheduleSpy).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Record the payment' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Record payoff/ })).toBeNull();
+  });
+
+  it('the record stands when the schedule cannot be fetched', async () => {
+    arrange([NOTE], null);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText('First Federal')).toBeDefined();
+    });
+    expect(screen.queryByText(/Next per the engine/)).toBeNull();
+    // The form still records; empty fields defer to the server's engine split.
+    expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('');
+  });
+
+  it('records a mortgage from the entry form, nameless lender as null', async () => {
+    arrange([]);
+    const create = vi.spyOn(api, 'createDebt').mockResolvedValue({} as never);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No notes on record/)).toBeDefined();
+    });
+    fireEvent.change(screen.getByLabelText('Original principal'), {
+      target: { value: '190000.00' },
+    });
+    fireEvent.change(screen.getByLabelText(/Annual rate/), { target: { value: '0.0625' } });
+    fireEvent.change(screen.getByLabelText('Originated'), { target: { value: '2024-02-01' } });
+    fireEvent.change(screen.getByLabelText('Kind'), { target: { value: 'seller_financing' } });
+    fireEvent.change(screen.getByLabelText('Term (months)'), { target: { value: '180' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record the mortgage' }));
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith({
+        lender: null,
+        kind: 'seller_financing',
+        original_principal: '190000.00',
+        interest_rate: '0.0625',
+        term_months: 180,
+        originated_on: '2024-02-01',
+        amortization: 'fully_amortizing',
+        lien_position: 1,
+        is_recourse: true,
+        has_due_on_sale: true,
+        prepayment: 'none',
+        escrows_taxes: false,
+        escrows_insurance: false,
+        property_id: 'p1',
+      });
+    });
+  });
+
+  it('a named lender travels by name', async () => {
+    arrange([]);
+    const create = vi.spyOn(api, 'createDebt').mockResolvedValue({} as never);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Lender')).toBeDefined();
+    });
+    fireEvent.change(screen.getByLabelText('Lender'), { target: { value: 'First Federal' } });
+    fireEvent.change(screen.getByLabelText('Original principal'), { target: { value: '1000' } });
+    fireEvent.change(screen.getByLabelText(/Annual rate/), { target: { value: '0.05' } });
+    fireEvent.change(screen.getByLabelText('Originated'), { target: { value: '2026-01-01' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record the mortgage' }));
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({ lender: 'First Federal' }));
+    });
+  });
+
+  it('names the nameless lender and stays quiet about a consumed schedule', async () => {
+    arrange([{ ...NOTE, lender: null }], {
+      ...SCHEDULE,
+      next_month: null,
+      next_interest: null,
+      next_principal: null,
+      rows: [],
+    });
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText('Unnamed lender')).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /The schedule/ })).toBeDefined();
+    });
+    // A schedule with nothing next offers no suggestion sentence.
+    expect(screen.queryByText(/Next per the engine/)).toBeNull();
+    expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('');
+  });
+
+  it('a failure that is not an Error still reads as words', async () => {
+    vi.spyOn(api, 'listDebts').mockRejectedValue('the wire snapped');
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText('the wire snapped').className).toBe('error-note');
+    });
+  });
+
+  it('an action failure that is not an Error still reads as words', async () => {
+    arrange([NOTE]);
+    vi.spyOn(api, 'payoffDebt').mockRejectedValue('the lender hung up');
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Record payoff/ })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record payoff/ }));
+    await waitFor(() => {
+      expect(screen.getByText('the lender hung up').className).toBe('error-note');
+    });
+  });
+
+  it('surfaces a load failure as an error note', async () => {
+    vi.spyOn(api, 'listDebts').mockRejectedValue(new Error('the API is down'));
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(screen.getByText('the API is down').className).toBe('error-note');
+    });
+  });
+
+  it('surfaces an action failure and does not call onChanged', async () => {
+    arrange([NOTE]);
+    vi.spyOn(api, 'payoffDebt').mockRejectedValue(new Error('already paid off'));
+    const onChanged = vi.fn();
+    render(<DebtPanel propertyId="p1" today={TODAY} onChanged={onChanged} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Record payoff/ })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record payoff/ }));
+    await waitFor(() => {
+      expect(screen.getByText('already paid off')).toBeDefined();
+    });
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #89 — the web half of #37, per the co-dev handoff. Unblocks the UI side of #51.

The dossier's debt section becomes two honest halves: the #56 explorer scrubs futures; this panel is the record.

**The record**: every note with its terms, its scheduled payment — or the stated gap, because interest-only and negative-amortizing notes get no schedule and no inferred split — and the counters (payments recorded, principal paid, interest paid). A retired note is a record, not a workbench.

**The schedule**: unfolds per note under its citation (the engine names itself), with the next-period split pre-filled into the payment recorder — exactly the suggestion #51's mortgage split needs. A payment stating its own figures records what the lender applied; a cleared field travels as null so the engine decides server-side, the same convention either way.

**Entry and payoff**: recording a mortgage asks the required fields plus lender and kind, stating the long tail of DebtIn explicitly at the defaults it means; payoff dates the retirement. Both refresh the financials the what-if explorer reads, so the halves move together.

**Ladder**: 226 unit tests, 100% statements/branches/functions/lines; the api client walks all six contract paths with URL/method assertions; 24/24 e2e against the live stack (the new walk owns its note by lender name and watches the counters move against the real engine); full verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)