### PR TITLE
Assessments: the notice an owner was mailed, entered two ways

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/assessments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Assessment */
+        post: operations["create_assessment_assessments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/bank/accounts": {
         parameters: {
             query?: never;
@@ -290,6 +307,23 @@ export interface paths {
         put?: never;
         /** Apply Document */
         post: operations["apply_document_documents__document_id__apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{document_id}/apply-assessment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Apply Assessment Notice */
+        post: operations["apply_assessment_notice_documents__document_id__apply_assessment_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1155,6 +1189,76 @@ export interface components {
             /** Total Basis */
             total_basis: string;
         };
+        /**
+         * AssessmentIn
+         * @description A notice typed off the paper.
+         */
+        AssessmentIn: {
+            /** Assessed Improvement */
+            assessed_improvement?: number | string | null;
+            /** Assessed Land */
+            assessed_land?: number | string | null;
+            /** Assessed Total */
+            assessed_total: number | string;
+            /** Jurisdiction Id */
+            jurisdiction_id?: string | null;
+            /** Notice Received On */
+            notice_received_on?: string | null;
+            /**
+             * Property Id
+             * Format: uuid
+             */
+            property_id: string;
+            /** Tax Year */
+            tax_year: number;
+            /**
+             * Value Basis
+             * @enum {string}
+             */
+            value_basis: "market" | "taxable";
+        };
+        /** AssessmentOut */
+        AssessmentOut: {
+            /** Assessed Improvement */
+            assessed_improvement: string | null;
+            /** Assessed Land */
+            assessed_land: string | null;
+            /** Assessed Total */
+            assessed_total: string;
+            /** Change From Prior */
+            change_from_prior: string | null;
+            /** Confidence */
+            confidence: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: string;
+            /** Jurisdiction */
+            jurisdiction: string;
+            /** Jurisdiction Id */
+            jurisdiction_id: string;
+            /** Land Share */
+            land_share: string | null;
+            /** Notice Received On */
+            notice_received_on: string | null;
+            /** Prior Tax Year */
+            prior_tax_year: number | null;
+            /** Property Id */
+            property_id: string;
+            /** Provenance Kind */
+            provenance_kind: string;
+            /** Source Document Id */
+            source_document_id: string | null;
+            /** Source Label */
+            source_label: string | null;
+            /** Tax Year */
+            tax_year: number;
+            /** Value Basis */
+            value_basis: string;
+        };
         /** BankAccountIn */
         BankAccountIn: {
             /** Account Last4 */
@@ -1274,6 +1378,8 @@ export interface components {
         };
         /** ChainLink */
         ChainLink: {
+            /** Id */
+            id: string;
             /** Level */
             level: string;
             /** Name */
@@ -1870,6 +1976,8 @@ export interface components {
         };
         /** DossierView */
         DossierView: {
+            /** Assessments */
+            assessments: components["schemas"]["AssessmentOut"][];
             /** City */
             city: string;
             /** Components */
@@ -2310,6 +2418,15 @@ export interface components {
             occurred_on: string;
             /** Reason */
             reason: string;
+        };
+        /**
+         * NoticeApplyIn
+         * @description The one decision applying a notice asks for; every number comes off the
+         *     reviewed document.
+         */
+        NoticeApplyIn: {
+            /** Jurisdiction Id */
+            jurisdiction_id?: string | null;
         };
         /** NoticeIn */
         NoticeIn: {
@@ -3234,6 +3351,41 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    create_assessment_assessments_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssessmentIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssessmentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_bank_accounts_bank_accounts_get: {
         parameters: {
             query?: never;
@@ -3882,6 +4034,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApplyResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    apply_assessment_notice_documents__document_id__apply_assessment_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NoticeApplyIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssessmentOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -253,6 +253,268 @@
         "title": "ApplySuggestion",
         "type": "object"
       },
+      "AssessmentIn": {
+        "description": "A notice typed off the paper.",
+        "properties": {
+          "assessed_improvement": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessed Improvement"
+          },
+          "assessed_land": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessed Land"
+          },
+          "assessed_total": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Assessed Total"
+          },
+          "jurisdiction_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Jurisdiction Id"
+          },
+          "notice_received_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notice Received On"
+          },
+          "property_id": {
+            "format": "uuid",
+            "title": "Property Id",
+            "type": "string"
+          },
+          "tax_year": {
+            "maximum": 2200.0,
+            "minimum": 1990.0,
+            "title": "Tax Year",
+            "type": "integer"
+          },
+          "value_basis": {
+            "enum": [
+              "market",
+              "taxable"
+            ],
+            "title": "Value Basis",
+            "type": "string"
+          }
+        },
+        "required": [
+          "property_id",
+          "tax_year",
+          "value_basis",
+          "assessed_total"
+        ],
+        "title": "AssessmentIn",
+        "type": "object"
+      },
+      "AssessmentOut": {
+        "properties": {
+          "assessed_improvement": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessed Improvement"
+          },
+          "assessed_land": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessed Land"
+          },
+          "assessed_total": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Assessed Total",
+            "type": "string"
+          },
+          "change_from_prior": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Change From Prior"
+          },
+          "confidence": {
+            "title": "Confidence",
+            "type": "number"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "jurisdiction": {
+            "title": "Jurisdiction",
+            "type": "string"
+          },
+          "jurisdiction_id": {
+            "title": "Jurisdiction Id",
+            "type": "string"
+          },
+          "land_share": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Land Share"
+          },
+          "notice_received_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notice Received On"
+          },
+          "prior_tax_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prior Tax Year"
+          },
+          "property_id": {
+            "title": "Property Id",
+            "type": "string"
+          },
+          "provenance_kind": {
+            "title": "Provenance Kind",
+            "type": "string"
+          },
+          "source_document_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Document Id"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "tax_year": {
+            "title": "Tax Year",
+            "type": "integer"
+          },
+          "value_basis": {
+            "title": "Value Basis",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "property_id",
+          "jurisdiction_id",
+          "jurisdiction",
+          "tax_year",
+          "value_basis",
+          "assessed_land",
+          "assessed_improvement",
+          "assessed_total",
+          "notice_received_on",
+          "land_share",
+          "prior_tax_year",
+          "change_from_prior",
+          "provenance_kind",
+          "confidence",
+          "source_label",
+          "source_document_id",
+          "created_at"
+        ],
+        "title": "AssessmentOut",
+        "type": "object"
+      },
       "BankAccountIn": {
         "properties": {
           "account_last4": {
@@ -593,6 +855,10 @@
       },
       "ChainLink": {
         "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
           "level": {
             "title": "Level",
             "type": "string"
@@ -603,6 +869,7 @@
           }
         },
         "required": [
+          "id",
           "name",
           "level"
         ],
@@ -2582,6 +2849,13 @@
       },
       "DossierView": {
         "properties": {
+          "assessments": {
+            "items": {
+              "$ref": "#/components/schemas/AssessmentOut"
+            },
+            "title": "Assessments",
+            "type": "array"
+          },
           "city": {
             "title": "City",
             "type": "string"
@@ -2711,7 +2985,8 @@
           "hazards",
           "components",
           "defects",
-          "deadlines"
+          "deadlines",
+          "assessments"
         ],
         "title": "DossierView",
         "type": "object"
@@ -4013,6 +4288,25 @@
           "reason"
         ],
         "title": "NeedsClassification",
+        "type": "object"
+      },
+      "NoticeApplyIn": {
+        "description": "The one decision applying a notice asks for; every number comes off the\nreviewed document.",
+        "properties": {
+          "jurisdiction_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Jurisdiction Id"
+          }
+        },
+        "title": "NoticeApplyIn",
         "type": "object"
       },
       "NoticeIn": {
@@ -7046,6 +7340,56 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/assessments": {
+      "post": {
+        "operationId": "create_assessment_assessments_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssessmentIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Assessment"
+      }
+    },
     "/bank/accounts": {
       "get": {
         "operationId": "list_bank_accounts_bank_accounts_get",
@@ -8094,6 +8438,66 @@
           }
         },
         "summary": "Apply Document"
+      }
+    },
+    "/documents/{document_id}/apply-assessment": {
+      "post": {
+        "operationId": "apply_assessment_notice_documents__document_id__apply_assessment_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "document_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Document Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoticeApplyIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Apply Assessment Notice"
       }
     },
     "/documents/{document_id}/content": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -17,3 +17,4 @@
 \ir 016_maintenance.sql
 \ir 017_replacement_history.sql
 \ir 018_screening.sql
+\ir 019_assessment_records.sql

--- a/packages/domain/schema/019_assessment_records.sql
+++ b/packages/domain/schema/019_assessment_records.sql
@@ -1,0 +1,254 @@
+-- ===========================================================================
+--  019 — Assessment records: what a notice may say, and what it may not.
+--
+--  `assessments` has stood since module 004 with no comment on any of its
+--  columns and no CHECK of any kind, which was defensible only because
+--  nothing had ever written to it — the single reader in the whole repository
+--  is the assessor-ratio land suggestion in documents._suggestion. Issue #46
+--  opens the first two write paths: an owner typing the notice they were
+--  mailed, and the same notice arriving as an uploaded document. The
+--  preconditions ship first.
+--
+--  The question 004 left open is the one every constraint here turns on: do
+--  the assessed_* columns hold appraised (market) value, or taxable value
+--  after the assessing authority's ratio?
+--
+--  Fixing one unit was the obvious answer and it is wrong, because the paper
+--  does not cooperate. An Ohio value notice states MARKET value and nothing
+--  else — the 35% taxable figure appears on the tax BILL, not the notice
+--  (ORC 5713.03 speaks of "true value in money"; ORC 5715.01(B) caps taxable
+--  at thirty-five per cent). A Tennessee assessment change notice prints
+--  BOTH, side by side, and says so on its own reverse. Kentucky assesses at
+--  100% of fair cash value, so the two coincide except where a homestead
+--  exemption parts them. Demand "taxable" and an Ohio owner has nothing to
+--  type; demand "market" and a Tennessee owner must choose a column and hope.
+--
+--  So the unit is not fixed. It is RECORDED, per row, in value_basis, and the
+--  row is meaningless without it: market and taxable differ by a factor of
+--  three in Ohio and four in Tennessee, which is the largest silent error
+--  available anywhere in this system. The ratio itself stays in the pack
+--  (ADR 0003) where it has always been; what this column adds is the fact a
+--  reader needs before deciding whether to apply it.
+--
+--  Three things are deliberately NOT constrained, and each absence is a
+--  decision rather than an oversight.
+--
+--  * `assessed_land + assessed_improvement = assessed_total`. A notice
+--    carries lines this table has no column for: agricultural use-value,
+--    business personalty, and separately-stated exemptions. Where the total
+--    is printed NET of a homestead or similar exemption and the parts are
+--    printed gross, the parts legitimately sum past it. price_allocations can
+--    assert its own equality (004) because it enumerates all three parts of
+--    the thing; this table enumerates two of an unbounded set.
+--
+--  * `assessed_improvement <= assessed_total`, for the same reason. The
+--    improvement line is the large one, so it is the line an exemption-netted
+--    total falls below. Only the land bound survives contact with real paper,
+--    and it survives because it protects a named reader (below).
+--
+--  * Any bound on `millage_rate` beyond non-negativity. Mills per $1,000,
+--    dollars per $100 (Kentucky's own statutory convention) and a plain
+--    decimal fraction all fit NUMERIC(10, 6) and are indistinguishable once
+--    stored; a bound generous to one is absurd for another. The column has no
+--    writer in this release and the comment below says why.
+--
+--  And one thing that is not expressible at all: "the notice is not dated in
+--  the future". CURRENT_DATE is not IMMUTABLE and PostgreSQL refuses it in a
+--  CHECK. Nor should it be a trigger — a post-dated assessor letter is real
+--  paper, not a defect.
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- Money that cannot be negative
+-- ---------------------------------------------------------------------------
+
+-- Narrowing the DOMAIN rather than writing five named CHECKs is module 004's
+-- own instruction: a restated domain predicate is a second, independently
+-- editable copy of one rule. A violation therefore reports the domain's name,
+-- money_nonneg_check, which is what the assertion suite has expected for this
+-- case since the price-allocation block.
+--
+-- Zero stays legal on every one of these: a fully exempt parcel and a
+-- nominal-value sliver lot are both real, and `> 0` would refuse them. The
+-- one reader that divides by assessed_total carries its own `> 0` guard
+-- (documents._suggestion) and keeps it.
+ALTER TABLE assessments ALTER COLUMN assessed_land        TYPE money_nonneg;
+ALTER TABLE assessments ALTER COLUMN assessed_improvement TYPE money_nonneg;
+ALTER TABLE assessments ALTER COLUMN assessed_total       TYPE money_nonneg;
+ALTER TABLE assessments ALTER COLUMN market_value_opinion TYPE money_nonneg;
+ALTER TABLE assessments ALTER COLUMN tax_billed           TYPE money_nonneg;
+
+-- ---------------------------------------------------------------------------
+-- Which figure the notice printed
+-- ---------------------------------------------------------------------------
+
+-- Named for what the amounts ARE, not for the word a particular state uses
+-- for them, because the words collide across states: Kentucky's "assessed
+-- value" IS market value, Ohio's is 35% of it, Tennessee's is 25% or 40% of
+-- appraised depending on class. Two neutral terms, and a comment mapping the
+-- local vocabulary onto them, beats three states arguing over one adjective.
+CREATE TYPE assessed_value_basis AS ENUM (
+  -- What the assessor says the property is worth. Kentucky's "Fair Cash
+  -- Value", Ohio's "true value in money" or "Market Total Value",
+  -- Tennessee's "Total Market Appraisal" or "Total Appraisal".
+  'market',
+  -- What the tax is actually computed on, after the state's ratio and any
+  -- classification. Ohio's "Assessed Value" or "35% Taxable Value",
+  -- Tennessee's "Assessment" or "Total Assessment", Kentucky's "Taxable
+  -- Value" (which differs from market only by an exemption, never a ratio).
+  'taxable'
+);
+
+-- No DEFAULT, deliberately. A default would be a guess about which figure a
+-- row already in the table holds, and a wrong guess is a threefold error that
+-- reads as data. The column is NOT NULL with nothing to fall back on, so this
+-- module refuses to apply at all to a database that somehow holds
+-- assessments — which no writer has ever created, this being the release that
+-- adds the first two.
+ALTER TABLE assessments ADD COLUMN value_basis assessed_value_basis NOT NULL;
+
+COMMENT ON COLUMN assessments.value_basis IS
+  'Whether every assessed_* amount in this row is a market figure or a '
+  'taxable one. Not derivable and never inferred: an Ohio notice states only '
+  'market, a Tennessee notice states both, and Kentucky''s coincide at a '
+  '100% ratio. A reader that wants full value from a taxable row divides by '
+  'the pack''s assessment.ratio; a reader that treats this column as '
+  'decoration is off by three in Ohio and four in Tennessee.';
+
+-- ---------------------------------------------------------------------------
+-- What one notice may state about itself
+-- ---------------------------------------------------------------------------
+
+-- One body, one year, one BASIS. The key 004 wrote could not know that a
+-- Tennessee assessment change notice prints an appraised total and an
+-- assessed total side by side, for the same parcel and the same year, and
+-- that both are worth keeping: the first is what an over-assessment test
+-- compares against a market opinion, the second is what the tax is actually
+-- computed on. Under the old key an owner transcribing that notice had to
+-- throw one away. The basis joins the key so both rows fit, and the key still
+-- refuses the thing it was written to refuse — the same figure twice.
+ALTER TABLE assessments
+  DROP CONSTRAINT assessments_property_id_jurisdiction_id_tax_year_key;
+ALTER TABLE assessments ADD CONSTRAINT one_body_one_year_one_basis
+  UNIQUE (property_id, jurisdiction_id, tax_year, value_basis);
+
+COMMENT ON CONSTRAINT one_body_one_year_one_basis ON assessments IS
+  'A Tennessee notice states both bases for one parcel and one year, so both '
+  'may be recorded; what may not be recorded twice is the same body''s same '
+  'figure for the same year. Note this does NOT stop one notice being '
+  'recorded against a county and again against a municipality: some states '
+  'genuinely levy at both levels, and a key that refused it would refuse real '
+  'paper.';
+
+ALTER TABLE assessments ADD CONSTRAINT assessed_land_within_total
+  CHECK (assessed_land IS NULL OR assessed_land <= assessed_total);
+
+-- Module 008 already set this band for a tax year, on two tables, under two
+-- names (plausible_tax_year on tax_profiles and again on tax_elections) —
+-- because the assertion harness matches on constraint name alone and a shared
+-- name leaves a case unable to say which table refused. A third name, then.
+-- SMALLINT already caps at 32767; this is about catching a typed 20226.
+ALTER TABLE assessments ADD CONSTRAINT plausible_assessment_year
+  CHECK (tax_year BETWEEN 1990 AND 2200);
+
+-- The LOWER half of the plausible band only. Ohio's sexennial reappraisal
+-- notices go out in the autumn PRECEDING the tax year they set, so a notice
+-- dated in year-1 is ordinary; and omitted-property and supplemental
+-- assessments reach back several years, so a 2026 notice assessing 2022 is
+-- real paper an owner would want to type in. An upper bound would refuse it.
+-- This catches the transposed year — a 2016 date on a 2026 notice — and
+-- claims nothing about how late a correction may arrive.
+ALTER TABLE assessments ADD CONSTRAINT notice_not_before_its_year
+  CHECK (notice_received_on IS NULL
+         OR notice_received_on >= make_date(tax_year::int - 1, 1, 1));
+
+ALTER TABLE assessments ADD CONSTRAINT millage_rate_nonneg
+  CHECK (millage_rate IS NULL OR millage_rate >= 0);
+
+-- ---------------------------------------------------------------------------
+-- Every assessment cites its authority
+-- ---------------------------------------------------------------------------
+
+-- Nullable was defensible while nothing wrote here. It stops being defensible
+-- the moment the appeal card renders these numbers: a figure the owner cannot
+-- trace back to a paper notice, an upload, or a county feed is a figure they
+-- cannot check. Every writer that exists or is planned — manual entry, the
+-- notice path, and the county adapter of #12 — has a provenance to hand or
+-- has no business writing here.
+ALTER TABLE assessments ALTER COLUMN provenance_id SET NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- What the columns mean
+-- ---------------------------------------------------------------------------
+
+COMMENT ON TABLE assessments IS
+  'One assessing body''s stated value for one property in one tax year, as '
+  'the notice states it. The row is a transcript, not a judgement: no ratio '
+  'is applied on the way in and no market comparison is drawn here. A '
+  'correction arrives as a new row for a new year, or as an appeal in '
+  'assessment_appeals — never by rewriting what the notice said.';
+
+COMMENT ON COLUMN assessments.jurisdiction_id IS
+  'The body that ISSUED this assessment, which is often not the property''s '
+  'most specific governing body: Kentucky assesses through the county PVA, '
+  'Ohio through the county Auditor, Tennessee through the county Assessor of '
+  'Property, while a property commonly resolves to a municipality. Which '
+  'level assesses is a jurisdiction fact and therefore pack data, not code, '
+  'so the API asks the caller to name the body and validates the answer '
+  'against jurisdiction_chain() rather than inferring a level. A rule code '
+  'naming the assessing level per state is the fix that would remove the '
+  'question; until it is seeded, the property''s own resolved jurisdiction '
+  'stands in.';
+
+COMMENT ON COLUMN assessments.assessed_total IS
+  'The total the notice states, in the basis value_basis names. Never '
+  'divided or multiplied by an assessment ratio on the way in: Ohio''s 35% and '
+  'Tennessee''s classification live in jurisdiction_rules and are applied by '
+  'the reader, so a row transcribed in one state means the same thing as a '
+  'row transcribed in another. Zero is legal and meaningful — a fully exempt '
+  'parcel is a real assessment.';
+
+COMMENT ON COLUMN assessments.assessed_land IS
+  'Optional, and in the SAME basis as assessed_total. It is the numerator of '
+  'the assessor-ratio land split that documents._suggestion multiplies a '
+  'purchase basis by, which is the whole reason assessed_land_within_total '
+  'exists. Where a notice prints land at market against a total stated at a '
+  'statutory ratio, or a total net of an exemption the parts are gross of, '
+  'leave this blank rather than mixing units: a blank costs nothing this '
+  'release promises, and a mixed unit silently corrupts an allocation.';
+
+COMMENT ON COLUMN assessments.assessed_improvement IS
+  'Optional, same basis as assessed_total. Deliberately unconstrained against '
+  'the total — see the module header.';
+
+COMMENT ON COLUMN assessments.market_value_opinion IS
+  'Our view, not the assessor''s — the other side of the over-assessment '
+  'test. A different fact with a different provenance from everything else in '
+  'this row, which is why no writer shipped in #46 sets it.';
+
+COMMENT ON COLUMN assessments.millage_rate IS
+  'UNIT UNDEFINED, and therefore unwritten. Mills per $1,000, dollars per '
+  '$100 and a plain decimal fraction all fit this column and differ by orders '
+  'of magnitude, so the only honest constraint is non-negativity and no API '
+  'endpoint accepts a value. The module that ships millage and tax-bill '
+  'reconciliation fixes the convention by rewriting this comment and adding '
+  'the real bound, before writing a single value. Compare the annual_rate '
+  'domain in 001, which exists because exactly this confusion once produced a '
+  'payment a hundredfold too large.';
+
+COMMENT ON COLUMN assessments.tax_billed IS
+  'What a notice or bill says is owed. Not derivable from assessed_total and '
+  'millage_rate: homestead exemptions, HB 920 reduction factors and credits '
+  'all sit between them and none of that is modelled yet.';
+
+COMMENT ON COLUMN assessments.notice_received_on IS
+  'When the paper arrived — the owner''s own clock on a short statutory '
+  'window, and not derivable from tax_year in either direction.';
+
+COMMENT ON CONSTRAINT assessed_land_within_total ON assessments IS
+  'The only arithmetic relation between these columns that survives contact '
+  'with a notice from any state. documents._suggestion divides assessed_land '
+  'by assessed_total and multiplies a purchase basis by the result; a ratio '
+  'above 1 puts more than the whole basis into land, which never depreciates '
+  '— the precise failure the price_allocations table comment exists to '
+  'prevent.';

--- a/packages/domain/schema/seed/908_extraction_assessment_notice.sql
+++ b/packages/domain/schema/seed/908_extraction_assessment_notice.sql
@@ -1,0 +1,84 @@
+-- ===========================================================================
+--  Seed — extraction field specs: the assessment notice
+--
+--  The second extractable kind, and the proof of extraction_field_specs' own
+--  claim that a new kind is seed rows plus a parser — never a schema change,
+--  and never an edit to an applied file.
+--
+--  Seven rows, not thirteen. A spec exists only where the apply step writes
+--  the value it names, or where a reviewer needs to see the value to check a
+--  decision. millage_rate has no documented unit (module 019 says so on the
+--  column), tax_billed belongs to a tax bill, which is its own document kind,
+--  and market_value_opinion is our view rather than the assessor's. Seeding
+--  any of them would put a field on the review screen that apply then
+--  silently drops.
+--
+--  WHAT THESE DOCUMENTS ACTUALLY ARE, because it sets what may be promised.
+--  There is no standard assessment notice in the United States and only
+--  Kentucky prescribes a form (62A352). Ohio requires notice under ORC
+--  5713.01(C) but fixes no fields, and at least two counties in the owner's
+--  own metro satisfy it by publication and mail nothing per parcel. Tennessee
+--  mails a card whose front no county publishes. Where a specimen does exist
+--  the labels disagree: "Fair Cash Value", "Market Total Value", "Total
+--  Market Appraisal", "Total Appraisal" all name one idea, and Campbell
+--  County prints Fair Cash Value as 0.00 on ordinary residential parcels
+--  while the real figure sits in Total Value.
+--
+--  So these rows are not a promise to read any notice. They are the registry
+--  the review screen renders and the apply step writes, and a notice the
+--  parser cannot read arrives as flagged skeleton rows — a typing form with
+--  the original attached and the provenance still 'document'. That is the
+--  honest shape for paper that mostly reaches us as a phone photograph.
+--
+--  target_hint is reviewer documentation. The apply step is code
+--  (services/api/hestia_api/assessments.py) and writes exactly what these
+--  hints describe: one assessments row, provenance-linked to this document,
+--  and nothing else. No ledger event — an assessment is a statement of
+--  value, not a movement of cash.
+-- ===========================================================================
+
+INSERT INTO extraction_field_specs
+  (document_kind, field_path, label, datatype, required, display_order, target_hint)
+VALUES
+  ('assessment_notice', 'assessment.tax_year', 'Tax year',
+   'text', TRUE, 1,
+   'assessments.tax_year — the year assessed, which is not always the year '
+   'printed on the envelope: Ohio mails a reappraisal notice in the autumn '
+   'before the year it sets'),
+  -- Required, and deliberately NOT something the parser may answer. The same
+  -- card prints an appraised total and an assessed total that differ by a
+  -- factor of three in Ohio and four in Tennessee, under labels that vary by
+  -- county; a machine that guesses wrong produces a number that looks
+  -- entirely reasonable and is off by 300%. A person holding the paper knows
+  -- which column they read. This arrives as a flagged skeleton row on every
+  -- notice, on purpose.
+  ('assessment_notice', 'assessment.value_basis', 'Which figure is this',
+   'text', TRUE, 2,
+   'assessments.value_basis — exactly "market" or "taxable". Market is what '
+   'the assessor says it is worth (Kentucky "Fair Cash Value", Ohio "true '
+   'value"/"Market Total Value", Tennessee "Total Market Appraisal"); taxable '
+   'is what the tax is computed on after the state ratio (Ohio "Assessed '
+   'Value"/"35% Taxable Value", Tennessee "Assessment", Kentucky "Taxable '
+   'Value"). Never inferred from the amounts'),
+  ('assessment_notice', 'assessment.assessed_total', 'Total value',
+   'money', TRUE, 3,
+   'assessments.assessed_total, in the basis named above and never converted '
+   'by any assessment ratio on the way in'),
+  ('assessment_notice', 'assessment.assessed_land', 'Land value',
+   'money', FALSE, 4,
+   'assessments.assessed_land — the numerator of the land split a purchase '
+   'allocation cites. Must be in the SAME basis as the total; where the '
+   'notice prints land at market against a total at a ratio, leave it blank'),
+  ('assessment_notice', 'assessment.assessed_improvement',
+   'Improvement value', 'money', FALSE, 5,
+   'assessments.assessed_improvement — printed as "Improvements" in Ohio and '
+   'as "Building Appraisal" in Shelby County, Tennessee'),
+  ('assessment_notice', 'assessment.notice_date', 'Notice date',
+   'date', FALSE, 6,
+   'assessments.notice_received_on — the printed mailing date, which is the '
+   'closest thing a document can prove about when the owner was told'),
+  ('assessment_notice', 'assessment.assessing_body', 'Assessing body',
+   'text', FALSE, 7,
+   'not applied: shown so the reviewer can confirm which governing body sent '
+   'this before choosing it at apply. Never matched by name — a fuzzy match '
+   'between "Campbell" and "Kenton" is how a notice lands on the wrong chain');

--- a/packages/domain/schema/seed/README.md
+++ b/packages/domain/schema/seed/README.md
@@ -8,7 +8,7 @@ answer questions instead of holding them (ADR 0003 — jurisdiction is data).
 | Range | Contents |
 |---|---|
 | `899_federal.sql` | The federal tier: the root jurisdiction row and rules that apply identically in all fifty states. Sorts before every pack; every pack may assume it is installed and nothing else. |
-| `900–949` | State packs, one file per state: `9NN_jurisdictions_xx.sql`. |
+| `900–949` | State packs, one file per state (`9NN_jurisdictions_xx.sql`), and the registry seeds that are data rather than structure: `905` and `908` are `extraction_field_specs` rows for a document kind, `906` names a deposit-interest formula builder. A registry seed is not a pack and needs no pack test. |
 | `950+` | Demo data and corrections. |
 
 The migration runner (`scripts/migrate.py`) discovers seeds by glob — a new

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -1180,3 +1180,146 @@ SELECT assert_accepted(
             '33333333-3333-3333-3333-333333333333', 'KRS 133.045')$$,
   'the following year is a different deadline');
 
+
+\echo ''
+\echo 'property tax assessments'
+SELECT assert_accepted(
+  $$INSERT INTO assessments (id, property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_land, assessed_improvement, assessed_total, notice_received_on,
+      millage_rate, provenance_id)
+    VALUES ('46464646-4646-4646-8646-464646460001',
+            '33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2026, 'taxable',
+            30000, 130000, 160000, '2026-05-04', 0.910000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'a 2026 notice transcribed whole');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2026, 'taxable', 170000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'one_body_one_year_one_basis',
+  'the same body stating the same figure for the same year twice');
+SELECT assert_accepted(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2025, 'taxable', 0,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'a fully exempt parcel, assessed at zero');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2024, 'taxable', -1,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'money_nonneg_check', 'an assessment worth less than nothing');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_land, assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2023, 'taxable', -1, 160000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'money_nonneg_check', 'a land line below zero');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_land, assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2022, 'taxable', 200000, 160000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'assessed_land_within_total', 'more land than whole property');
+-- Accepted ON PURPOSE, and this is the assertion that matters most in this
+-- block: an improvement line ABOVE the total is what a notice prints when the
+-- total is net of an exemption the parts are gross of. A later reader who
+-- "tidies up" assessed_land_within_total into a symmetric parts-within-total
+-- rule breaks here rather than in a Kentucky owner's face.
+SELECT assert_accepted(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_improvement, assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2021, 'taxable', 200000, 160000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'an improvement line gross of an exemption the total is net of');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 1899, 'taxable', 160000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'plausible_assessment_year', 'a tax year no notice states');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, notice_received_on, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2020, 'taxable', 160000, '2010-05-04',
+            '22222222-2222-2222-2222-222222222222')$$,
+  'notice_not_before_its_year',
+  'a notice dated a decade before the year it assesses');
+-- Ohio mails the reappraisal notice in the autumn BEFORE the tax year it
+-- sets. The lower bound is year-1 precisely so this is not refused.
+SELECT assert_accepted(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, notice_received_on, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2019, 'taxable', 160000, '2018-10-15',
+            '22222222-2222-2222-2222-222222222222')$$,
+  'a reappraisal notice mailed the autumn before its tax year');
+SELECT assert_rejected(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, millage_rate, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2018, 'taxable', 160000, -0.001,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'millage_rate_nonneg', 'a negative rate of tax');
+-- NOT NULL carries no constraint name, so assert_rejected would report
+-- '<trigger>' and read as a lie. Asserted directly instead.
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+                             assessed_total)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2017, 'taxable', 160000);
+    RAISE EXCEPTION 'CONSTRAINT DID NOT BITE: an assessment with no author was accepted';
+  EXCEPTION WHEN not_null_violation THEN
+    RAISE NOTICE '  ok      rejected by NOT NULL: an assessment that will not say how we know it';
+  END;
+END $$;
+-- The basis is the difference between a number and a number three times too
+-- large, so it is not optional and there is nothing to fall back on.
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO assessments (property_id, jurisdiction_id, tax_year,
+                             assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2016, 160000,
+            '22222222-2222-2222-2222-222222222222');
+    RAISE EXCEPTION 'CONSTRAINT DID NOT BITE: an assessment that will not say '
+      'whether it is a market or a taxable figure was accepted';
+  EXCEPTION WHEN not_null_violation THEN
+    RAISE NOTICE '  ok      rejected by NOT NULL: an assessment with no stated basis';
+  END;
+END $$;
+-- Tennessee prints both figures on one card for one parcel and one year. The
+-- widened key exists so an owner can transcribe the card whole rather than
+-- choosing which half to keep.
+SELECT assert_accepted(
+  $$INSERT INTO assessments (property_id, jurisdiction_id, tax_year, value_basis,
+      assessed_total, provenance_id)
+    VALUES ('33333333-3333-3333-3333-333333333333',
+            '77777777-7777-7777-7777-777777777777', 2026, 'market', 640000,
+            '22222222-2222-2222-2222-222222222222')$$,
+  'the market half of a notice whose taxable half is already recorded');
+-- window_ordered has stood since module 004 without ever being shown to
+-- reject anything, which by this file's opening line makes it a comment. It
+-- is an appeal on the assessment recorded above, so it belongs here.
+SELECT assert_rejected(
+  $$INSERT INTO assessment_appeals (assessment_id, window_opens_on, window_closes_on)
+    VALUES ('46464646-4646-4646-8646-464646460001', '2026-05-04', '2026-05-01')$$,
+  'window_ordered', 'an appeal window that closes before it opens');
+SELECT assert_accepted(
+  $$INSERT INTO assessment_appeals (assessment_id, window_opens_on, window_closes_on)
+    VALUES ('46464646-4646-4646-8646-464646460001', '2026-05-04', '2026-05-18')$$,
+  'the KRS 133.045 inspection period, in order');

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from decimal import Decimal
 from typing import Annotated, Any, Literal
 
@@ -32,6 +32,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from hestia_api import (
+    assessments,
     bank_import,
     config,
     coverage,
@@ -1427,7 +1428,11 @@ def apply_document(
             status_code=409,
             detail=f"apply requires status confirmed; the document is {error}",
         ) from error
-    except (documents.NotExactlyOneProperty, documents.InvalidAllocation) as error:
+    except (
+        documents.NotExactlyOneProperty,
+        documents.InvalidAllocation,
+        documents.WrongApplyKind,
+    ) as error:
         raise HTTPException(status_code=422, detail=str(error)) from error
     db.record_audit(
         conn,
@@ -2040,5 +2045,105 @@ def return_deposit(
         table_name="leases",
         record_id=str(lease_id),
         after_value=result.model_dump(mode="json"),
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Assessments: what a body says a property is worth
+# ---------------------------------------------------------------------------
+
+
+def _record_assessment(
+    write: Callable[[], assessments.AssessmentOut],
+) -> assessments.AssessmentOut:
+    """One error map for one writer. Both doors into `assessments` refuse for
+    the same reasons in the same words; two ladders would drift apart on the
+    first wording change."""
+    try:
+        return write()
+    except documents.UnknownDocument as error:
+        raise HTTPException(status_code=404, detail="document not found") from error
+    except assessments.UnknownProperty as error:
+        raise HTTPException(status_code=404, detail="property not found") from error
+    except documents.AlreadyApplied as error:
+        raise HTTPException(
+            status_code=409, detail="already applied; a document applies exactly once"
+        ) from error
+    except documents.NotConfirmed as error:
+        raise HTTPException(
+            status_code=409,
+            detail=f"apply requires status confirmed; the document is {error}",
+        ) from error
+    except assessments.DuplicateAssessment as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    except (
+        assessments.NotAGoverningBody,
+        assessments.UnusableValue,
+        documents.WrongApplyKind,
+        documents.NotExactlyOneProperty,
+    ) as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
+    except assessments.JurisdictionUnavailable as error:
+        raise HTTPException(
+            status_code=503,
+            detail=(f"no jurisdiction pack is loaded for {error}; see GET /coverage/jurisdictions"),
+        ) from error
+
+
+@app.post("/assessments", response_model=assessments.AssessmentOut, status_code=201)
+def create_assessment(
+    body: assessments.AssessmentIn, conn: Conn, request: Request, actor: Actor = "system"
+) -> assessments.AssessmentOut:
+    result = _record_assessment(lambda: assessments.record(conn, body, actor))
+    # The created ROW, not the request body: the body may omit the
+    # jurisdiction, and an audit reader needs what was written.
+    _audit(
+        conn,
+        request,
+        actor,
+        "assessment.create",
+        "assessments",
+        result.id,
+        result.model_dump(mode="json"),
+    )
+    return result
+
+
+@app.post(
+    "/documents/{document_id}/apply-assessment",
+    response_model=assessments.AssessmentOut,
+    status_code=201,
+)
+def apply_assessment_notice(
+    document_id: uuid.UUID,
+    body: assessments.NoticeApplyIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> assessments.AssessmentOut:
+    result = _record_assessment(
+        lambda: assessments.apply_notice(conn, str(document_id), body, actor)
+    )
+    _audit(
+        conn,
+        request,
+        actor,
+        "assessment.create",
+        "assessments",
+        result.id,
+        result.model_dump(mode="json"),
+    )
+    # The document changed state too, and every mutation owes a row. The same
+    # action string as /documents/{id}/apply, so "what closed this document" is
+    # one audit query however it was closed.
+    _audit(
+        conn,
+        request,
+        actor,
+        "documents.apply",
+        "source_documents",
+        str(document_id),
+        {"kind": "assessment_notice", "assessment_id": result.id},
     )
     return result

--- a/services/api/hestia_api/assessments.py
+++ b/services/api/hestia_api/assessments.py
@@ -1,0 +1,398 @@
+"""Assessment records: what an assessing body said a property is worth.
+
+Two doors, one table. An owner types the notice they were mailed, or the same
+notice arrives as an uploaded document and its reviewed fields are written
+here. Both leave a provenance row behind, because module 019 made that column
+NOT NULL: a figure the appeal card renders is a figure the owner must be able
+to trace back to paper.
+
+What this module deliberately does NOT do is judge. No ratio is applied on the
+way in, no market comparison is drawn, no verdict about over-assessment is
+formed — that is the detector's work, and it needs the pack's assessment.ratio
+which this module never reads. What is stored is what the paper said, plus the
+one fact the paper's own layout hides: WHICH figure it was.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+from pydantic import BaseModel, Field
+
+from hestia_api import documents, extraction_parse
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+ValueBasis = Literal["market", "taxable"]
+
+
+class UnknownProperty(Exception):
+    """No such property."""
+
+
+class NotAGoverningBody(Exception):
+    """The named jurisdiction is not on this property's chain."""
+
+
+class JurisdictionUnavailable(Exception):
+    """No pack resolves this property, and the caller named no body."""
+
+
+class DuplicateAssessment(Exception):
+    """One body, one property, one year, one basis — already recorded."""
+
+
+class UnusableValue(Exception):
+    """A confirmed value the domain refuses, in the domain's own words."""
+
+
+class AssessmentIn(BaseModel):
+    """A notice typed off the paper."""
+
+    property_id: uuid.UUID
+    # Which body issued it. Omitted, the property's own resolved jurisdiction
+    # stands in; named, it must be on that property's chain. Never inferred
+    # from the notice text — see _resolve_jurisdiction.
+    jurisdiction_id: uuid.UUID | None = None
+    tax_year: int = Field(ge=extraction_parse.MIN_TAX_YEAR, le=extraction_parse.MAX_TAX_YEAR)
+    # No default. Market and taxable differ by a factor of three in Ohio and
+    # four in Tennessee, so a default would be the largest silent error this
+    # system can make.
+    value_basis: ValueBasis
+    assessed_total: Decimal = Field(ge=0, decimal_places=2, max_digits=18)
+    assessed_land: Decimal | None = Field(default=None, ge=0, decimal_places=2, max_digits=18)
+    assessed_improvement: Decimal | None = Field(
+        default=None, ge=0, decimal_places=2, max_digits=18
+    )
+    notice_received_on: dt.date | None = None
+
+
+class NoticeApplyIn(BaseModel):
+    """The one decision applying a notice asks for; every number comes off the
+    reviewed document."""
+
+    jurisdiction_id: uuid.UUID | None = None
+
+
+class AssessmentOut(BaseModel):
+    id: str
+    property_id: str
+    jurisdiction_id: str
+    jurisdiction: str
+    tax_year: int
+    value_basis: str
+    assessed_land: Decimal | None
+    assessed_improvement: Decimal | None
+    assessed_total: Decimal
+    notice_received_on: dt.date | None
+    # Server-computed, because the browser computes nothing: the land share
+    # documents._suggestion already cites, and the year-over-year move that is
+    # the reason an owner appeals at all. Both are SQL, so neither costs a
+    # Python branch, and prior_tax_year travels with the delta so the card can
+    # never imply a comparison with last year when it was with 2019.
+    land_share: Decimal | None
+    prior_tax_year: int | None
+    change_from_prior: Decimal | None
+    # How we know. Non-optional, because module 019 made provenance_id NOT
+    # NULL — the card cannot render an authorless number.
+    provenance_kind: str
+    confidence: float
+    source_label: str | None
+    source_document_id: str | None
+    created_at: dt.datetime
+
+
+PROJECTION = """
+    SELECT ranked.* FROM (
+      SELECT a.id::text AS id, a.property_id::text AS property_id,
+             a.jurisdiction_id::text AS jurisdiction_id, j.name AS jurisdiction,
+             a.tax_year, a.value_basis::text AS value_basis,
+             a.assessed_land, a.assessed_improvement, a.assessed_total,
+             a.notice_received_on,
+             CASE WHEN a.assessed_land IS NOT NULL AND a.assessed_total > 0
+                  THEN round(a.assessed_land / a.assessed_total, 6) END AS land_share,
+             lag(a.tax_year) OVER prior AS prior_tax_year,
+             a.assessed_total - lag(a.assessed_total) OVER prior AS change_from_prior,
+             pr.kind::text AS provenance_kind, pr.confidence::float AS confidence,
+             pr.source_label, pr.source_document::text AS source_document_id,
+             a.created_at
+      FROM assessments a
+      JOIN jurisdictions j ON j.id = a.jurisdiction_id
+      JOIN provenance pr ON pr.id = a.provenance_id
+      WHERE a.property_id = %(property_id)s
+      -- PARTITION BY the assessing body AND the basis: a prior year from a
+      -- different body is not a comparison but two separate claims, and a
+      -- market total minus last year's taxable total is arithmetic on two
+      -- different units.
+      WINDOW prior AS (PARTITION BY a.jurisdiction_id, a.value_basis ORDER BY a.tax_year)
+    ) ranked
+    WHERE (%(assessment_id)s::uuid IS NULL OR ranked.id::uuid = %(assessment_id)s)
+    ORDER BY ranked.tax_year DESC, ranked.jurisdiction, ranked.value_basis
+"""
+
+
+def for_property(
+    conn: Conn, property_id: str, *, assessment_id: str | None = None
+) -> list[AssessmentOut]:
+    """Every assessment on file for a property, newest tax year first.
+
+    The NULL-guarded id filter is the list_documents idiom: reading back the
+    row just written and rendering the dossier are one query, so the two can
+    never compute the year-over-year move differently.
+    """
+    return [
+        AssessmentOut(**row)
+        for row in conn.execute(
+            PROJECTION, {"property_id": property_id, "assessment_id": assessment_id}
+        ).fetchall()
+    ]
+
+
+def _resolve_jurisdiction(
+    conn: Conn, property_id: uuid.UUID, named: uuid.UUID | None
+) -> tuple[str, str]:
+    """Which body assessed this property: the caller's choice validated
+    against the property's own chain, else the jurisdiction the packs resolved
+    for the property, else a refusal that names the gap.
+
+    Not from the notice. A notice prints an OFFICE — "Campbell County Property
+    Valuation Administrator" — and matching that string to a jurisdictions row
+    is fuzzy matching on names that collide by design; this repository now has
+    a Hamilton County in two states. A near miss attaches an assessment to a
+    neighbouring county silently, so the office is extracted, shown to the
+    reviewer, and never matched.
+
+    Not by walking to the nearest county either. "Counties assess real
+    property" is true in Kentucky, Ohio and Tennessee and false in New England
+    towns and Virginia's independent cities; encoding it here would put a
+    governance fact in dispatch logic, which is the ADR 0003 failure mode —
+    and one the state-literal ratchet would NOT catch, because it contains no
+    state literal. jurisdiction_chain() is data, and the caller chooses in it.
+    """
+    row = conn.execute(
+        """
+        SELECT p.state,
+               p.jurisdiction_id::text AS resolved_id,
+               resolved.name           AS resolved_name,
+               chosen.id::text         AS chosen_id,
+               chosen.name             AS chosen_name,
+               (EXISTS (SELECT 1 FROM jurisdiction_chain(p.jurisdiction_id) c
+                        WHERE c.jurisdiction_id = chosen.id)
+                -- The federal row is on every chain and assesses nothing.
+                -- A predicate, not a branch.
+                AND chosen.state IS NOT NULL) AS governs
+        FROM properties p
+        LEFT JOIN jurisdictions resolved ON resolved.id = p.jurisdiction_id
+        LEFT JOIN jurisdictions chosen   ON chosen.id = %(named)s::uuid
+        WHERE p.id = %(property_id)s
+        """,
+        {"named": named, "property_id": property_id},
+    ).fetchone()
+    if row is None:
+        raise UnknownProperty(str(property_id))
+    if named is None:
+        if row["resolved_id"] is None:
+            raise JurisdictionUnavailable(row["state"])
+        return row["resolved_id"], row["resolved_name"]
+    # An unknown id and a real id from another chain land in one refusal: with
+    # no `chosen` row, EXISTS is false and `governs` is false, not NULL. Two
+    # error shapes for the same wrong id would buy nothing.
+    if not row["governs"]:
+        raise NotAGoverningBody(
+            "that jurisdiction does not govern this property; choose one of the bodies on its chain"
+        )
+    return row["chosen_id"], row["chosen_name"]
+
+
+# The sentence each schema rule owes an owner, keyed by the constraint's own
+# name so a rule renamed in a later module fails to find its sentence rather
+# than quietly explaining the wrong thing. The rules are NOT restated in
+# Python — the database is the authority and this is only its voice.
+REFUSALS = {
+    "assessed_land_within_total": (
+        "the land line exceeds the total it is part of; enter both in the same"
+        " basis, or leave the land line blank"
+    ),
+    "notice_not_before_its_year": "the notice is dated before the tax year it assesses",
+    "plausible_assessment_year": "that is not a tax year a notice states",
+    "money_nonneg_check": "an assessed value cannot be negative",
+    "millage_rate_nonneg": "a millage rate cannot be negative",
+}
+
+
+def _insert(
+    conn: Conn,
+    *,
+    property_id: str,
+    jurisdiction_id: str,
+    tax_year: int,
+    value_basis: str,
+    assessed_land: Decimal | None,
+    assessed_improvement: Decimal | None,
+    assessed_total: Decimal,
+    notice_received_on: dt.date | None,
+    provenance_id: str,
+) -> str:
+    try:
+        row = conn.execute(
+            """
+            INSERT INTO assessments
+              (property_id, jurisdiction_id, tax_year, value_basis, assessed_land,
+               assessed_improvement, assessed_total, notice_received_on, provenance_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id::text
+            """,
+            (
+                property_id,
+                jurisdiction_id,
+                tax_year,
+                value_basis,
+                assessed_land,
+                assessed_improvement,
+                assessed_total,
+                notice_received_on,
+                provenance_id,
+            ),
+        ).fetchone()
+    except psycopg.errors.UniqueViolation as error:
+        raise DuplicateAssessment(
+            f"that body already has a {value_basis} {tax_year} assessment for this property"
+        ) from error
+    except psycopg.errors.CheckViolation as error:
+        # A confirmed notice can still be impossible — a reviewer can ratify a
+        # land line above the total — and a psycopg error reaching the client
+        # as a 500 is a defect. Each rule answers in its own words instead.
+        raise UnusableValue(
+            REFUSALS.get(error.diag.constraint_name or "", "the notice's values were refused")
+        ) from error
+    assert row is not None
+    return str(row["id"])
+
+
+def record(conn: Conn, body: AssessmentIn, actor: str) -> AssessmentOut:
+    """The manual door: an owner typing the notice they were mailed."""
+    jurisdiction_id, jurisdiction_name = _resolve_jurisdiction(
+        conn, body.property_id, body.jurisdiction_id
+    )
+    # confidence 1.0 is not decoration: provenance.stated_facts_are_certain
+    # refuses 'owner_stated' at anything else — and it is true, because the
+    # owner is reading the paper.
+    provenance = conn.execute(
+        """
+        INSERT INTO provenance (kind, confidence, source_label)
+        VALUES ('owner_stated', 1.0, %s) RETURNING id::text
+        """,
+        (
+            f"{body.tax_year} assessment notice, {body.value_basis} value"
+            f" ({jurisdiction_name}) entered by {actor}",
+        ),
+    ).fetchone()
+    assert provenance is not None
+    assessment_id = _insert(
+        conn,
+        property_id=str(body.property_id),
+        jurisdiction_id=jurisdiction_id,
+        tax_year=body.tax_year,
+        value_basis=body.value_basis,
+        assessed_land=body.assessed_land,
+        assessed_improvement=body.assessed_improvement,
+        assessed_total=body.assessed_total,
+        notice_received_on=body.notice_received_on,
+        provenance_id=str(provenance["id"]),
+    )
+    return for_property(conn, str(body.property_id), assessment_id=assessment_id)[0]
+
+
+def _money(values: dict[str, str | None], path: str) -> Decimal | None:
+    raw = values.get(path)
+    if raw is None:
+        return None
+    amount = Decimal(raw)
+    # An OPTIONAL money field can reach apply without ever passing a human, so
+    # it never passed documents._canonicalise's bound either. Unbounded, an
+    # eighteen-digit land line would reach the client as a psycopg
+    # NumericValueOutOfRange 500 — after the gate had already flipped the
+    # document. Refused here in a sentence, before anything is written.
+    if abs(amount) > documents.MAX_MONEY:
+        raise UnusableValue(f"{raw!r} exceeds the largest amount this records")
+    return amount
+
+
+def _date(values: dict[str, str | None], path: str) -> dt.date | None:
+    raw = values.get(path)
+    if raw is None:
+        return None
+    return dt.date.fromisoformat(raw)
+
+
+def apply_notice(conn: Conn, doc_id: str, body: NoticeApplyIn, actor: str) -> AssessmentOut:
+    """The document door: a reviewed notice becomes the row it describes."""
+    gate = documents.claim_for_apply(conn, doc_id, actor)
+    if gate["kind"] != "assessment_notice":
+        raise documents.WrongApplyKind(
+            f"a {gate['kind']} is not an assessment notice; apply it on its own route"
+        )
+    # No FOR UPDATE, unlike the settlement path: nothing here is a
+    # read-then-write on a property row. Two concurrent notices for one year
+    # race into the unique key and the loser gets a 409 from the database,
+    # which is stronger than a lock because it also holds across the manual
+    # door, where there is no document to gate on.
+    links = conn.execute(
+        "SELECT p.id::text AS id FROM document_properties dp"
+        " JOIN properties p ON p.id = dp.property_id"
+        " WHERE dp.document_id = %s ORDER BY p.id",
+        (doc_id,),
+    ).fetchall()
+    if len(links) != 1:
+        raise documents.NotExactlyOneProperty(
+            f"{len(links)} properties are linked to this notice; one notice assesses one parcel"
+        )
+    property_id = str(links[0]["id"])
+    jurisdiction_id, jurisdiction_name = _resolve_jurisdiction(
+        conn, uuid.UUID(property_id), body.jurisdiction_id
+    )
+    values = documents.effective_values(conn, doc_id)
+    # Subscripted, not .get(): 'confirmed' means every REQUIRED spec has a
+    # reviewed, accepted value, and the gate proves the document was
+    # confirmed. These three are the required specs for this kind.
+    raw_year = str(values["assessment.tax_year"])
+    raw_basis = str(values["assessment.value_basis"]).strip().lower()
+    if not extraction_parse.plausible_tax_year(raw_year):
+        raise UnusableValue(
+            f"{raw_year!r} is not a tax year between {extraction_parse.MIN_TAX_YEAR}"
+            f" and {extraction_parse.MAX_TAX_YEAR}; correct that field and apply again"
+        )
+    if raw_basis not in ("market", "taxable"):
+        raise UnusableValue(
+            f"{raw_basis!r} is not a value basis; say exactly 'market' (what the"
+            " assessor says it is worth) or 'taxable' (what the tax is computed"
+            " on), then apply again"
+        )
+    provenance = conn.execute(
+        """
+        INSERT INTO provenance (kind, confidence, source_label, source_document)
+        VALUES ('document', 1.0, %s, %s) RETURNING id::text
+        """,
+        (
+            f"Assessment notice {raw_year.strip()}, {raw_basis} value,"
+            f" {jurisdiction_name} ({gate['filename']})",
+            doc_id,
+        ),
+    ).fetchone()
+    assert provenance is not None
+    assessment_id = _insert(
+        conn,
+        property_id=property_id,
+        jurisdiction_id=jurisdiction_id,
+        tax_year=int(raw_year.strip()),
+        value_basis=raw_basis,
+        assessed_land=_money(values, "assessment.assessed_land"),
+        assessed_improvement=_money(values, "assessment.assessed_improvement"),
+        assessed_total=Decimal(str(values["assessment.assessed_total"])),
+        notice_received_on=_date(values, "assessment.notice_date"),
+        provenance_id=str(provenance["id"]),
+    )
+    return for_property(conn, property_id, assessment_id=assessment_id)[0]

--- a/services/api/hestia_api/documents.py
+++ b/services/api/hestia_api/documents.py
@@ -690,11 +690,24 @@ def get_content(conn: Conn, doc_id: str) -> tuple[str, str, bytes]:
     )
 
 
-def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyResult:
-    # The compare-and-set IS the idempotency guarantee: of two concurrent
-    # applies, exactly one sees 'confirmed'. Any later failure in this
-    # function raises, the endpoint transaction rolls back, and the gate
-    # resets with it — the module-014 transport lesson, reused.
+class WrongApplyKind(Exception):
+    """This document's kind applies through another door."""
+
+
+def claim_for_apply(conn: Conn, doc_id: str, actor: str) -> dict[str, Any]:
+    """Flip a confirmed document to 'applied', exactly once, or say why not.
+
+    THE compare-and-set. Of two concurrent applies exactly one sees
+    'confirmed': the second blocks on the row lock, re-evaluates its WHERE
+    against the committed 'applied', matches zero rows, and the miss is then
+    diagnosed into three distinct errors. Any later failure in the caller
+    raises, the endpoint transaction rolls back, and this UPDATE rolls back
+    with it — so a refused apply leaves the document confirmed and appliable.
+
+    Both doors come through here — the settlement statement's allocation step
+    and the assessment notice's record step — so "a document's facts enter the
+    domain exactly once" has one implementation rather than two.
+    """
     gate = conn.execute(
         """
         UPDATE source_documents
@@ -713,6 +726,30 @@ def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyR
         if current["status"] == "applied":
             raise AlreadyApplied(doc_id)
         raise NotConfirmed(current["status"])
+    return gate
+
+
+def effective_values(conn: Conn, doc_id: str) -> dict[str, str | None]:
+    """{field_path: the value apply would use}, shared by both doors so they
+    cannot come to disagree about what "the reviewed value" means."""
+    rows = conn.execute(
+        "SELECT field_path, normalised_value, accepted_value, needs_review, reviewed_at"
+        " FROM extracted_fields WHERE document_id = %s",
+        (doc_id,),
+    ).fetchall()
+    return {row["field_path"]: _effective(row) for row in rows}
+
+
+def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyResult:
+    gate = claim_for_apply(conn, doc_id, actor)
+    # The kind test this function never needed while one kind had registry
+    # rows. Seeding assessment_notice specs makes a notice reachable to
+    # 'confirmed', and without this line the settlement subscripts below are a
+    # KeyError that escapes the endpoint's except list as a 500 — on what is
+    # really a rule refusal. Refused before anything is written, and the gate
+    # rolls back with it.
+    if gate["kind"] != "settlement_statement":
+        raise WrongApplyKind(f"a {gate['kind']} does not apply as a settlement statement")
     # FOR UPDATE OF p, because the acquired_on / parcel_number decisions below
     # are read-then-write: unlocked, two applies of two documents for the SAME
     # property both read NULL, both write, and the second silently clobbers the
@@ -734,12 +771,7 @@ def apply_document(conn: Conn, doc_id: str, body: ApplyIn, actor: str) -> ApplyR
     if len(links) != 1:
         raise NotExactlyOneProperty(str(len(links)))
     prop = links[0]
-    field_rows = conn.execute(
-        "SELECT field_path, normalised_value, accepted_value, needs_review, reviewed_at"
-        " FROM extracted_fields WHERE document_id = %s",
-        (doc_id,),
-    ).fetchall()
-    values = {row["field_path"]: _effective(row) for row in field_rows}
+    values = effective_values(conn, doc_id)
     closing_date = dt.date.fromisoformat(values["settlement.closing_date"])  # type: ignore[arg-type]
     total_basis = Decimal(values["settlement.sale_price"]) + Decimal(  # type: ignore[arg-type]
         values["settlement.capitalizable_closing_costs"]  # type: ignore[arg-type]

--- a/services/api/hestia_api/extraction_parse.py
+++ b/services/api/hestia_api/extraction_parse.py
@@ -36,6 +36,26 @@ MAX_LINES = 50_000
 # a line we can read, and scanning it is work an uploader chose for us.
 MAX_LINE_CHARS = 2_000
 
+# The band module 019's plausible_assessment_year enforces, named here so the
+# parser, the API and the database cannot come to disagree about what a tax
+# year is. SMALLINT already caps the column; this catches a typed 20226.
+MIN_TAX_YEAR = 1990
+MAX_TAX_YEAR = 2200
+
+
+def plausible_tax_year(raw: str) -> bool:
+    """Whether a reviewed string is a year a notice could state.
+
+    A reviewer may ratify anything the `text` datatype accepts, so a tax year
+    arrives as free text and is checked here rather than discovered as a
+    CheckViolation in the middle of a write.
+    """
+    stripped = raw.strip()
+    if not stripped.isdigit():
+        return False
+    return MIN_TAX_YEAR <= int(stripped) <= MAX_TAX_YEAR
+
+
 CERTAIN = Decimal("1")
 # A value the parser DERIVED (summed itemized lines) rather than read: right
 # in every fixture we have, but derivation is judgment, and judgment routes
@@ -54,7 +74,12 @@ class UnreadableDocument(Exception):
 class ParsedField:
     field_path: str
     raw_value: str
-    normalised_value: str
+    # None where the parser found the field but will not propose a reading —
+    # two lines claimed to be the same figure and disagreed. The review path
+    # refuses to accept a field with no proposed value (NothingToAccept), so
+    # the reviewer must correct it, which is the point: there is nothing here
+    # a single click should be able to ratify.
+    normalised_value: str | None
     confidence: Decimal
     page: int
 
@@ -254,10 +279,176 @@ def parse_settlement(lines: list[tuple[int, str]]) -> list[ParsedField]:
     return fields
 
 
+# ---------------------------------------------------------------------------
+# The assessment notice
+# ---------------------------------------------------------------------------
+
+# Additive on purpose: the settlement dictionaries above are NOT reused. A
+# path added to MONEY_LABELS would make parse_settlement emit a field the
+# settlement registry has no spec for, and documents._run_extraction drops
+# those on the floor — a silent no-op that looks like a working parser.
+
+# The settlement matcher's twin, differing in one thing: cents are optional.
+# A closing statement always prints them; an assessor prints round dollars
+# ("Total Assessed Value   $150,000") about as often as not, and
+# AMOUNT_AT_END reads those lines as carrying no amount at all. The dollar
+# sign stays mandatory — without it `Tax Year   2026` is an amount of 2026.
+NOTICE_AMOUNT_AT_END = re.compile(r"\$(?P<amount>[\d,]+(?:\.\d{2})?)\s*$")
+
+# "Tax Year 2026", "Tax Year: 2026", "TAX YEAR 2026 PAYABLE 2027". The bounded
+# gap keeps it from reaching across a table row into somebody else's column.
+TAX_YEAR_IN_LINE = re.compile(r"(?i)\btax year\b\D{0,12}(?P<year>(?:19|20)\d{2})")
+
+# Longest phrase first: 'total value' is a substring of nothing here, but
+# 'land' is a substring of 'land market value', and a shorter key matching
+# first would file a land line under the wrong path. Ordered tuple, not a
+# dict, because the order IS the rule.
+#
+# Every one of these was read off a real county form or parcel record —
+# Kentucky form 62A352 and Campbell County's PVA system, Hamilton and Warren
+# and Miami and Clark County auditor pages in Ohio, the Tennessee state TPAD
+# record and Shelby County's own card. No two states agree on wording, and
+# Shelby says "Building Appraisal" where Ohio says "Improvements".
+NOTICE_MONEY_LABELS: tuple[tuple[str, str], ...] = (
+    ("total market appraisal", "assessment.assessed_total"),
+    ("market total value", "assessment.assessed_total"),
+    ("total appraisal", "assessment.assessed_total"),
+    ("total assessment", "assessment.assessed_total"),
+    ("current market value", "assessment.assessed_total"),
+    ("proposed market value", "assessment.assessed_total"),
+    ("fair cash value", "assessment.assessed_total"),
+    ("appraised value", "assessment.assessed_total"),
+    ("assessed value", "assessment.assessed_total"),
+    ("taxable value", "assessment.assessed_total"),
+    ("total value", "assessment.assessed_total"),
+    ("land market value", "assessment.assessed_land"),
+    ("market land value", "assessment.assessed_land"),
+    ("land appraisal", "assessment.assessed_land"),
+    ("land value", "assessment.assessed_land"),
+    ("land", "assessment.assessed_land"),
+    ("market improvement value", "assessment.assessed_improvement"),
+    ("improvement value", "assessment.assessed_improvement"),
+    ("building appraisal", "assessment.assessed_improvement"),
+    ("improvements", "assessment.assessed_improvement"),
+    ("improvement", "assessment.assessed_improvement"),
+)
+
+NOTICE_DATE_LABELS = frozenset(
+    {"date", "notice date", "date mailed", "notice sent on", "date of notice"}
+)
+
+# The offices that issue these, as they sign them. Never matched against the
+# jurisdiction table — this is shown to the reviewer so they can check their
+# own pick against the paper, and nothing more.
+ASSESSING_OFFICES = (
+    "property valuation administrator",
+    "county auditor",
+    "assessor of property",
+    "county assessor",
+)
+
+
+def _notice_label(raw_label: str) -> str | None:
+    """The field a notice's label names, or None. Substring matching, because
+    a county prints 'Total Market Appraisal (100%)' and means 'total'."""
+    label = raw_label.strip().rstrip(":").lower()
+    for phrase, path in NOTICE_MONEY_LABELS:
+        if phrase in label:
+            return path
+    return None
+
+
+def _settle_candidates(path: str, found: list[tuple[str, str, int]]) -> ParsedField:
+    """One field from every line that claimed to be it.
+
+    These documents print the same idea more than once and mean different
+    things by it. A Campbell County record shows Fair Cash Value 0.00 beside
+    a Total Value of 600,000 on an ordinary house; a Tennessee card prints an
+    appraised total beside an assessed total three or four times smaller; an
+    Ohio notice prints last year's value above this year's. So agreement is
+    reported as a reading and disagreement is reported as a question — never
+    resolved by preferring whichever line came first.
+    """
+    distinct = {amount for _, amount, _ in found}
+    if len(distinct) == 1:
+        label, amount, page = found[0]
+        return ParsedField(path, f"{label} ${amount}", normalise_money(amount), DERIVED, page)
+    # No proposed value, deliberately. Offering the first reading would let a
+    # reviewer ratify Campbell County's Fair Cash Value of 0.00 with one
+    # click while the real figure sat in the next line.
+    return ParsedField(
+        path,
+        "; ".join(f"{label} ${amount}" for label, amount, _ in found),
+        None,
+        SUSPECT,
+        found[0][2],
+    )
+
+
+def parse_assessment_notice(lines: list[tuple[int, str]]) -> list[ParsedField]:
+    """What can be read off an assessment notice, and nothing beyond it.
+
+    Two things this deliberately does NOT do. It never emits
+    `assessment.value_basis`: the same card prints a market figure and a
+    taxable one that differ by a factor of three in Ohio and four in
+    Tennessee, under labels that vary county by county, and a machine that
+    guesses wrong produces a plausible number that is off by 300%. The
+    registry marks that field required, so it arrives as a flagged skeleton
+    row and a person holding the paper answers it.
+
+    And nothing here is CERTAIN. There is no standard assessment notice —
+    only Kentucky prescribes a form, Ohio fixes no fields at all and some
+    counties mail nothing per parcel, and no Tennessee county publishes its
+    card's front. Every value routes through a human by construction.
+    """
+    money: dict[str, list[tuple[str, str, int]]] = {}
+    fields: list[ParsedField] = []
+    seen: set[str] = set()
+
+    for page, line in lines:
+        text = line.strip()[:MAX_LINE_CHARS]
+        amount_at_end = NOTICE_AMOUNT_AT_END.search(text)
+        if amount_at_end is not None:
+            raw_label = text[: amount_at_end.start()]
+            path = _notice_label(raw_label)
+            if path is not None:
+                money.setdefault(path, []).append(
+                    (raw_label.strip(), amount_at_end.group("amount"), page)
+                )
+            continue
+        year = TAX_YEAR_IN_LINE.search(text)
+        if year is not None and "assessment.tax_year" not in seen:
+            seen.add("assessment.tax_year")
+            fields.append(
+                ParsedField("assessment.tax_year", text, year.group("year"), DERIVED, page)
+            )
+            continue
+        office = next((o for o in ASSESSING_OFFICES if o in text.lower()), None)
+        if office is not None and "assessment.assessing_body" not in seen:
+            seen.add("assessment.assessing_body")
+            fields.append(ParsedField("assessment.assessing_body", text, text, SUSPECT, page))
+            continue
+        labeled = LABELED_LINE.match(text)
+        if labeled and labeled.group("label").strip().lower() in NOTICE_DATE_LABELS:
+            if "assessment.notice_date" in seen:
+                continue
+            seen.add("assessment.notice_date")
+            raw = labeled.group("value").strip()
+            normalised = normalise_date(raw)
+            if normalised is None:
+                fields.append(ParsedField("assessment.notice_date", raw, raw, SUSPECT, page))
+            else:
+                fields.append(ParsedField("assessment.notice_date", raw, normalised, DERIVED, page))
+
+    fields.extend(_settle_candidates(path, found) for path, found in money.items())
+    return fields
+
+
 # Which parser reads which document kind. Kinds absent here upload fine and
 # wait, honestly unextracted, for their parser (or the model seam) to exist.
 PARSERS = {
     "settlement_statement": parse_settlement,
+    "assessment_notice": parse_assessment_notice,
 }
 
 

--- a/services/api/hestia_api/views.py
+++ b/services/api/hestia_api/views.py
@@ -13,6 +13,8 @@ from typing import Any
 import psycopg
 from pydantic import BaseModel
 
+from hestia_api import assessments as assessment_records
+
 Conn = psycopg.Connection[dict[str, Any]]
 
 
@@ -32,6 +34,9 @@ class PropertySummary(BaseModel):
 
 
 class ChainLink(BaseModel):
+    # The picker that chooses an assessment's issuing body sends an id, and
+    # this list is exactly the set the API will accept.
+    id: str
     name: str
     level: str
 
@@ -98,6 +103,10 @@ class DossierView(BaseModel):
     components: list[ComponentOut]
     defects: list[DefectOut]
     deadlines: list[DeadlineOut]
+    # Newest tax year first. The appeal card reads these beside the
+    # assessment_appeal_window deadline above: what the body said, when the
+    # notice came, and how far the value moved since that body last spoke.
+    assessments: list[assessment_records.AssessmentOut]
 
 
 def list_properties(conn: Conn) -> list[PropertySummary]:
@@ -137,7 +146,7 @@ def dossier_view(conn: Conn, property_id: str) -> DossierView | None:
     if prop["jurisdiction_id"] is not None:
         chain = conn.execute(
             """
-            SELECT j.name, j.level::text
+            SELECT j.id::text AS id, j.name, j.level::text
             FROM jurisdiction_chain(%s) c
             JOIN jurisdictions j ON j.id = c.jurisdiction_id
             ORDER BY c.depth
@@ -197,6 +206,7 @@ def dossier_view(conn: Conn, property_id: str) -> DossierView | None:
         components=[ComponentOut(**c) for c in components],
         defects=[DefectOut(**d) for d in defects],
         deadlines=[DeadlineOut(**d) for d in deadlines],
+        assessments=assessment_records.for_property(conn, property_id),
     )
 
 

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -156,6 +156,11 @@ def clean(conn: psycopg.Connection[Any]) -> None:
     world rather than to a globally empty one."""
     for table in (
         "deadlines",
+        # Not reached by the properties CASCADE below: a property pinned by a
+        # ledger row survives the clean, and its assessments survived with it
+        # — then collided with the next test's own 2026 notice on the unique
+        # key, turning a 201 into a 409 depending on test order.
+        "assessments",
         "exchanges",
         "debt_instruments",
         "policies",

--- a/services/api/tests/test_assessments.py
+++ b/services/api/tests/test_assessments.py
@@ -1,0 +1,691 @@
+"""Assessment records: the notice an owner was mailed, entered two ways.
+
+Issue #46's acceptance, executable: the 2026 notice goes in by hand or by
+upload, both leave a provenance behind, and the property's dossier carries
+what the body said so the appeal card can render it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+CAMPBELL_COUNTY = "a0000000-0000-4000-8000-000000000021"
+KENTON_COUNTY = "a0000000-0000-4000-8000-000000000022"
+
+FULL_NOTICE = """CAMPBELL COUNTY PROPERTY VALUATION ADMINISTRATOR
+Notice to Real Property Owner of Assessment
+998 Monmouth St
+Tax Year 2026
+Notice Date: 04/17/2026
+Land                                        $30,000.00
+Improvement                                 $130,000.00
+Total Value                                 $160,000.00
+"""
+
+BARE_NOTICE = """Total Assessed Value                        $150,000
+"""
+
+# The Campbell County shape, which is the reason the parser proposes nothing
+# when two lines disagree: Fair Cash Value prints 0.00 on an ordinary
+# residential parcel while the real figure sits in Total Value. It also prints
+# its mailing date twice, which real notices do.
+CONFLICTING_NOTICE = """CAMPBELL COUNTY PROPERTY VALUATION ADMINISTRATOR
+Tax Year 2026
+Notice Date: 04/17/2026
+Notice Date: 04/18/2026
+Fair Cash Value                             $0.00
+Total Value                                 $600,000.00
+"""
+
+RAGGED_NOTICE = """Assessor of Property
+Parcel ID: 999-99-999
+Tax Year: twenty twenty-six
+Notice Date: the fifteenth of April
+Homestead Exemption                         $46,350.00
+Land Value$4.00
+Total Value                                 $210,000.00
+"""
+
+
+def make_property(client: TestClient, *, city: str = "Newport", state: str = "KY") -> str:
+    entity = client.post("/entities", json={"name": f"{city} LLC", "kind": "llc"}).json()
+    return client.post(
+        "/properties",
+        json={
+            "entity_id": entity["id"],
+            "label": f"{city} parcel",
+            "street_1": "998 Monmouth St",
+            "city": city,
+            "state": state,
+            "postal_code": "41071",
+            "kind": "single_family",
+        },
+    ).json()["id"]
+
+
+def notice_body(text: str, tag: str) -> bytes:
+    """Unique bytes per upload: source_documents dedupes on the content hash
+    globally, so two tests uploading the same notice would collide."""
+    return f"{text}Reference: {tag}\n".encode()
+
+
+def upload_notice(client: TestClient, property_id: str, text: str, tag: str) -> dict[str, Any]:
+    return client.post(
+        "/documents",
+        data={"kind": "assessment_notice", "property_id": property_id},
+        files={"file": (f"notice-{tag}.txt", notice_body(text, tag), "text/plain")},
+    ).json()
+
+
+def ratify(client: TestClient, doc_id: str, values: dict[str, str]) -> dict[str, Any]:
+    """Work the review screen the way a person does.
+
+    Correct what the caller names, then settle everything the parser flagged:
+    accept what it proposed, reject what it could not. NOTHING this parser
+    emits is CERTAIN — these documents are too various for that — so a notice
+    only reaches 'confirmed' once a human has been through every line, which
+    is the design rather than an inconvenience.
+    """
+    for path, value in values.items():
+        client.post(
+            f"/documents/{doc_id}/review",
+            json={"field_path": path, "action": "correct", "value": value},
+        )
+    for field in client.get(f"/documents/{doc_id}").json()["fields"]:
+        if field["reviewed_at"] is not None:
+            continue
+        settled = client.post(
+            f"/documents/{doc_id}/review",
+            json={
+                "field_path": field["field_path"],
+                "action": "accept" if field["normalised_value"] is not None else "reject",
+            },
+        )
+        if settled.status_code == 422:
+            # A value the parser preserved verbatim BECAUSE it would not
+            # normalise — "the fifteenth of April" — cannot be ratified by one
+            # click. That refusal is the feature; the reviewer rejects it.
+            client.post(
+                f"/documents/{doc_id}/review",
+                json={"field_path": field["field_path"], "action": "reject"},
+            )
+    return client.get(f"/documents/{doc_id}").json()
+
+
+class TestTheAcceptanceWalk:
+    def test_the_2026_notice_by_hand_and_by_upload(self, clean: None, client: TestClient) -> None:
+        """Issue #46's acceptance in one test: the same notice, two doors, and
+        the only difference in the result is how we know it."""
+        typed_property = make_property(client)
+        typed = client.post(
+            "/assessments",
+            json={
+                "property_id": typed_property,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+                "assessed_land": "30000.00",
+                "assessed_improvement": "130000.00",
+                "notice_received_on": "2026-04-17",
+            },
+        )
+        assert typed.status_code == 201, typed.text
+        by_hand = typed.json()
+
+        uploaded_property = make_property(client)
+        detail = upload_notice(client, uploaded_property, FULL_NOTICE, "acceptance")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "taxable",
+                "assessment.assessed_total": "160000.00",
+            },
+        )
+        assert detail["status"] == "confirmed", detail
+        applied = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert applied.status_code == 201, applied.text
+        by_upload = applied.json()
+
+        for field in ("tax_year", "value_basis", "assessed_total"):
+            assert by_hand[field] == by_upload[field]
+        assert by_hand["provenance_kind"] == "owner_stated"
+        assert by_hand["source_document_id"] is None
+        assert by_upload["provenance_kind"] == "document"
+        assert by_upload["source_document_id"] == detail["id"]
+
+        # And the appeal card's read: both dossiers carry the row.
+        for property_id in (typed_property, uploaded_property):
+            view = client.get(f"/properties/{property_id}/dossier").json()
+            assert view["assessments"][0]["tax_year"] == 2026
+            assert view["assessments"][0]["assessed_total"] == "160000.00"
+
+
+class TestWhichBodyAssessed:
+    def test_an_omitted_body_defaults_to_the_property_s_own(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client)
+        body = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+            },
+        ).json()
+        assert body["jurisdiction"] == "Newport"
+
+    def test_the_owner_names_the_county_that_assessed_it(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Kentucky assesses through the county PVA, and a Newport property
+        resolves to Newport — so the owner says which body sent the paper."""
+        property_id = make_property(client)
+        body = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "jurisdiction_id": CAMPBELL_COUNTY,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+            },
+        )
+        assert body.status_code == 201, body.text
+        assert body.json()["jurisdiction"] == "Campbell County"
+
+    @pytest.mark.parametrize("named", [KENTON_COUNTY, str(uuid.uuid4())])
+    def test_a_body_that_does_not_govern_is_refused(
+        self, clean: None, client: TestClient, named: str
+    ) -> None:
+        """Kenton County is real, adjacent, and does not govern this parcel; a
+        made-up id is neither. Both are the same mistake and get one answer."""
+        property_id = make_property(client)
+        refused = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "jurisdiction_id": named,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+            },
+        )
+        assert refused.status_code == 422
+        assert "does not govern" in refused.json()["detail"]
+
+    def test_a_property_no_pack_resolves_cannot_record_an_assessment(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """No pack for the state means no body to record against — the
+        platform is unconfigured for this address, which is a 503, not a
+        malformed request the caller could fix."""
+        property_id = make_property(client, city="Indianapolis", state="IN")
+        refused = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+            },
+        )
+        assert refused.status_code == 503
+        assert "IN" in refused.json()["detail"]
+
+    def test_an_assessment_for_a_property_that_is_not_there_is_404(
+        self, clean: None, client: TestClient
+    ) -> None:
+        refused = client.post(
+            "/assessments",
+            json={
+                "property_id": str(uuid.uuid4()),
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+            },
+        )
+        assert refused.status_code == 404
+
+
+class TestWhatTheDomainRefuses:
+    def test_one_body_one_year_one_basis(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client)
+        payload = {
+            "property_id": property_id,
+            "tax_year": 2026,
+            "value_basis": "taxable",
+            "assessed_total": "160000.00",
+        }
+        assert client.post("/assessments", json=payload).status_code == 201
+        again = client.post("/assessments", json=payload)
+        assert again.status_code == 409
+        assert "already has a taxable 2026" in again.json()["detail"]
+
+    def test_both_bases_of_one_notice_fit(self, clean: None, client: TestClient) -> None:
+        """A Tennessee card prints an appraised total beside an assessed one
+        for the same parcel and year. The key admits both; that is why the
+        basis is in it."""
+        property_id = make_property(client)
+        for basis, total in (("taxable", "160000.00"), ("market", "640000.00")):
+            created = client.post(
+                "/assessments",
+                json={
+                    "property_id": property_id,
+                    "tax_year": 2026,
+                    "value_basis": basis,
+                    "assessed_total": total,
+                },
+            )
+            assert created.status_code == 201, created.text
+        view = client.get(f"/properties/{property_id}/dossier").json()
+        assert {row["value_basis"] for row in view["assessments"]} == {"market", "taxable"}
+
+    def test_a_land_line_above_the_total_is_refused(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client)
+        refused = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+                "assessed_land": "200000.00",
+            },
+        )
+        assert refused.status_code == 422
+        assert "exceeds the total" in refused.json()["detail"]
+
+    def test_a_notice_dated_before_its_year_is_refused(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client)
+        refused = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+                "notice_received_on": "2016-04-15",
+            },
+        )
+        assert refused.status_code == 422
+        assert "dated before" in refused.json()["detail"]
+
+    def test_an_improvement_above_the_total_is_accepted(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Deliberately legal: a total stated net of an exemption its parts
+        are gross of. Refusing this would refuse correctly transcribed paper."""
+        property_id = make_property(client)
+        created = client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "160000.00",
+                "assessed_improvement": "200000.00",
+            },
+        )
+        assert created.status_code == 201, created.text
+
+
+class TestTheNoticeDoor:
+    def test_a_bare_notice_applies_with_only_a_year_a_basis_and_a_total(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Whole dollars, no land split, no notice date — the smallest notice
+        that still makes a row."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, BARE_NOTICE, "bare")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        applied = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert applied.status_code == 201, applied.text
+        row = applied.json()
+        assert row["assessed_land"] is None
+        assert row["notice_received_on"] is None
+        assert row["land_share"] is None
+        assert row["value_basis"] == "market"
+
+    def test_a_full_notice_applies_every_line(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, FULL_NOTICE, "full")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "taxable",
+                "assessment.assessed_total": "160000.00",
+            },
+        )
+        applied = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert applied.status_code == 201, applied.text
+        row = applied.json()
+        assert row["assessed_land"] == "30000.00"
+        assert row["assessed_improvement"] == "130000.00"
+        assert row["notice_received_on"] == "2026-04-17"
+        assert Decimal(row["land_share"]) == Decimal("0.187500")
+
+    def test_a_tax_year_typed_as_words_is_refused_at_apply(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """A reviewer may ratify anything the text datatype accepts, so the
+        band is enforced at the write — and the refusal leaves the document
+        confirmed and appliable rather than half-consumed."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, RAGGED_NOTICE, "words")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "twenty twenty-six",
+                "assessment.value_basis": "taxable",
+                "assessment.assessed_total": "210000.00",
+            },
+        )
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 422
+        assert "is not a tax year" in refused.json()["detail"]
+        assert client.get(f"/documents/{detail['id']}").json()["status"] == "confirmed"
+
+    def test_a_basis_that_is_neither_word_is_refused_at_apply(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The one field the parser refuses to guess, so it is the one field a
+        reviewer can most easily fill with prose."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, BARE_NOTICE, "basis")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "the big number",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 422
+        assert "is not a value basis" in refused.json()["detail"]
+        assert client.get(f"/documents/{detail['id']}").json()["status"] == "confirmed"
+
+    def test_applying_the_same_notice_twice_is_a_409(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, BARE_NOTICE, "twice")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        assert (
+            client.post(f"/documents/{detail['id']}/apply-assessment", json={}).status_code == 201
+        )
+        again = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert again.status_code == 409
+        rows = conn.execute(
+            "SELECT count(*) AS n FROM assessments WHERE property_id = %s", (property_id,)
+        ).fetchone()
+        assert rows is not None and rows["n"] == 1
+
+    def test_an_unreviewed_notice_cannot_be_applied(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, FULL_NOTICE, "unreviewed")
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 409
+        assert "confirmed" in refused.json()["detail"]
+
+    def test_applying_a_notice_that_is_not_there_is_404(
+        self, clean: None, client: TestClient
+    ) -> None:
+        refused = client.post(f"/documents/{uuid.uuid4()}/apply-assessment", json={})
+        assert refused.status_code == 404
+
+    def test_a_notice_for_a_year_already_typed_is_a_409(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The collision an owner will actually hit: they type the notice, then
+        upload the same paper. The document survives, still appliable."""
+        property_id = make_property(client)
+        client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "market",
+                "assessed_total": "150000.00",
+            },
+        )
+        detail = upload_notice(client, property_id, BARE_NOTICE, "collide")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 409
+        assert client.get(f"/documents/{detail['id']}").json()["status"] == "confirmed"
+
+    def test_a_notice_linked_to_two_properties_is_refused(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        first = make_property(client)
+        second = make_property(client, city="Bellevue")
+        detail = upload_notice(client, first, BARE_NOTICE, "twoprops")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        conn.execute(
+            "INSERT INTO document_properties (document_id, property_id) VALUES (%s, %s)",
+            (detail["id"], second),
+        )
+        conn.commit()
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 422
+        assert "one notice assesses one parcel" in refused.json()["detail"]
+
+
+class TestTheTwoDoorsDoNotCross:
+    def test_a_notice_does_not_apply_as_a_settlement_statement(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Before #46 this reached a KeyError and escaped as a 500, because
+        nothing but a settlement statement could ever reach 'confirmed'."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, BARE_NOTICE, "wrongdoor")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        refused = client.post(f"/documents/{detail['id']}/apply", json={"land_value": "1000.00"})
+        assert refused.status_code == 422
+        assert "does not apply as a settlement statement" in refused.json()["detail"]
+        assert client.get(f"/documents/{detail['id']}").json()["status"] == "confirmed"
+
+
+class TestTheDossierRead:
+    def test_the_dossier_carries_the_assessments_it_knows(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client)
+        for year, total, land in ((2025, "150000.00", None), (2026, "160000.00", "30000.00")):
+            payload: dict[str, Any] = {
+                "property_id": property_id,
+                "jurisdiction_id": CAMPBELL_COUNTY,
+                "tax_year": year,
+                "value_basis": "taxable",
+                "assessed_total": total,
+            }
+            if land is not None:
+                payload["assessed_land"] = land
+            assert client.post("/assessments", json=payload).status_code == 201
+        # A third row, same year, DIFFERENT body: not a comparison, so it must
+        # not become one.
+        client.post(
+            "/assessments",
+            json={
+                "property_id": property_id,
+                "tax_year": 2026,
+                "value_basis": "taxable",
+                "assessed_total": "155000.00",
+            },
+        )
+
+        view = client.get(f"/properties/{property_id}/dossier").json()
+        rows = {(r["tax_year"], r["jurisdiction"]): r for r in view["assessments"]}
+        assert view["assessments"][0]["tax_year"] == 2026
+
+        current = rows[(2026, "Campbell County")]
+        assert current["prior_tax_year"] == 2025
+        assert Decimal(current["change_from_prior"]) == Decimal("10000.00")
+        assert Decimal(current["land_share"]) == Decimal("0.187500")
+        assert current["provenance_kind"] == "owner_stated"
+
+        assert rows[(2025, "Campbell County")]["land_share"] is None
+        # Newport's own 2026 row has no prior year from Newport.
+        assert rows[(2026, "Newport")]["prior_tax_year"] is None
+        assert rows[(2026, "Newport")]["change_from_prior"] is None
+
+    def test_the_chain_carries_the_ids_a_picker_needs(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client)
+        view = client.get(f"/properties/{property_id}/dossier").json()
+        chain = {link["level"]: link for link in view["jurisdiction_chain"]}
+        assert chain["county"]["id"] == CAMPBELL_COUNTY
+        assert chain["county"]["name"] == "Campbell County"
+
+
+class TestWhatThePaperActuallyLooksLike:
+    def test_two_lines_that_disagree_propose_nothing(self, clean: None, client: TestClient) -> None:
+        """Campbell County's own records print Fair Cash Value as 0.00 beside
+        a Total Value of 600,000 on an ordinary house. Proposing the first
+        reading would let a reviewer ratify zero with one click, so the parser
+        shows both and proposes neither — and the review path refuses to
+        accept a field with no proposed value."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, CONFLICTING_NOTICE, "conflict")
+        total = next(f for f in detail["fields"] if f["field_path"] == "assessment.assessed_total")
+        assert total["normalised_value"] is None
+        assert "Fair Cash Value $0.00" in total["raw_value"]
+        assert "Total Value $600,000.00" in total["raw_value"]
+        refused = client.post(
+            f"/documents/{detail['id']}/review",
+            json={"field_path": "assessment.assessed_total", "action": "accept"},
+        )
+        assert refused.status_code == 422
+
+        # Only the FIRST notice date is taken; the second is not a new fact.
+        notice_date = next(
+            f for f in detail["fields"] if f["field_path"] == "assessment.notice_date"
+        )
+        assert notice_date["normalised_value"] == "2026-04-17"
+
+    def test_a_settlement_statement_does_not_apply_as_a_notice(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The mirror of the other door's guard. Both refusals leave the
+        document confirmed, because the gate rolls back with the refusal."""
+        property_id = make_property(client)
+        document_id = str(uuid.uuid4())
+        conn.execute(
+            """
+            INSERT INTO source_documents (id, kind, filename, content_hash, status)
+            VALUES (%s, 'settlement_statement', 'closing.pdf', %s, 'confirmed')
+            """,
+            (document_id, "c" * 64),
+        )
+        conn.execute(
+            "INSERT INTO document_properties (document_id, property_id) VALUES (%s, %s)",
+            (document_id, property_id),
+        )
+        conn.commit()
+        refused = client.post(f"/documents/{document_id}/apply-assessment", json={})
+        assert refused.status_code == 422
+        assert "is not an assessment notice" in refused.json()["detail"]
+        status = conn.execute(
+            "SELECT status::text AS status FROM source_documents WHERE id = %s",
+            (document_id,),
+        ).fetchone()
+        assert status is not None and status["status"] == "confirmed"
+
+    def test_an_absurd_land_line_is_refused_not_a_500(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """An OPTIONAL money field that never needed review never passed the
+        review path's bound either. Today's parser marks nothing certain, but
+        the model seam behind the same registry will, and unbounded this
+        reached the client as a psycopg NumericValueOutOfRange 500 — after the
+        gate had already flipped the document."""
+        property_id = make_property(client)
+        detail = upload_notice(client, property_id, BARE_NOTICE, "absurd")
+        detail = ratify(
+            client,
+            detail["id"],
+            {
+                "assessment.tax_year": "2026",
+                "assessment.value_basis": "market",
+                "assessment.assessed_total": "150000.00",
+            },
+        )
+        assert detail["status"] == "confirmed", detail
+        # AFTER review, and needing none: this is the shape a certain-enough
+        # extractor produces, and the one that never meets the review path's
+        # own bound.
+        conn.execute(
+            """
+            INSERT INTO extracted_fields
+              (document_id, field_path, raw_value, normalised_value, confidence,
+               needs_review, model_id)
+            VALUES (%s, 'assessment.assessed_land', '$1e20', %s, 1, FALSE, 'test')
+            ON CONFLICT (document_id, field_path) DO UPDATE
+              SET normalised_value = EXCLUDED.normalised_value,
+                  accepted_value = NULL, reviewed_at = NULL, reviewed_by = NULL,
+                  needs_review = FALSE, confidence = 1
+            """,
+            (detail["id"], "9" * 20),
+        )
+        conn.commit()
+        refused = client.post(f"/documents/{detail['id']}/apply-assessment", json={})
+        assert refused.status_code == 422
+        assert "exceeds the largest amount" in refused.json()["detail"]

--- a/services/api/tests/test_documents.py
+++ b/services/api/tests/test_documents.py
@@ -575,10 +575,16 @@ class TestReviewFindings:
         for year, land, total in ((2019, 30000, 160000), (2026, 90000, 300000)):
             conn.execute(
                 """
+                WITH source AS (
+                  INSERT INTO provenance (kind, confidence, source_label)
+                  VALUES ('owner_stated', 1.0, 'assessment fixture') RETURNING id
+                )
                 INSERT INTO assessments
-                  (property_id, jurisdiction_id, tax_year, assessed_land, assessed_total)
-                VALUES (%s, %s, %s, %s, %s)
-                ON CONFLICT (property_id, jurisdiction_id, tax_year) DO NOTHING
+                  (property_id, jurisdiction_id, tax_year, value_basis,
+                   assessed_land, assessed_total, provenance_id)
+                SELECT %s, %s, %s, 'taxable', %s, %s, source.id FROM source
+                ON CONFLICT (property_id, jurisdiction_id, tax_year, value_basis)
+                DO NOTHING
                 """,
                 (newport_property, KY_STATE, year, land, total),
             )
@@ -925,10 +931,16 @@ class TestApply:
     def seed_assessment(self, conn: psycopg.Connection[Any], property_id: str) -> None:
         conn.execute(
             """
+            WITH source AS (
+              INSERT INTO provenance (kind, confidence, source_label)
+              VALUES ('owner_stated', 1.0, 'assessment fixture') RETURNING id
+            )
             INSERT INTO assessments
-              (property_id, jurisdiction_id, tax_year, assessed_land, assessed_total)
-            VALUES (%s, %s, 2019, 30000, 160000)
-            ON CONFLICT (property_id, jurisdiction_id, tax_year) DO NOTHING
+              (property_id, jurisdiction_id, tax_year, value_basis,
+               assessed_land, assessed_total, provenance_id)
+            SELECT %s, %s, 2019, 'taxable', 30000, 160000, source.id FROM source
+            ON CONFLICT (property_id, jurisdiction_id, tax_year, value_basis)
+            DO NOTHING
             """,
             (property_id, KY_STATE),
         )


### PR DESCRIPTION
Closes #46.

`assessments` has stood since module 004 with no writer, no comment on any column and no CHECK of any kind. This opens both doors the ticket asks for — an owner typing the notice, and the same notice arriving as an upload — and ships the preconditions first.

## What the paper actually says changed the design

The obvious answer was to fix one unit: every `assessed_*` column holds the taxable total, with the state's ratio applied later by whichever reader needs market value. **That unit is unfillable.**

- An **Ohio** value notice states market value and nothing else. The 35% taxable figure appears on the tax *bill*. (ORC 5713.03 speaks of "true value in money"; 5715.01(B) caps taxable at thirty-five per cent.)
- A **Tennessee** assessment change notice prints **both**, side by side, and says so on its own reverse.
- **Kentucky** assesses at 100%, so the two coincide except where a homestead exemption parts them.

Demand "taxable" and an Ohio owner has nothing to type; demand "market" and a Tennessee owner must choose a column and hope. So the unit is not fixed — it is **recorded per row** in `value_basis`, NOT NULL with no default. Market and taxable differ by a factor of three in Ohio and four in Tennessee, which is the largest silent error available anywhere in this system; a default would be a guess that reads as data.

The unique key gains the basis for the same reason. Under `(property, jurisdiction, tax_year)` a Tennessee owner had to throw half the card away.

## Module 019

Five money columns narrow to `money_nonneg`; the tax year is bounded; a notice dated before the year it assesses is refused; `provenance_id` becomes NOT NULL, because the appeal card cannot render an authorless number.

Three relations are **deliberately not** constrained, and the header says why. A total stated net of an exemption its parts are gross of makes `land + improvement > total` ordinary — so only the land bound survives contact with real paper. `constraints.sql` asserts the improvement-above-total case is **ACCEPTED**, specifically so a later reader who "tidies" the rule into symmetry breaks there rather than in a Kentucky owner's face.

## A latent 500, closed

`apply_document` never had a kind check. That was safe only because `settlement_statement` was the sole kind with `extraction_field_specs` rows, so nothing else could reach `confirmed`. **Seeding assessment_notice specs makes it reachable** — and the settlement subscripts would have been a `KeyError` escaping the endpoint's except list as a 500, on what is really a rule refusal. Seeding without splitting apply was never a safe intermediate state.

The compare-and-set gate and the reviewed-field read are now shared by both doors, and each door refuses the other's documents in a sentence, leaving the document `confirmed` and still appliable.

## The parser is honest about what these documents are

There is no standard assessment notice in the United States. Only Kentucky prescribes a form (62A352); Ohio requires notice but fixes no fields, and at least two counties in this owner's own metro satisfy it by publication and mail nothing per parcel; no Tennessee county publishes its card's front. Every label in the matcher was read off a real county form or parcel record.

So: nothing it emits is `CERTAIN`, it **never** guesses `value_basis`, and where two lines disagree it shows both and **proposes nothing** — because Campbell County prints `Fair Cash Value` as `0.00` beside a `Total Value` of 600,000 on an ordinary house, and offering the first reading would let a reviewer ratify zero with one click. The review path already refuses to accept a field with no proposed value, so the correction is forced.

A notice it cannot read becomes a typing form with the original attached and its provenance still `document` — the honest shape for paper that mostly arrives as a phone photograph.

## Which body assessed it is asked, never inferred

A notice prints an *office*, and matching that string to a jurisdictions row is fuzzy matching on names that collide by design — this repository now has a Hamilton County in two states. Walking to the nearest county would be worse: true in KY, OH and TN, false in New England towns and Virginia's independent cities, and a governance fact hidden in dispatch logic that the state-literal ratchet would **not** catch, because it contains no state literal. The caller chooses within `jurisdiction_chain()`, validated; omitted, the property's own resolved body stands in; unresolvable, a 503 that names the gap.

## Gates

- schema verified, **152** constraint assertions (was 136)
- `services/api` — **313** passed at 100% line and branch against real Postgres
- `services/sim`, `services/ingest` — 100%
- `pnpm run verify` — green
- ruff, state-literal ratchet, config audit, and the regenerated `openapi.json` + `api-schema.d.ts` — all clean

## For the web agent

A full handoff note is in `~/co-claude/ACTIONS.md`. The load-bearing part: `apps/web/src/app/documents/[id]/page.tsx` renders the land/personal-property allocation form for **any** confirmed document and posts to `/apply`. An `assessment_notice` can now reach `confirmed`, and posting it there returns 422 — it needs a branch on `detail.kind` and a post to `/documents/{id}/apply-assessment`.
