### PR TITLE
The split at entry: the engine's pair, wherever the payment arrives

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -269,6 +269,85 @@ test('the debt record: a mortgage, the engine split, and the counters move', asy
   await expect(card.getByText(/of interest over the remaining term/)).toBeVisible();
 });
 
+test('the mortgage split: one entry, one bank row, both land as the engine pair', async ({
+  page,
+}) => {
+  // This walk OWNS its note, its bank account and its bank row — unique
+  // names throughout, every assertion scoped to them.
+  const stamp = String(Date.now());
+  const lender = `Split Federal ${stamp}`;
+  await page.goto('/');
+  await page.getByText('998 Monmouth St, Newport, KY 41071').first().click();
+  await expect(page.getByRole('heading', { name: '998 Monmouth St' })).toBeVisible();
+  const propertyId = /property\/([0-9a-f-]+)/.exec(page.url())?.[1];
+  if (!propertyId) throw new Error(`no property id in ${page.url()}`);
+  await page.getByLabel('Lender').fill(lender);
+  await page.getByLabel('Original principal').fill('200000.00');
+  await page.getByLabel(/Annual rate/).fill('0.055');
+  await page.getByLabel('Term (months)').fill('360');
+  await page.getByLabel('Originated').fill('2025-01-01');
+  await page.getByRole('button', { name: 'Record the mortgage' }).click();
+  const noteCard = page.locator('.debt-panel .card', { hasText: lender });
+  // The engine's scheduled payment, read off the record — the walk carries
+  // the engine's own figure forward instead of hand-computing one.
+  await expect(noteCard.getByText(/\/mo$/)).toBeVisible();
+  const perMonth = await noteCard.getByText(/\/mo$/).textContent();
+  const payment = /\$([\d,]+\.\d\d)\/mo/.exec(perMonth ?? '')?.[1]?.replaceAll(',', '');
+  if (!payment) throw new Error(`no scheduled payment read from: ${perMonth ?? 'nothing'}`);
+
+  // Entry surface: the transaction form recognizes a note payment and
+  // routes it through the note — the register receives the linked pair.
+  await page.goto('/transactions');
+  await page.getByLabel('Date').fill('2026-08-05');
+  await page.getByLabel('Category').selectOption('mortgage_interest');
+  await page.locator('#tx-property').selectOption(propertyId);
+  await expect(page.getByText('This is a note payment.')).toBeVisible();
+  // A long-lived database holds notes from other runs: pick ours by name.
+  const whichNote = page.getByLabel('Which note');
+  if (await whichNote.isVisible().catch(() => false)) {
+    const value = await whichNote.locator('option', { hasText: lender }).getAttribute('value');
+    await whichNote.selectOption(value ?? '');
+  }
+  await page.getByRole('button', { name: `Record through ${lender}` }).click();
+  const formPair = page.locator('tr', { hasText: `${lender} payment` }).first();
+  await expect(formPair.getByText('Mortgage Payment')).toBeVisible();
+  await expect(formPair.getByText(/interest −\$[\d,.]+ · principal −\$[\d,.]+/)).toBeVisible();
+
+  // Bank surface: an account tied to the property, a statement row equal to
+  // the scheduled payment, and the engine split offered at review.
+  const entities = (await (await page.request.get('http://localhost:8000/entities')).json()) as {
+    id: string;
+  }[];
+  const accountResponse = await page.request.post('http://localhost:8000/bank/accounts', {
+    data: {
+      entity_id: (entities[0] as { id: string }).id,
+      property_id: propertyId,
+      nickname: `Mortgage Ops ${stamp}`,
+      kind: 'checking',
+    },
+  });
+  expect(accountResponse.ok()).toBe(true);
+
+  const description = `SPLIT FEDERAL MORTGAGE ${stamp}`;
+  await page.goto('/transactions/import');
+  await page.getByLabel('Bank account').selectOption({ label: `Mortgage Ops ${stamp}` });
+  await page.getByLabel('Statement file (.csv / .ofx / .qfx)').setInputFiles({
+    name: 'mortgage.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from(`Date,Description,Amount\n2026-08-20,${description},-${payment}\n`),
+  });
+  await page.getByRole('button', { name: 'Import' }).click();
+  const queueRow = page.locator('tr', { hasText: description });
+  await expect(queueRow.getByText(/engine split: \$[\d,.]+ interest/)).toBeVisible();
+  await queueRow.getByRole('button', { name: 'Accept as engine split' }).click();
+
+  // The register folds the accepted row into one payment, split beneath.
+  await page.goto('/transactions');
+  const bankPair = page.locator('tr', { hasText: description }).first();
+  await expect(bankPair.getByText('Mortgage Payment')).toBeVisible();
+  await expect(bankPair.getByText(/interest −\$[\d,.]+ · principal −\$[\d,.]+/)).toBeVisible();
+});
+
 test('a work order completes and the vendor calendar knows its certificate', async ({ page }) => {
   // A vendor with a certificate that expires: the day it lapses is a deadline.
   await page.goto('/vendors');

--- a/apps/web/src/app/transactions/import/page.tsx
+++ b/apps/web/src/app/transactions/import/page.tsx
@@ -10,6 +10,7 @@ import {
   type ImportSummary,
   type StagedTransaction,
 } from '../../../lib/api';
+import { acceptSplits, type NoteSplit, noteSplit } from '../../../lib/mortgage-split';
 
 export default function ImportPage() {
   const [accounts, setAccounts] = useState<BankAccountOut[]>([]);
@@ -39,6 +40,37 @@ export default function ImportPage() {
   const refreshQueue = useCallback(async (batchId: string) => {
     setQueue(await api.reviewQueue(batchId, 'pending'));
   }, []);
+
+  // The engine splits for each property in the queue, fetched once per
+  // property. A property with no live amortizing note maps to an empty
+  // list, which is the honest no-offer state.
+  const [splitsByProperty, setSplitsByProperty] = useState<Record<string, NoteSplit[]>>({});
+  useEffect(() => {
+    const pending = [
+      ...new Set(
+        queue
+          .map((row) => row.suggested_property_id)
+          .filter((id): id is string => id !== null && id !== undefined),
+      ),
+    ].filter((id) => !(id in splitsByProperty));
+    for (const propertyId of pending) {
+      void (async () => {
+        try {
+          const debts = await api.listDebts({ propertyId });
+          const loaded: NoteSplit[] = [];
+          for (const debt of debts) {
+            if (debt.paid_off_on !== null || debt.scheduled_payment === null) continue;
+            const split = noteSplit(debt, await api.debtSchedule(debt.id));
+            if (split) loaded.push(split);
+          }
+          setSplitsByProperty((current) => ({ ...current, [propertyId]: loaded }));
+        } catch {
+          // No offer is an honest state; plain accept still works.
+          setSplitsByProperty((current) => ({ ...current, [propertyId]: [] }));
+        }
+      })();
+    }
+  }, [queue, splitsByProperty]);
 
   const upload = async () => {
     if (!file) return;
@@ -181,6 +213,17 @@ export default function ImportPage() {
             }}
             onExclude={(txnId) => {
               void decide(() => api.excludeBankTransaction(txnId));
+            }}
+            noteSplits={(row) =>
+              row.suggested_property_id ? (splitsByProperty[row.suggested_property_id] ?? []) : []
+            }
+            onAcceptSplit={(row, split) => {
+              void decide(() =>
+                api.acceptBankTransaction(row.id, {
+                  splits: acceptSplits(row.amount, split),
+                  ...(row.suggested_property_id ? { property_id: row.suggested_property_id } : {}),
+                }),
+              );
             }}
           />
         </section>

--- a/apps/web/src/app/transactions/page.tsx
+++ b/apps/web/src/app/transactions/page.tsx
@@ -2,6 +2,7 @@
 
 import { Skeleton } from '@hestia/design';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { MortgagePaymentOffer } from '../../components/MortgagePaymentOffer';
 import { TransactionsTable } from '../../components/TransactionsTable';
 import { api, type LedgerEntryIn, type LedgerRegister, type PropertySummary } from '../../lib/api';
 
@@ -161,6 +162,17 @@ export default function TransactionsPage() {
 
       <section className="section">
         <h2 className="section__title">Record a transaction</h2>
+        {(category === 'mortgage_interest' || category === 'mortgage_principal') &&
+        propertyId !== '' ? (
+          <MortgagePaymentOffer
+            key={propertyId}
+            propertyId={propertyId}
+            occurredOn={occurredOn}
+            onRecorded={() => {
+              void load();
+            }}
+          />
+        ) : null}
         <form
           className="card"
           onSubmit={(event) => {

--- a/apps/web/src/components/MortgagePaymentOffer.tsx
+++ b/apps/web/src/components/MortgagePaymentOffer.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Button, CitationChip } from '@hestia/design';
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import { type NoteSplit, noteSplit } from '../lib/mortgage-split';
+import { formatMoney } from './TransactionsTable';
+
+/**
+ * The honest way to enter a mortgage payment: through the note. One entry
+ * becomes the linked interest/principal pair on the ledger — the engine's
+ * split for the period, to the cent — instead of two hand-computed lines.
+ * Renders nothing when the property has no live amortizing note; the plain
+ * form beneath always remains.
+ *
+ * Render it keyed by propertyId: the remount is what keeps a slow fetch for
+ * one property from wearing another property's offer.
+ */
+type MortgagePaymentOfferProps = {
+  propertyId: string;
+  occurredOn: string;
+  onRecorded: () => void;
+};
+
+export function MortgagePaymentOffer({
+  propertyId,
+  occurredOn,
+  onRecorded,
+}: MortgagePaymentOfferProps) {
+  const [splits, setSplits] = useState<NoteSplit[]>([]);
+  const [chosen, setChosen] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const debts = await api.listDebts({ propertyId });
+        const live = debts.filter(
+          (debt) => debt.paid_off_on === null && debt.scheduled_payment !== null,
+        );
+        const loaded: NoteSplit[] = [];
+        for (const debt of live) {
+          const split = noteSplit(debt, await api.debtSchedule(debt.id));
+          if (split) loaded.push(split);
+        }
+        setSplits(loaded);
+        setChosen(loaded[0]?.debtId ?? '');
+      } catch {
+        // No offer is an honest state; the plain form still records.
+        setSplits([]);
+      }
+    })();
+  }, [propertyId]);
+
+  const split = splits.find((candidate) => candidate.debtId === chosen);
+  if (!split) {
+    return null;
+  }
+
+  const record = async () => {
+    setError(null);
+    try {
+      await api.recordDebtPayment(split.debtId, {
+        paid_on: occurredOn,
+        // No figures stated: the server takes the engine's split for the
+        // period — the same figures shown here — and writes the pair.
+        interest: null,
+        principal: null,
+        extra_principal: '0',
+        escrow: '0',
+        post_to_ledger: true,
+      });
+      onRecorded();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <div className="card">
+      <p>
+        <strong>This is a note payment.</strong> Record it through the note and the ledger receives
+        the linked pair — {formatMoney(split.interest)} interest, {formatMoney(split.principal)}{' '}
+        principal, {formatMoney(split.payment)} together. <CitationChip cite={split.citation} />
+      </p>
+      {splits.length > 1 ? (
+        <div className="field">
+          <label htmlFor="mp-note">Which note</label>
+          <select
+            id="mp-note"
+            value={chosen}
+            onChange={(event) => {
+              setChosen(event.target.value);
+            }}
+          >
+            {splits.map((candidate) => (
+              <option key={candidate.debtId} value={candidate.debtId}>
+                {candidate.lender} — {formatMoney(candidate.payment)}/mo
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+      {error ? <p className="error-note">{error}</p> : null}
+      <Button
+        type="button"
+        disabled={occurredOn === ''}
+        onClick={() => {
+          void record();
+        }}
+      >
+        Record through {split.lender}
+      </Button>{' '}
+      {occurredOn === '' ? <span className="muted">— pick the date above first</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ReviewQueueTable.tsx
+++ b/apps/web/src/components/ReviewQueueTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { StagedTransaction } from '../lib/api';
 import { formatDate, titleCase } from '../lib/format';
+import { matchOffers, type NoteSplit } from '../lib/mortgage-split';
 import { formatMoney } from './TransactionsTable';
 
 const CATEGORIES = [
@@ -38,10 +39,15 @@ export function ReviewQueueTable({
   rows,
   onAccept,
   onExclude,
+  noteSplits,
+  onAcceptSplit,
 }: {
   rows: StagedTransaction[];
   onAccept: (txnId: string, category: string) => void;
   onExclude: (txnId: string) => void;
+  /** The engine splits for a row's property, when the page has them. */
+  noteSplits?: (row: StagedTransaction) => readonly NoteSplit[];
+  onAcceptSplit?: (row: StagedTransaction, split: NoteSplit) => void;
 }) {
   if (rows.length === 0) {
     return <p className="muted">Queue clear — every row has been reviewed.</p>;
@@ -60,7 +66,14 @@ export function ReviewQueueTable({
         </thead>
         <tbody>
           {rows.map((row) => (
-            <QueueRow key={row.id} row={row} onAccept={onAccept} onExclude={onExclude} />
+            <QueueRow
+              key={row.id}
+              row={row}
+              onAccept={onAccept}
+              onExclude={onExclude}
+              {...(noteSplits ? { noteSplits } : {})}
+              {...(onAcceptSplit ? { onAcceptSplit } : {})}
+            />
           ))}
         </tbody>
       </table>
@@ -68,16 +81,83 @@ export function ReviewQueueTable({
   );
 }
 
+/** What the engine can offer this row, if anything — and the honest line
+ * when it cannot: an impound remainder has no ledger category for money a
+ * servicer merely holds, so those rows go through the note instead. */
+function SplitOfferCell({
+  row,
+  splits,
+  onAcceptSplit,
+}: {
+  row: StagedTransaction;
+  splits: readonly NoteSplit[];
+  onAcceptSplit: (row: StagedTransaction, split: NoteSplit) => void;
+}) {
+  const { exact, nearest } = matchOffers(row.amount, splits);
+  const [chosen, setChosen] = useState(0);
+  if (exact.length > 0) {
+    const split = exact[Math.min(chosen, exact.length - 1)] as NoteSplit;
+    return (
+      <div className="review__split">
+        {exact.length > 1 ? (
+          <select
+            aria-label={`note for ${row.description}`}
+            value={chosen}
+            onChange={(event) => {
+              setChosen(Number(event.target.value));
+            }}
+          >
+            {exact.map((candidate, index) => (
+              <option key={candidate.debtId} value={index}>
+                {candidate.lender}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        <div className="faint">
+          engine split: {formatMoney(split.interest)} interest · {formatMoney(split.principal)}{' '}
+          principal — {split.lender}
+        </div>
+        <button
+          className="button"
+          type="button"
+          onClick={() => {
+            onAcceptSplit(row, split);
+          }}
+        >
+          Accept as engine split
+        </button>
+      </div>
+    );
+  }
+  if (nearest?.kind === 'remainder') {
+    return (
+      <div className="faint">
+        {formatMoney(nearest.remainder)} above {nearest.split.lender}’s scheduled payment — an
+        escrow impound rides along. Record it through the note on the property page, which holds
+        escrow honestly; no ledger category exists for money a servicer merely holds.
+      </div>
+    );
+  }
+  return null;
+}
+
 function QueueRow({
   row,
   onAccept,
   onExclude,
+  noteSplits,
+  onAcceptSplit,
 }: {
   row: StagedTransaction;
   onAccept: (txnId: string, category: string) => void;
   onExclude: (txnId: string) => void;
+  noteSplits?: (row: StagedTransaction) => readonly NoteSplit[];
+  onAcceptSplit?: (row: StagedTransaction, split: NoteSplit) => void;
 }) {
   const [category, setCategory] = useState(row.suggested_category ?? '');
+  const mortgageish = category === 'mortgage_interest' || category === 'mortgage_principal';
+  const splits = mortgageish && noteSplits && onAcceptSplit ? noteSplits(row) : [];
   return (
     <tr>
       <td>{formatDate(row.posted_on)}</td>
@@ -133,6 +213,9 @@ function QueueRow({
         >
           Exclude
         </button>
+        {splits.length > 0 && onAcceptSplit ? (
+          <SplitOfferCell row={row} splits={splits} onAcceptSplit={onAcceptSplit} />
+        ) : null}
       </td>
     </tr>
   );

--- a/apps/web/src/components/TransactionsTable.tsx
+++ b/apps/web/src/components/TransactionsTable.tsx
@@ -1,5 +1,6 @@
 import type { LedgerEventOut } from '../lib/api';
 import { formatDate, titleCase } from '../lib/format';
+import { pairMortgageEvents } from '../lib/mortgage-split';
 
 const formatMoney = (amount: string): string => {
   const value = Number(amount);
@@ -38,16 +39,73 @@ export function TransactionsTable({
           </tr>
         </thead>
         <tbody>
-          {events.map((event) => (
-            <TransactionRow
-              key={event.event_uuid}
-              event={event}
-              {...(onReverse ? { onReverse } : {})}
-            />
-          ))}
+          {pairMortgageEvents(events).map((line) =>
+            line.kind === 'pair' ? (
+              <PairRow
+                key={line.interest.event_uuid}
+                line={line}
+                {...(onReverse ? { onReverse } : {})}
+              />
+            ) : (
+              <TransactionRow
+                key={line.event.event_uuid}
+                event={line.event}
+                {...(onReverse ? { onReverse } : {})}
+              />
+            ),
+          )}
         </tbody>
       </table>
     </div>
+  );
+}
+
+/** One payment, visually: the pair the engine split, summed on its line
+ * with the split stated beneath. It reverses as a payment — both events —
+ * because half a reversed mortgage payment is not a position anyone took;
+ * once either member is struck the two stand alone again in the register. */
+function PairRow({
+  line,
+  onReverse,
+}: {
+  line: { total: string; interest: LedgerEventOut; principal: LedgerEventOut };
+  onReverse?: (eventUuid: string) => void;
+}) {
+  const { interest, principal } = line;
+  return (
+    <tr>
+      <td>{formatDate(interest.occurred_on)}</td>
+      <td>
+        <span className="pill">Mortgage Payment</span>
+      </td>
+      <td>
+        <span>{interest.memo ?? '—'}</span>
+        {interest.counterparty ? <div className="faint">{interest.counterparty}</div> : null}
+        <div className="faint">
+          interest {formatMoney(interest.amount)} · principal {formatMoney(principal.amount)}
+        </div>
+      </td>
+      <td
+        style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}
+        className={Number(line.total) < 0 ? 'muted' : ''}
+      >
+        {formatMoney(line.total)}
+      </td>
+      <td>
+        {onReverse ? (
+          <button
+            className="button button--quiet"
+            type="button"
+            onClick={() => {
+              onReverse(interest.event_uuid);
+              onReverse(principal.event_uuid);
+            }}
+          >
+            Reverse
+          </button>
+        ) : null}
+      </td>
+    </tr>
   );
 }
 

--- a/apps/web/src/lib/mortgage-split.ts
+++ b/apps/web/src/lib/mortgage-split.ts
@@ -1,0 +1,146 @@
+/**
+ * The split at entry: a mortgage payment reaches the bank as ONE row, but
+ * Schedule E needs interest (deductible) apart from principal (equity).
+ * The engine already knows the period's split — this module only decides
+ * what can honestly be offered for a given bank amount. It computes no
+ * arithmetic of its own beyond exact money comparison: the figures are the
+ * engine's, passed through.
+ */
+import { abs, add, equals, lessThan, money, subtract, toDecimalString } from '@hestia/domain';
+import type { DebtOut, LedgerEventOut, ScheduleOut } from './api';
+
+export interface NoteSplit {
+  debtId: string;
+  lender: string;
+  interest: string;
+  principal: string;
+  /** The engine's scheduled payment — interest + principal, to the cent. */
+  payment: string;
+  /** The engine naming itself; every offer carries its stamp. */
+  citation: string;
+}
+
+export type SplitOffer =
+  /** The bank row equals the scheduled payment exactly: the pair is offerable. */
+  | { kind: 'exact'; split: NoteSplit }
+  /** The row exceeds the payment — an escrow impound rides along. There is no
+   * honest ledger category for money a servicer merely holds, so the offer
+   * points at the debt-payment path, which records escrow on the note. */
+  | { kind: 'remainder'; split: NoteSplit; remainder: string }
+  /** The row is short of the payment; nothing is offered. */
+  | { kind: 'short'; split: NoteSplit; shortfall: string };
+
+/** The engine's split for a note's next period, or null when the note has
+ * no schedule (interest-only, negative-amortizing) or nothing next. */
+export function noteSplit(debt: DebtOut, schedule: ScheduleOut): NoteSplit | null {
+  if (schedule.next_interest === null || schedule.next_principal === null) {
+    return null;
+  }
+  const interest = money(schedule.next_interest);
+  const principal = money(schedule.next_principal);
+  return {
+    debtId: debt.id,
+    lender: debt.lender ?? 'Unnamed lender',
+    interest: toDecimalString(interest),
+    principal: toDecimalString(principal),
+    payment: toDecimalString(add(interest, principal)),
+    citation: schedule.citation,
+  };
+}
+
+/** What can be offered for a bank-row amount against a note's split. The
+ * row amount may carry either sign — an outflow is compared by magnitude. */
+export function splitOffer(amount: string, split: NoteSplit): SplitOffer {
+  const rowMagnitude = abs(money(amount));
+  const payment = money(split.payment);
+  if (equals(rowMagnitude, payment)) {
+    return { kind: 'exact', split };
+  }
+  if (lessThan(rowMagnitude, payment)) {
+    return { kind: 'short', split, shortfall: toDecimalString(subtract(payment, rowMagnitude)) };
+  }
+  return { kind: 'remainder', split, remainder: toDecimalString(subtract(rowMagnitude, payment)) };
+}
+
+/** Which notes a bank row can honestly settle. Exact matches identify the
+ * note by the figure itself; with none, `nearest` explains the closest miss. */
+export function matchOffers(
+  amount: string,
+  splits: readonly NoteSplit[],
+): { exact: NoteSplit[]; nearest: SplitOffer | null } {
+  const offers = splits.map((split) => splitOffer(amount, split));
+  const exact = offers.filter((offer) => offer.kind === 'exact').map((offer) => offer.split);
+  if (exact.length > 0 || offers.length === 0) {
+    return { exact, nearest: null };
+  }
+  const magnitude = abs(money(amount));
+  let nearest = offers[0] as SplitOffer;
+  for (const offer of offers.slice(1)) {
+    const gap = (candidate: SplitOffer) => abs(subtract(magnitude, money(candidate.split.payment)));
+    if (lessThan(gap(offer), gap(nearest))) {
+      nearest = offer;
+    }
+  }
+  return { exact, nearest };
+}
+
+/** The AcceptIn splits for a row settled by a note: the engine's figures,
+ * carrying the row's own sign so the pair sums to the row exactly. */
+export function acceptSplits(
+  rowAmount: string,
+  split: NoteSplit,
+): { category: 'mortgage_interest' | 'mortgage_principal'; amount: string }[] {
+  const outflow = lessThan(money(rowAmount), money('0'));
+  const signed = (value: string) => (outflow ? `-${value}` : value);
+  return [
+    { category: 'mortgage_interest', amount: signed(split.interest) },
+    { category: 'mortgage_principal', amount: signed(split.principal) },
+  ];
+}
+
+export type RegisterLine =
+  | { kind: 'single'; event: LedgerEventOut }
+  | { kind: 'pair'; total: string; interest: LedgerEventOut; principal: LedgerEventOut };
+
+const liveMortgage = (event: LedgerEventOut, category: string): boolean =>
+  event.category === category && !event.reversed && event.reverses_event_uuid === null;
+
+const sameKey = (a: LedgerEventOut, b: LedgerEventOut): boolean =>
+  a.occurred_on === b.occurred_on && a.memo === b.memo && a.counterparty === b.counterparty;
+
+/** Fold a register so each mortgage interest/principal pair — same day, same
+ * memo, same counterparty, both standing — reads as the one payment it was.
+ * A reversed member disqualifies the pair: struck entries stand alone. */
+export function pairMortgageEvents(events: readonly LedgerEventOut[]): RegisterLine[] {
+  const lines: RegisterLine[] = [];
+  const consumed = new Set<string>();
+  for (const event of events) {
+    if (consumed.has(event.event_uuid)) continue;
+    if (liveMortgage(event, 'mortgage_interest') || liveMortgage(event, 'mortgage_principal')) {
+      const otherCategory =
+        event.category === 'mortgage_interest' ? 'mortgage_principal' : 'mortgage_interest';
+      const partner = events.find(
+        (candidate) =>
+          !consumed.has(candidate.event_uuid) &&
+          candidate.event_uuid !== event.event_uuid &&
+          liveMortgage(candidate, otherCategory) &&
+          sameKey(event, candidate),
+      );
+      if (partner) {
+        consumed.add(event.event_uuid);
+        consumed.add(partner.event_uuid);
+        const [interest, principal] =
+          event.category === 'mortgage_interest' ? [event, partner] : [partner, event];
+        lines.push({
+          kind: 'pair',
+          total: toDecimalString(add(money(interest.amount), money(principal.amount))),
+          interest,
+          principal,
+        });
+        continue;
+      }
+    }
+    lines.push({ kind: 'single', event });
+  }
+  return lines;
+}

--- a/apps/web/tests/mortgage-payment-offer.test.tsx
+++ b/apps/web/tests/mortgage-payment-offer.test.tsx
@@ -1,0 +1,170 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MortgagePaymentOffer } from '../src/components/MortgagePaymentOffer';
+import { api, type DebtOut, type ScheduleOut } from '../src/lib/api';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const NOTE = {
+  id: 'n1',
+  lender: 'First Federal',
+  paid_off_on: null,
+  scheduled_payment: '1169.79',
+} as DebtOut;
+
+const SCHEDULE = {
+  debt_id: 'n1',
+  citation: 'level-payment amortization, hestia_sim.finance.amortization',
+  next_interest: '985.61',
+  next_principal: '184.18',
+} as ScheduleOut;
+
+describe('MortgagePaymentOffer', () => {
+  it('offers the engine pair with its citation and records through the note', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
+    const record = vi.spyOn(api, 'recordDebtPayment').mockResolvedValue({} as never);
+    const onRecorded = vi.fn();
+    render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={onRecorded} />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/\$985\.61 interest, \$184\.18 principal, \$1,169\.79 together/),
+      ).toBeDefined();
+    });
+    expect(screen.getByText(/hestia_sim\.finance\.amortization/)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Record through First Federal' }));
+    await waitFor(() => {
+      expect(record).toHaveBeenCalledWith('n1', {
+        paid_on: '2026-08-28',
+        interest: null,
+        principal: null,
+        extra_principal: '0',
+        escrow: '0',
+        post_to_ledger: true,
+      });
+    });
+    await waitFor(() => {
+      expect(onRecorded).toHaveBeenCalled();
+    });
+  });
+
+  it('multi-lien picks the note explicitly', async () => {
+    const junior = { ...NOTE, id: 'n2', lender: 'Second Street' } as DebtOut;
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE, junior]);
+    vi.spyOn(api, 'debtSchedule').mockImplementation((debtId) =>
+      Promise.resolve(
+        debtId === 'n1'
+          ? SCHEDULE
+          : ({
+              ...SCHEDULE,
+              debt_id: 'n2',
+              next_interest: '100.00',
+              next_principal: '50.00',
+            } as ScheduleOut),
+      ),
+    );
+    const record = vi.spyOn(api, 'recordDebtPayment').mockResolvedValue({} as never);
+    render(<MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Which note')).toBeDefined();
+    });
+    fireEvent.change(screen.getByLabelText('Which note'), { target: { value: 'n2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record through Second Street' }));
+    await waitFor(() => {
+      expect(record).toHaveBeenCalledWith('n2', expect.objectContaining({ post_to_ledger: true }));
+    });
+  });
+
+  it('waits for a date rather than guessing one', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
+    render(<MortgagePaymentOffer propertyId="p1" occurredOn="" onRecorded={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Record through/ })).toBeDefined();
+    });
+    expect(
+      (screen.getByRole('button', { name: /Record through/ }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.getByText(/pick the date above first/)).toBeDefined();
+  });
+
+  it('renders nothing without a live amortizing note', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([
+      { ...NOTE, paid_off_on: '2026-06-30' } as DebtOut,
+      { ...NOTE, id: 'n3', scheduled_payment: null } as DebtOut,
+    ]);
+    const scheduleSpy = vi.spyOn(api, 'debtSchedule');
+    const { container } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(api.listDebts).toHaveBeenCalled();
+    });
+    expect(container.firstElementChild).toBeNull();
+    expect(scheduleSpy).not.toHaveBeenCalled();
+  });
+
+  it('a consumed schedule offers nothing', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockResolvedValue({
+      ...SCHEDULE,
+      next_interest: null,
+      next_principal: null,
+    } as ScheduleOut);
+    const { container } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(api.debtSchedule).toHaveBeenCalled();
+    });
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it('a failed fetch is a quiet no-offer, never a broken form', async () => {
+    vi.spyOn(api, 'listDebts').mockRejectedValue(new Error('down'));
+    const { container } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(api.listDebts).toHaveBeenCalled();
+    });
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it('a refusal that is not an Error still reads as words', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
+    vi.spyOn(api, 'recordDebtPayment').mockRejectedValue('the lender hung up');
+    render(<MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Record through/ })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record through/ }));
+    await waitFor(() => {
+      expect(screen.getByText('the lender hung up').className).toBe('error-note');
+    });
+  });
+
+  it('a refused recording surfaces its reason and records nothing', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
+    vi.spyOn(api, 'recordDebtPayment').mockRejectedValue(new Error('already paid this period'));
+    const onRecorded = vi.fn();
+    render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={onRecorded} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Record through/ })).toBeDefined();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record through/ }));
+    await waitFor(() => {
+      expect(screen.getByText('already paid this period').className).toBe('error-note');
+    });
+    expect(onRecorded).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/mortgage-split.test.ts
+++ b/apps/web/tests/mortgage-split.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import type { DebtOut, LedgerEventOut, ScheduleOut } from '../src/lib/api';
+import {
+  acceptSplits,
+  matchOffers,
+  type NoteSplit,
+  noteSplit,
+  pairMortgageEvents,
+  splitOffer,
+} from '../src/lib/mortgage-split';
+
+const DEBT = { id: 'n1', lender: 'First Federal' } as DebtOut;
+
+const SCHEDULE = {
+  next_interest: '985.61',
+  next_principal: '184.18',
+  citation: 'engine',
+} as ScheduleOut;
+
+const SPLIT: NoteSplit = {
+  debtId: 'n1',
+  lender: 'First Federal',
+  interest: '985.61',
+  principal: '184.18',
+  payment: '1169.79',
+  citation: 'engine',
+};
+
+const event = (overrides: Partial<LedgerEventOut>): LedgerEventOut =>
+  ({
+    event_uuid: overrides.memo ?? 'e',
+    occurred_on: '2026-08-28',
+    category: 'rent',
+    amount: '-1.00',
+    memo: null,
+    counterparty: null,
+    property_id: 'p1',
+    entity_id: 'e1',
+    lease_id: null,
+    unit_id: null,
+    is_capital: false,
+    capitalisation_rationale: null,
+    recorded_at: '2026-08-28T00:00:00Z',
+    reversed: false,
+    reverses_event_uuid: null,
+    ...overrides,
+  }) as LedgerEventOut;
+
+const pairEvents = (): LedgerEventOut[] => [
+  event({
+    event_uuid: 'i1',
+    category: 'mortgage_interest',
+    amount: '-985.61',
+    memo: 'First Federal payment',
+    counterparty: 'First Federal',
+  }),
+  event({
+    event_uuid: 'p1e',
+    category: 'mortgage_principal',
+    amount: '-184.18',
+    memo: 'First Federal payment',
+    counterparty: 'First Federal',
+  }),
+];
+
+describe('noteSplit', () => {
+  it('carries the engine figures and their exact sum', () => {
+    expect(noteSplit(DEBT, SCHEDULE)).toEqual(SPLIT);
+  });
+
+  it('a consumed or absent schedule offers nothing', () => {
+    expect(noteSplit(DEBT, { ...SCHEDULE, next_interest: null })).toBeNull();
+    expect(noteSplit(DEBT, { ...SCHEDULE, next_principal: null })).toBeNull();
+  });
+
+  it('names the nameless lender', () => {
+    expect(noteSplit({ ...DEBT, lender: null } as DebtOut, SCHEDULE)?.lender).toBe(
+      'Unnamed lender',
+    );
+  });
+});
+
+describe('splitOffer', () => {
+  it('an exact match offers the pair, either sign', () => {
+    expect(splitOffer('1169.79', SPLIT).kind).toBe('exact');
+    expect(splitOffer('-1169.79', SPLIT).kind).toBe('exact');
+  });
+
+  it('a short row states its shortfall to the cent', () => {
+    const offer = splitOffer('-1000.00', SPLIT);
+    expect(offer).toEqual({ kind: 'short', split: SPLIT, shortfall: '169.79' });
+  });
+
+  it('a rich row names the impound remainder to the cent', () => {
+    const offer = splitOffer('-1218.55', SPLIT);
+    expect(offer).toEqual({ kind: 'remainder', split: SPLIT, remainder: '48.76' });
+  });
+});
+
+describe('matchOffers', () => {
+  const junior: NoteSplit = {
+    debtId: 'n2',
+    lender: 'Second Street',
+    interest: '100.00',
+    principal: '50.00',
+    payment: '150.00',
+    citation: 'engine',
+  };
+
+  it('the figure itself identifies the note', () => {
+    const { exact, nearest } = matchOffers('-150.00', [SPLIT, junior]);
+    expect(exact).toEqual([junior]);
+    expect(nearest).toBeNull();
+  });
+
+  it('two notes sharing a payment both stand, for the operator to pick', () => {
+    const twin = { ...junior, debtId: 'n3', lender: 'Third Street', payment: '1169.79' };
+    const { exact } = matchOffers('1169.79', [SPLIT, twin]);
+    expect(exact.map((split) => split.debtId)).toEqual(['n1', 'n3']);
+  });
+
+  it('with no exact match, the nearest note explains the miss', () => {
+    const { exact, nearest } = matchOffers('-1218.55', [SPLIT, junior]);
+    expect(exact).toEqual([]);
+    expect(nearest?.kind).toBe('remainder');
+    expect(nearest?.split.debtId).toBe('n1');
+  });
+
+  it('a later note that misses by less takes the nearest slot', () => {
+    // 160 is 10 off the junior note and 1009.79 off the senior: the loop
+    // must replace its opening candidate with the closer one.
+    const { nearest } = matchOffers('-160.00', [SPLIT, junior]);
+    expect(nearest?.split.debtId).toBe('n2');
+    expect(nearest?.kind).toBe('remainder');
+  });
+
+  it('no notes, no offer', () => {
+    expect(matchOffers('-100.00', [])).toEqual({ exact: [], nearest: null });
+  });
+});
+
+describe('acceptSplits', () => {
+  it('carries the row sign so the pair sums to the row exactly', () => {
+    expect(acceptSplits('-1169.79', SPLIT)).toEqual([
+      { category: 'mortgage_interest', amount: '-985.61' },
+      { category: 'mortgage_principal', amount: '-184.18' },
+    ]);
+    expect(acceptSplits('1169.79', SPLIT)).toEqual([
+      { category: 'mortgage_interest', amount: '985.61' },
+      { category: 'mortgage_principal', amount: '184.18' },
+    ]);
+  });
+});
+
+describe('pairMortgageEvents', () => {
+  it('folds the pair into one payment with the exact total', () => {
+    const lines = pairMortgageEvents(pairEvents());
+    expect(lines).toHaveLength(1);
+    const line = lines[0];
+    if (line?.kind !== 'pair') throw new Error('pair expected');
+    expect(line.total).toBe('-1169.79');
+    expect(line.interest.event_uuid).toBe('i1');
+    expect(line.principal.event_uuid).toBe('p1e');
+  });
+
+  it('order does not matter: principal first still pairs', () => {
+    const lines = pairMortgageEvents([...pairEvents()].reverse());
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.kind).toBe('pair');
+  });
+
+  it('a struck member breaks the pair — both stand alone', () => {
+    const [interest, principal] = pairEvents();
+    const lines = pairMortgageEvents([
+      { ...(interest as LedgerEventOut), reversed: true },
+      principal as LedgerEventOut,
+    ]);
+    expect(lines.map((line) => line.kind)).toEqual(['single', 'single']);
+  });
+
+  it('a different day, memo or counterparty never pairs', () => {
+    const [interest, principal] = pairEvents();
+    for (const change of [
+      { occurred_on: '2026-08-29' },
+      { memo: 'other note payment' },
+      { counterparty: 'Someone Else' },
+    ]) {
+      const lines = pairMortgageEvents([
+        interest as LedgerEventOut,
+        { ...(principal as LedgerEventOut), ...change },
+      ]);
+      expect(lines.map((line) => line.kind)).toEqual(['single', 'single']);
+    }
+  });
+
+  it('two payments on one day pair one-to-one, nothing double-spent', () => {
+    const [i1, p1] = pairEvents();
+    const second = pairEvents().map((entry, index) => ({
+      ...entry,
+      event_uuid: `${entry.event_uuid}-b${String(index)}`,
+    }));
+    const lines = pairMortgageEvents([
+      i1 as LedgerEventOut,
+      p1 as LedgerEventOut,
+      ...(second as LedgerEventOut[]),
+    ]);
+    expect(lines.map((line) => line.kind)).toEqual(['pair', 'pair']);
+  });
+
+  it('everything else passes through untouched', () => {
+    const rent = event({ event_uuid: 'r1', category: 'rent', amount: '1450.00' });
+    expect(pairMortgageEvents([rent])).toEqual([{ kind: 'single', event: rent }]);
+  });
+});

--- a/apps/web/tests/review-queue.test.tsx
+++ b/apps/web/tests/review-queue.test.tsx
@@ -76,3 +76,107 @@ describe('ReviewQueueTable', () => {
     expect(screen.getByText(/Queue clear/)).toBeDefined();
   });
 });
+
+describe('ReviewQueueTable — the engine split offer', () => {
+  const SPLIT = {
+    debtId: 'n1',
+    lender: 'First Federal',
+    interest: '985.61',
+    principal: '184.18',
+    payment: '1169.79',
+    citation: 'engine',
+  };
+  const mortgageRow = () =>
+    staged({
+      id: 'm1',
+      description: 'FIRST FEDERAL MTG',
+      amount: '-1169.79',
+      suggested_category: 'mortgage_interest',
+      suggested_property_id: 'p1',
+    });
+
+  it('an exact match offers the pair and hands back the note', () => {
+    const onAcceptSplit = vi.fn();
+    render(
+      <ReviewQueueTable
+        rows={[mortgageRow()]}
+        onAccept={vi.fn()}
+        onExclude={vi.fn()}
+        noteSplits={() => [SPLIT]}
+        onAcceptSplit={onAcceptSplit}
+      />,
+    );
+    expect(
+      screen.getByText(/engine split: \$985\.61 interest · \$184\.18 principal — First Federal/),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Accept as engine split' }));
+    expect(onAcceptSplit).toHaveBeenCalledWith(expect.objectContaining({ id: 'm1' }), SPLIT);
+  });
+
+  it('two exact notes make the operator choose', () => {
+    const twin = { ...SPLIT, debtId: 'n2', lender: 'Second Street' };
+    const onAcceptSplit = vi.fn();
+    render(
+      <ReviewQueueTable
+        rows={[mortgageRow()]}
+        onAccept={vi.fn()}
+        onExclude={vi.fn()}
+        noteSplits={() => [SPLIT, twin]}
+        onAcceptSplit={onAcceptSplit}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('note for FIRST FEDERAL MTG'), {
+      target: { value: '1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Accept as engine split' }));
+    expect(onAcceptSplit).toHaveBeenCalledWith(expect.anything(), twin);
+  });
+
+  it('an impound remainder explains itself instead of guessing a category', () => {
+    render(
+      <ReviewQueueTable
+        rows={[
+          staged({
+            id: 'm2',
+            description: 'FIRST FEDERAL MTG',
+            amount: '-1218.55',
+            suggested_category: 'mortgage_interest',
+            suggested_property_id: 'p1',
+          }),
+        ]}
+        onAccept={vi.fn()}
+        onExclude={vi.fn()}
+        noteSplits={() => [SPLIT]}
+        onAcceptSplit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Accept as engine split' })).toBeNull();
+    expect(screen.getByText(/\$48\.76 above First Federal.s scheduled payment/)).toBeDefined();
+    expect(
+      screen.getByText(/no ledger category exists for money a servicer merely holds/),
+    ).toBeDefined();
+  });
+
+  it('a short row and a non-mortgage category offer nothing', () => {
+    render(
+      <ReviewQueueTable
+        rows={[
+          staged({
+            id: 's1',
+            description: 'SHORT ROW',
+            amount: '-10.00',
+            suggested_category: 'mortgage_interest',
+            suggested_property_id: 'p1',
+          }),
+          staged({}),
+        ]}
+        onAccept={vi.fn()}
+        onExclude={vi.fn()}
+        noteSplits={() => [SPLIT]}
+        onAcceptSplit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Accept as engine split' })).toBeNull();
+    expect(screen.queryByText(/engine split/)).toBeNull();
+  });
+});

--- a/apps/web/tests/transactions.test.tsx
+++ b/apps/web/tests/transactions.test.tsx
@@ -96,3 +96,68 @@ describe('TransactionsTable', () => {
     expect(screen.getByText(/record one below/i)).toBeDefined();
   });
 });
+
+describe('the register folds a mortgage pair into one payment', () => {
+  const pair = (): LedgerEventOut[] => [
+    event({
+      event_uuid: 'mi1',
+      category: 'mortgage_interest',
+      amount: '-985.61',
+      memo: 'First Federal payment',
+      counterparty: 'First Federal',
+    }),
+    event({
+      event_uuid: 'mp1',
+      category: 'mortgage_principal',
+      amount: '-184.18',
+      memo: 'First Federal payment',
+      counterparty: 'First Federal',
+    }),
+  ];
+
+  it('one line, the exact total, the split stated beneath', () => {
+    render(<TransactionsTable events={pair()} />);
+    expect(screen.getByText('Mortgage Payment')).toBeDefined();
+    expect(screen.getByText('−$1,169.79')).toBeDefined();
+    expect(screen.getByText(/interest −\$985\.61 · principal −\$184\.18/)).toBeDefined();
+    // The pair reads as ONE payment: neither category pill stands alone.
+    expect(screen.queryByText('Mortgage Interest')).toBeNull();
+    expect(screen.queryByText('Mortgage Principal')).toBeNull();
+  });
+
+  it('reverses as a payment: both events, one click', () => {
+    const onReverse = vi.fn();
+    render(<TransactionsTable events={pair()} onReverse={onReverse} />);
+    screen.getByText('Reverse').click();
+    expect(onReverse).toHaveBeenCalledWith('mi1');
+    expect(onReverse).toHaveBeenCalledWith('mp1');
+  });
+
+  it('a pair with no memo or counterparty still reads as one payment', () => {
+    const bare = pair().map((entry) => ({ ...entry, memo: null, counterparty: null }));
+    render(<TransactionsTable events={bare} />);
+    expect(screen.getByText('Mortgage Payment')).toBeDefined();
+    expect(screen.getByText('—')).toBeDefined();
+  });
+
+  it('an inflow pair keeps its ink: only outflows mute', () => {
+    const inflow = pair().map((entry) => ({
+      ...entry,
+      amount: entry.amount.replace('-', ''),
+    }));
+    render(<TransactionsTable events={inflow} />);
+    expect(screen.getByText('$1,169.79').className).not.toContain('muted');
+  });
+
+  it('a struck member unfolds the pair back into two honest rows', () => {
+    const [interest, principal] = pair();
+    render(
+      <TransactionsTable
+        events={[{ ...(interest as LedgerEventOut), reversed: true }, principal as LedgerEventOut]}
+      />,
+    );
+    expect(screen.queryByText('Mortgage Payment')).toBeNull();
+    expect(screen.getByText('Mortgage Interest')).toBeDefined();
+    expect(screen.getByText('Mortgage Principal')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #51. Builds on #37's pair-posting API and #89's panel.

**The transaction form** recognizes a note payment: a mortgage category on a property with a live note offers to record through the note — the ledger receives the linked pair, the engine's figures under its citation, multi-lien picked by name. The plain form stays for the operator who means one line.

**The bank review queue** offers *Accept as engine split* when a row equals a note's scheduled payment to the cent — the figure itself identifies the note; two notes sharing one payment make the operator choose. A row exceeding the payment names its impound remainder and points at the note path: no honest ledger category exists for money a servicer merely holds (gap journaled to the API side), and the note path records escrow without inventing an expense.

**The register** folds each standing interest/principal pair into the one payment it was — split beneath, exact total on the line, reversing as a payment (both events); a struck member unfolds the pair into two honest rows.

**Ladder**: 263 unit tests at 100% statements/branches/functions/lines (pure arithmetic in `lib/mortgage-split.ts` on domain money — the client never computes a split); 25/25 e2e, including a walk that reads the engine's scheduled payment off the note record, routes a form entry through the note, imports a bank row of exactly that figure, accepts the offered split, and finds both pairs folded in the register; full verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)