### PR TITLE
The over-assessment card: two numbers, and the ratio between them

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -657,6 +657,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/properties/{property_id}/appeal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Property Appeal
+         * @description 404 is the only error this can return. Every "we cannot answer" is a
+         *     named gap inside a 200, because a card that vanishes tells the owner
+         *     nothing about why.
+         */
+        get: operations["property_appeal_properties__property_id__appeal_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/properties/{property_id}/capex-forecast": {
         parameters: {
             query?: never;
@@ -1139,6 +1161,53 @@ export interface components {
             /** Splits */
             splits?: components["schemas"]["SplitIn"][] | null;
         };
+        /** AppealCase */
+        AppealCase: {
+            /**
+             * As Of
+             * Format: date
+             */
+            as_of: string;
+            /** Findings */
+            findings: components["schemas"]["AssessmentFinding"][];
+            /** Gaps */
+            gaps: components["schemas"]["AppealGap"][];
+            market_opinion: components["schemas"]["MarketOpinionOut"] | null;
+            /**
+             * Pairing
+             * @enum {string}
+             */
+            pairing: "contests_this_assessment" | "contests_a_different_year" | "unknown";
+            /** Property Id */
+            property_id: string;
+            /** Ratio Notes */
+            ratio_notes: components["schemas"]["RuleTextOut"][];
+            /** State */
+            state: string;
+            /** Tax Year */
+            tax_year: number | null;
+            window: components["schemas"]["WindowOut"] | null;
+        };
+        /**
+         * AppealGap
+         * @description A question this chain cannot answer. Named, never defaulted.
+         *
+         *     Field-identical to deposit.GapOut and deliberately NOT shared: hoisting
+         *     that model would rename its published schema and churn the generated
+         *     client for no gain. Named differently, though — two classes called GapOut
+         *     make FastAPI qualify BOTH into hestia_api__deposit__GapOut and
+         *     hestia_api__appeal__GapOut, which renames the very schema the separation
+         *     was meant to protect. A third occurrence is when to hoist one shared
+         *     model; the second one just needs its own name.
+         */
+        AppealGap: {
+            /** Code */
+            code: string;
+            /** Detail */
+            detail: string;
+            /** Reason */
+            reason: string;
+        };
         /** ApplyIn */
         ApplyIn: {
             /** Land Value */
@@ -1188,6 +1257,27 @@ export interface components {
             suggestion_citation: string | null;
             /** Total Basis */
             total_basis: string;
+        };
+        /**
+         * AssessmentFinding
+         * @description One assessing body's claim about this property in one tax year, tested.
+         *
+         *     `assessment` is the SAME projection the dossier renders, so the card and
+         *     the dossier can never disagree about what the notice said.
+         */
+        AssessmentFinding: {
+            assessment: components["schemas"]["AssessmentOut"];
+            /** Gaps */
+            gaps: components["schemas"]["AppealGap"][];
+            /** Implied Market Value */
+            implied_market_value: string | null;
+            /** Over Assessed */
+            over_assessed: boolean | null;
+            /** Over Market Amount */
+            over_market_amount: string | null;
+            /** Over Market Pct */
+            over_market_pct: string | null;
+            ratio: components["schemas"]["RatioOut"] | null;
         };
         /**
          * AssessmentIn
@@ -2378,6 +2468,30 @@ export interface components {
             /** Total Out */
             total_out: string;
         };
+        /** MarketOpinionOut */
+        MarketOpinionOut: {
+            /** Age Days */
+            age_days: number;
+            /**
+             * As Of
+             * Format: date
+             */
+            as_of: string;
+            /** Confidence */
+            confidence: number;
+            /** High Estimate */
+            high_estimate: string | null;
+            /** Low Estimate */
+            low_estimate: string | null;
+            /** Provenance Kind */
+            provenance_kind: string;
+            /** Source */
+            source: string;
+            /** Source Label */
+            source_label: string | null;
+            /** Value */
+            value: string;
+        };
         /** MatchIn */
         MatchIn: {
             /**
@@ -2648,6 +2762,26 @@ export interface components {
             /** Year Built */
             year_built: number | null;
         };
+        /**
+         * RatioOut
+         * @description The pack's ratio, and whether this row's BASIS called for it.
+         */
+        RatioOut: {
+            /** Applied */
+            applied: boolean;
+            /** Applied Reason */
+            applied_reason: string;
+            /** Citation */
+            citation: string;
+            /** Class Text */
+            class_text: string | null;
+            /** Code */
+            code: string;
+            /** Source */
+            source: string;
+            /** Value */
+            value: string;
+        };
         /** Readiness */
         Readiness: {
             /** Migrations */
@@ -2834,6 +2968,26 @@ export interface components {
             field_path: string;
             /** Value */
             value?: string | null;
+        };
+        /**
+         * RuleTextOut
+         * @description A pack rule carried verbatim — the pack's own words and authority.
+         *
+         *     Not parsed. `appeal.conference_required` reads "true; PVA conference ..."
+         *     in Kentucky and "false; no conference prerequisite ..." in Ohio, and the
+         *     leading-token convention already has two implementations that must agree.
+         *     A third copy would be a third place for three readers to disagree, so this
+         *     card prints what the pack wrote and lets the reader read it.
+         */
+        RuleTextOut: {
+            /** Citation */
+            citation: string;
+            /** Code */
+            code: string;
+            /** Source */
+            source: string;
+            /** Text */
+            text: string | null;
         };
         /** ScheduleELine */
         ScheduleELine: {
@@ -3246,6 +3400,28 @@ export interface components {
         WaiveIn: {
             /** Reason */
             reason: string;
+        };
+        /**
+         * WindowOut
+         * @description The next appeal window, as the sweep wrote it, plus the paperwork.
+         */
+        WindowOut: {
+            /** Citation */
+            citation: string;
+            /**
+             * Closes On
+             * Format: date
+             */
+            closes_on: string;
+            conference: components["schemas"]["RuleTextOut"] | null;
+            /** Contests Tax Year */
+            contests_tax_year: number | null;
+            /** Contests Tax Year Citation */
+            contests_tax_year_citation: string | null;
+            form: components["schemas"]["RuleTextOut"] | null;
+            instructions: components["schemas"]["RuleTextOut"] | null;
+            /** Opens On */
+            opens_on: string | null;
         };
         /** WorkOrderIn */
         WorkOrderIn: {
@@ -4801,6 +4977,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PropertyOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    property_appeal_properties__property_id__appeal_get: {
+        parameters: {
+            query?: {
+                as_of?: string | null;
+            };
+            header?: never;
+            path: {
+                property_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppealCase"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -100,6 +100,122 @@
         "title": "AcceptIn",
         "type": "object"
       },
+      "AppealCase": {
+        "properties": {
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "findings": {
+            "items": {
+              "$ref": "#/components/schemas/AssessmentFinding"
+            },
+            "title": "Findings",
+            "type": "array"
+          },
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/AppealGap"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "market_opinion": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MarketOpinionOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pairing": {
+            "enum": [
+              "contests_this_assessment",
+              "contests_a_different_year",
+              "unknown"
+            ],
+            "title": "Pairing",
+            "type": "string"
+          },
+          "property_id": {
+            "title": "Property Id",
+            "type": "string"
+          },
+          "ratio_notes": {
+            "items": {
+              "$ref": "#/components/schemas/RuleTextOut"
+            },
+            "title": "Ratio Notes",
+            "type": "array"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "tax_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tax Year"
+          },
+          "window": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WindowOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "property_id",
+          "state",
+          "as_of",
+          "tax_year",
+          "findings",
+          "market_opinion",
+          "ratio_notes",
+          "window",
+          "pairing",
+          "gaps"
+        ],
+        "title": "AppealCase",
+        "type": "object"
+      },
+      "AppealGap": {
+        "description": "A question this chain cannot answer. Named, never defaulted.\n\nField-identical to deposit.GapOut and deliberately NOT shared: hoisting\nthat model would rename its published schema and churn the generated\nclient for no gain. Named differently, though \u2014 two classes called GapOut\nmake FastAPI qualify BOTH into hestia_api__deposit__GapOut and\nhestia_api__appeal__GapOut, which renames the very schema the separation\nwas meant to protect. A third occurrence is when to hoist one shared\nmodel; the second one just needs its own name.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "reason",
+          "detail"
+        ],
+        "title": "AppealGap",
+        "type": "object"
+      },
       "ApplyIn": {
         "properties": {
           "land_value": {
@@ -251,6 +367,89 @@
           "address_matches"
         ],
         "title": "ApplySuggestion",
+        "type": "object"
+      },
+      "AssessmentFinding": {
+        "description": "One assessing body's claim about this property in one tax year, tested.\n\n`assessment` is the SAME projection the dossier renders, so the card and\nthe dossier can never disagree about what the notice said.",
+        "properties": {
+          "assessment": {
+            "$ref": "#/components/schemas/AssessmentOut"
+          },
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/AppealGap"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "implied_market_value": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Implied Market Value"
+          },
+          "over_assessed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Over Assessed"
+          },
+          "over_market_amount": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Over Market Amount"
+          },
+          "over_market_pct": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Over Market Pct"
+          },
+          "ratio": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RatioOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "assessment",
+          "ratio",
+          "implied_market_value",
+          "over_market_amount",
+          "over_market_pct",
+          "over_assessed",
+          "gaps"
+        ],
+        "title": "AssessmentFinding",
         "type": "object"
       },
       "AssessmentIn": {
@@ -4185,6 +4384,84 @@
         "title": "LedgerRegister",
         "type": "object"
       },
+      "MarketOpinionOut": {
+        "properties": {
+          "age_days": {
+            "title": "Age Days",
+            "type": "integer"
+          },
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "confidence": {
+            "title": "Confidence",
+            "type": "number"
+          },
+          "high_estimate": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Estimate"
+          },
+          "low_estimate": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Low Estimate"
+          },
+          "provenance_kind": {
+            "title": "Provenance Kind",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "value": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "source",
+          "as_of",
+          "age_days",
+          "low_estimate",
+          "high_estimate",
+          "provenance_kind",
+          "confidence",
+          "source_label"
+        ],
+        "title": "MarketOpinionOut",
+        "type": "object"
+      },
       "MatchIn": {
         "properties": {
           "event_uuid": {
@@ -4985,6 +5262,58 @@
         "title": "PropertySummary",
         "type": "object"
       },
+      "RatioOut": {
+        "description": "The pack's ratio, and whether this row's BASIS called for it.",
+        "properties": {
+          "applied": {
+            "title": "Applied",
+            "type": "boolean"
+          },
+          "applied_reason": {
+            "title": "Applied Reason",
+            "type": "string"
+          },
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "class_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Class Text"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "value": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "value",
+          "class_text",
+          "citation",
+          "source",
+          "applied",
+          "applied_reason"
+        ],
+        "title": "RatioOut",
+        "type": "object"
+      },
       "Readiness": {
         "properties": {
           "migrations": {
@@ -5615,6 +5944,42 @@
           "field_path"
         ],
         "title": "ReviewIn",
+        "type": "object"
+      },
+      "RuleTextOut": {
+        "description": "A pack rule carried verbatim \u2014 the pack's own words and authority.\n\nNot parsed. `appeal.conference_required` reads \"true; PVA conference ...\"\nin Kentucky and \"false; no conference prerequisite ...\" in Ohio, and the\nleading-token convention already has two implementations that must agree.\nA third copy would be a third place for three readers to disagree, so this\ncard prints what the pack wrote and lets the reader read it.",
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          }
+        },
+        "required": [
+          "code",
+          "text",
+          "citation",
+          "source"
+        ],
+        "title": "RuleTextOut",
         "type": "object"
       },
       "ScheduleELine": {
@@ -6965,6 +7330,96 @@
           "reason"
         ],
         "title": "WaiveIn",
+        "type": "object"
+      },
+      "WindowOut": {
+        "description": "The next appeal window, as the sweep wrote it, plus the paperwork.",
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "closes_on": {
+            "format": "date",
+            "title": "Closes On",
+            "type": "string"
+          },
+          "conference": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuleTextOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contests_tax_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contests Tax Year"
+          },
+          "contests_tax_year_citation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contests Tax Year Citation"
+          },
+          "form": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuleTextOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuleTextOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opens_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Opens On"
+          }
+        },
+        "required": [
+          "opens_on",
+          "closes_on",
+          "citation",
+          "instructions",
+          "form",
+          "conference",
+          "contests_tax_year",
+          "contests_tax_year_citation"
+        ],
+        "title": "WindowOut",
         "type": "object"
       },
       "WorkOrderIn": {
@@ -9616,6 +10071,64 @@
           }
         },
         "summary": "Get Property"
+      }
+    },
+    "/properties/{property_id}/appeal": {
+      "get": {
+        "description": "404 is the only error this can return. Every \"we cannot answer\" is a\nnamed gap inside a 200, because a card that vanishes tells the owner\nnothing about why.",
+        "operationId": "property_appeal_properties__property_id__appeal_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Property Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "As Of"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppealCase"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Property Appeal"
       }
     },
     "/properties/{property_id}/capex-forecast": {

--- a/packages/domain/schema/seed/950_kentucky_assessment_ratio.sql
+++ b/packages/domain/schema/seed/950_kentucky_assessment_ratio.sql
@@ -1,0 +1,84 @@
+-- ===========================================================================
+--  Correction — Kentucky's assessment ratio, and three things that are not
+--  it.
+--
+--  In the 950 range because seed/README.md reserves it for corrections: the
+--  Kentucky pack is applied and may not be edited, and this is a row it
+--  should have carried from the start.
+--
+--  The Kentucky pack shipped without an assessment.ratio row because Kentucky
+--  assesses at full value and the omission read as harmless. It is not: a
+--  detector comparing assessed value against market has to divide by
+--  something, and a MISSING ratio is indistinguishable from a ratio of zero
+--  unless the reader is careful. Ohio and Tennessee both carry one, so
+--  Kentucky's absence made the only fully covered state the one the platform
+--  could say least about.
+--
+--  Seeding 1.00 is a transcription, not an interpretation. KRS 132.191(1)
+--  says the words: "the General Assembly recognizes that Section 172 of the
+--  Constitution of Kentucky requires all property ... to be assessed at one
+--  hundred percent (100%) of the fair cash value". The operative command is
+--  older and plainer — Ky. Const. s.172 and KRS 132.190(3) both say "fair
+--  cash value, estimated at the price it would bring at a fair voluntary
+--  sale" — and 132.191(1) is the sentence that states it as a percentage.
+--
+--  THREE NUMBERS THAT LOOK LIKE THIS ONE AND ARE NOT, each recorded here so
+--  that nobody later files them in this field:
+--
+--  * The 90% (or 95%-105%, or 90%-110%) figure from Kentucky's sales-assessment
+--    ratio study. That is a COUNTY-level compliance band applied to a median
+--    across many parcels, it comes from Department of Revenue manual policy
+--    rather than statute or regulation, and KRS 133.250(4)'s only statutory
+--    number is the 80% that triggers an underassessment audit. A parcel in a
+--    county whose median ratio is 0.93 is still legally assessed at 100%.
+--    Storing that band here would understate every Kentucky assessment by
+--    seven percent.
+--
+--  * Agricultural and horticultural land. Ky. Const. s.172A and KRS
+--    132.450(2)(d) substitute a different DEFINITION of value — the land's
+--    value for agricultural use — and then assess 100% of that. It is a value
+--    basis, not a ratio, and encoding it as one would be wrong in both
+--    directions at once.
+--
+--  * The homestead exemption. Ky. Const. s.170 and KRS 132.810 subtract a
+--    fixed number of dollars from assessed value ($49,100 for the 2025-2026
+--    assessment period, adjusted biennially for the cost of living under KRS
+--    132.810(2)(e)3). A subtraction is not a ratio. It is not seeded here
+--    because nothing in this release reads it, and a figure that changes
+--    every two years should arrive with the reader that needs it.
+-- ===========================================================================
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+SELECT id, 'assessment_ratio', 'assessment.ratio',
+       1.000000,
+       'all real property, at one hundred percent of fair cash value — the '
+       'price it would bring at a fair voluntary sale',
+       'Ky. Const. s.172 (never amended since 1891); KRS 132.190(3); KRS '
+       '132.191(1) (which states the standard as "one hundred percent '
+       '(100%)"); Russman v. Luckett, 391 S.W.2d 694 (Ky. 1965) (assessment at '
+       'a fraction of fair cash value held unconstitutional, ending a practice '
+       'whose statewide median ratio was about 27 percent; the 1965 special '
+       'session responded by rolling back RATES, leaving the standard itself '
+       'untouched)',
+       DATE '1891-08-03'
+FROM jurisdictions WHERE level = 'state' AND state = 'KY';
+
+-- Recorded as data rather than left to a comment, because the next reader of
+-- assessment.ratio is a detector that will divide by it, and "why is there no
+-- second ratio for farmland" is a question it should be able to answer from
+-- the pack instead of from a source file.
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+SELECT id, 'assessment_ratio', 'assessment.ratio.basis_note',
+       NULL,
+       'Kentucky has ONE ratio. The assessed value and the value the tax is '
+       'computed on are the same number before exemptions — there is no '
+       'taxable-value step, and the phrase "taxable value" does not appear in '
+       'the Department of Revenue''s assessment manual at all. Agricultural '
+       'and horticultural land is not an exception to the ratio but a '
+       'different definition of value, assessed at 100% of ITS value.',
+       'Ky. Const. s.172A; KRS 132.450(2)(d); KRS 132.020(1)(a) (the rate '
+       'applies to assessed value directly)',
+       DATE '1969-11-04'
+FROM jurisdictions WHERE level = 'state' AND state = 'KY';

--- a/packages/domain/schema/seed/951_appeal_contests_tax_year.sql
+++ b/packages/domain/schema/seed/951_appeal_contests_tax_year.sql
@@ -1,0 +1,87 @@
+-- ===========================================================================
+--  Correction — which tax year an appeal window contests, and the form
+--  Kentucky files to open one.
+--
+--  A window and an assessment are two facts; WHICH TAX YEAR the window
+--  contests is a third, and it is jurisdiction data. Ohio's Board of Revision
+--  complaint is filed in the year FOLLOWING the tax year it contests, so a
+--  window closing in 2027 contests tax year 2026 — and an owner holding a
+--  2026 notice beside a 2027 window is looking at the right pair. Kentucky's
+--  open inspection period runs in May on the roll "being prepared ... for the
+--  current year", so a window closing in 2027 contests 2027, and that same
+--  owner is looking at the WRONG pair by a year.
+--
+--  This repository asserts that difference twice today — in calendar.py and
+--  in packages/engines/src/deadlines.ts — as a DOCSTRING, where no read model
+--  can reach it. These rows are that sentence made resolvable:
+--
+--      contested_tax_year = year(the window closes) + offset
+--
+--  A RULE and not a field on the calendar registry, because only one of the
+--  three window shapes has a builder to hang a field on. Tennessee's window
+--  is a PUBLISHED date with no builder at all, so a registry-side offset
+--  would answer for two states out of three and be structurally unable to
+--  answer for the third.
+--
+--  TENNESSEE IS DELIBERATELY UNSEEDED. Davidson County's June adjournment
+--  almost certainly contests the current tax year, but nothing in the pack
+--  says so and the authorities it already cites are authorities for the
+--  WINDOW, not for the year it contests. The card reports the pairing as
+--  unknown and shows the window as informational, which is the honest answer
+--  until somebody sources it.
+-- ===========================================================================
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+
+  -- Kentucky: offset 0. Verified rather than inferred — KRS 133.045(1) says
+  -- the roll open for inspection is the one "being prepared by the property
+  -- valuation administrator for the current year", and the Department of
+  -- Revenue's own appeal form carries the field "assessed as of January 1,
+  -- 20___" on its face, which the taxpayer fills with the same year they file.
+  ('a0000000-0000-4000-8000-000000000010', 'assessment_appeal',
+   'appeal.contests_tax_year_offset',
+   0,
+   'the open inspection period held in May of calendar year Y contests the '
+   'assessment made as of January 1 of that same year Y — Kentucky is a '
+   'same-year contest state',
+   'KRS 133.045(1) (the roll open for inspection is the one being prepared '
+   'for the current year); KRS 132.220(1)(a) (all taxable property listed, '
+   'assessed and valued as of January 1 of each year); Kentucky Department of '
+   'Revenue Form 62F031 (the appeal states the assessment "as of January 1" '
+   'of the year it is filed in)',
+   DATE '1994-01-01'),
+
+  -- Ohio: offset -1, quoted from the statute the pack already cites.
+  ('a0000000-0039-4000-8000-000000000010', 'assessment_appeal',
+   'appeal.contests_tax_year_offset',
+   -1,
+   'a complaint filed in calendar year Y contests tax year Y-1: the statute '
+   'speaks of a complaint against a determination "for the current tax year" '
+   'filed "of the ensuing tax year"',
+   'ORC 5715.19(A)(1)', DATE '1976-01-01'),
+
+  -- The form Kentucky's pack never named. Ohio has carried DTE Form 1 since
+  -- its own pack and Tennessee names its route, so the appeal card's form
+  -- slot was a gap in one state and a value in the others for a difference of
+  -- seeding rather than of law.
+  --
+  -- Two things this row is careful about. Form 62A307 is the PVA's CONFERENCE
+  -- RECORD, which the owner attaches — it is not the document filed with the
+  -- clerk, and the pack's conference rule already says so correctly. And the
+  -- form is not mandatory: KRS 133.120(2)(b) accepts "a letter or other
+  -- written petition", so this names the form the counties hand out without
+  -- claiming a filing is void without it.
+  ('a0000000-0000-4000-8000-000000000010', 'assessment_appeal', 'appeal.form',
+   NULL,
+   'Form 62F031, "Appeal to Local Board of Assessment Appeals", filed with the '
+   'county clerk with Form 62A307 (the PVA conference record) attached. The '
+   'statute accepts a letter or other written petition instead, so the form is '
+   'the county''s convention rather than a condition of the appeal. The '
+   'deadline is relative, never a fixed date: one workday after the inspection '
+   'period closes, unless the Department grants an extension.',
+   'KRS 133.120(2)(b); KRS 133.120(2)(c); Kentucky Department of Revenue Form '
+   '62F031 (12-20). NOTE: 103 KAR 3:030, which formerly named both forms, was '
+   'repealed effective 2017-03-03 — cite the Department''s form, not the '
+   'regulation.',
+   DATE '1994-01-01');

--- a/packages/domain/schema/tests/packs/kentucky.sql
+++ b/packages/domain/schema/tests/packs/kentucky.sql
@@ -21,6 +21,9 @@ DECLARE
   conformity TEXT;
   cap NUMERIC;
   phaseout NUMERIC;
+  ratio NUMERIC;
+  ratio_citation TEXT;
+  distinct_ratios INT;
 BEGIN
   -- The load-bearing URLTA contrast: one street across the Newport line is a
   -- different legal regime.
@@ -95,4 +98,39 @@ BEGIN
     RAISE EXCEPTION 'the federal 100 percent bonus row (899_federal.sql) is missing';
   END IF;
   RAISE NOTICE '  ok      the shared federal tier is installed beneath the pack';
+
+  -- One hundred percent, and it is transcription rather than inference: KRS
+  -- 132.191(1) states the standard in those words. A detector comparing an
+  -- assessment against market divides by this, so an ABSENT row and a row of
+  -- zero are one keystroke apart — which is why the pack now carries it.
+  SELECT r.value_numeric, r.citation INTO ratio, ratio_citation
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND r.code = 'assessment.ratio' AND r.superseded_by IS NULL;
+  IF ratio IS DISTINCT FROM 1.000000::NUMERIC THEN
+    RAISE EXCEPTION 'Kentucky assesses at %, expected 1.0 of fair cash value', ratio;
+  END IF;
+  IF ratio_citation NOT LIKE '%132.191%' THEN
+    RAISE EXCEPTION 'the Kentucky ratio does not cite the statute that states it '
+      'as a percentage: %', ratio_citation;
+  END IF;
+  -- The sales-assessment ratio study's 90 percent is a COUNTY compliance band
+  -- from Department of Revenue manual policy, not a parcel's standard. If it
+  -- ever lands in this field every Kentucky assessment is understated by
+  -- seven percent, so the value is pinned exactly rather than by a range.
+  IF ratio < 1.000000 THEN
+    RAISE EXCEPTION 'Kentucky ratio is below 1.0 — the ratio-study compliance '
+      'band is not the assessment standard';
+  END IF;
+  RAISE NOTICE '  ok      Kentucky assesses at 100 percent, and cites the words';
+
+  -- Three states, three ratios. This is the whole reason the detector cannot
+  -- compare an assessment to a market value without asking the pack first.
+  SELECT count(DISTINCT r.value_numeric) INTO distinct_ratios
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name IN ('Kentucky', 'Ohio', 'Tennessee')
+    AND r.code = 'assessment.ratio' AND r.superseded_by IS NULL;
+  IF distinct_ratios <> 3 THEN
+    RAISE EXCEPTION 'expected three distinct assessment ratios, found %', distinct_ratios;
+  END IF;
+  RAISE NOTICE '  ok      100, 35 and 25 percent: three states, three ratios';
 END $$;

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -32,6 +32,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from hestia_api import (
+    appeal,
     assessments,
     bank_import,
     config,
@@ -902,6 +903,21 @@ def cash_flow_report(
 @app.get("/reports/rent-roll", response_model=list[reports.RentRollRow])
 def rent_roll_report(conn: Conn) -> list[reports.RentRollRow]:
     return reports.rent_roll(conn)
+
+
+@app.get("/properties/{property_id}/appeal", response_model=appeal.AppealCase)
+def property_appeal(
+    property_id: uuid.UUID,
+    conn: Conn,
+    as_of: Annotated[dt.date | None, Query()] = None,
+) -> appeal.AppealCase:
+    """404 is the only error this can return. Every "we cannot answer" is a
+    named gap inside a 200, because a card that vanishes tells the owner
+    nothing about why."""
+    _require_property(conn, property_id)
+    return appeal.read(
+        conn, str(property_id), as_of=as_of if as_of is not None else dt.date.today()
+    )
 
 
 @app.get("/properties/{property_id}/financials", response_model=reports.Financials)

--- a/services/api/hestia_api/appeal.py
+++ b/services/api/hestia_api/appeal.py
@@ -1,0 +1,564 @@
+"""The over-assessment card: what a body said, what the market says, and the
+ratio the pack puts between them.
+
+Two numbers are compared and one of them may need converting first. WHICH one
+is never inferred: assessments.value_basis records it per row (module 019),
+because market and taxable differ by a factor of three in Ohio and four in
+Tennessee — "the largest silent error available anywhere in this system". A
+market row is compared directly and the pack's ratio is CITED beside it,
+unapplied, so a reader can see the ratio was considered and correctly
+withheld. A taxable row is divided by the chain-resolved ratio, or it produces
+a named gap; it is never divided by an assumed 1.0.
+
+The window comes from the deadlines row the sweep already wrote rather than
+from a second resolver, because jurisdiction_chain()'s own comment forbids
+resolution order disagreeing between readers, and sweep._appeal_windows is the
+sole authority on which of the three window shapes governs. What this module
+resolves for itself is the paperwork the sweep does not carry: the form, the
+conference prerequisite, and the offset that says which tax year the window
+contests.
+
+NO THRESHOLD IS APPLIED ANYWHERE. Every numeric threshold in this repository
+traces to a named authority — the de-minimis cents to Treas. Reg.
+1.263(a)-1(f), the Ohio deposit rate to ORC 5321.16(A) under "every number
+here comes from the statute; none is a default". No pack seeds a materiality
+figure and no jurisdiction publishes one, so this card states the gap between
+two numbers and does not decide whether that gap is worth a filing fee.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import ROUND_HALF_EVEN, Decimal
+from typing import Any, Literal
+
+import psycopg
+from pydantic import BaseModel
+
+from hestia_api import assessments
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+CENT = Decimal("0.01")
+# Six places, matching the land_share the assessment projection already
+# publishes and jurisdiction_rules.value_numeric's own scale.
+RATE = Decimal("0.000001")
+
+# Which opinions of value are INDEPENDENT of the assessment being tested.
+# A whitelist and not a blacklist: a ninth valuation_source member added later
+# is inadmissible until somebody decides it belongs, which is the safe
+# direction. This is a domain constant rather than pack data — it is
+# identically true in all fifty states, so fifty identical rows would only
+# create fifty chances for one of them to disagree.
+#
+#   assessor                  — IS the assessment. Comparing it to itself
+#                               reports 0.00% over-assessed with a statute
+#                               attached, and nothing about it looks broken.
+#   purchase_price            — one transaction on one day, stale by
+#                               construction. The document suggestion path
+#                               already refuses the mirror image of this.
+#   replacement_cost_estimate — cost to rebuild, land excluded; it answers an
+#                               insurance question, not a market one.
+#   owner_estimate            — the owner's own number, in the one proceeding
+#                               where it is the number in dispute.
+#                               assessment_appeals.opinion_of_value is where
+#                               that belongs.
+ADMISSIBLE_SOURCES = ("appraisal", "broker_opinion", "comparable_sales", "avm")
+
+Pairing = Literal["contests_this_assessment", "contests_a_different_year", "unknown"]
+
+
+class AppealGap(BaseModel):
+    """A question this chain cannot answer. Named, never defaulted.
+
+    Field-identical to deposit.GapOut and deliberately NOT shared: hoisting
+    that model would rename its published schema and churn the generated
+    client for no gain. Named differently, though — two classes called GapOut
+    make FastAPI qualify BOTH into hestia_api__deposit__GapOut and
+    hestia_api__appeal__GapOut, which renames the very schema the separation
+    was meant to protect. A third occurrence is when to hoist one shared
+    model; the second one just needs its own name.
+    """
+
+    code: str
+    reason: str
+    detail: str
+
+
+class RuleTextOut(BaseModel):
+    """A pack rule carried verbatim — the pack's own words and authority.
+
+    Not parsed. `appeal.conference_required` reads "true; PVA conference ..."
+    in Kentucky and "false; no conference prerequisite ..." in Ohio, and the
+    leading-token convention already has two implementations that must agree.
+    A third copy would be a third place for three readers to disagree, so this
+    card prints what the pack wrote and lets the reader read it.
+    """
+
+    code: str
+    text: str | None
+    citation: str
+    source: str
+
+
+class RatioOut(BaseModel):
+    """The pack's ratio, and whether this row's BASIS called for it."""
+
+    code: str
+    value: Decimal
+    class_text: str | None
+    citation: str
+    source: str
+    applied: bool
+    applied_reason: str
+
+
+class MarketOpinionOut(BaseModel):
+    value: Decimal
+    source: str
+    as_of: dt.date
+    # Stated, never scored. A 2019 opinion against a 2026 assessment is the
+    # defect the land-split suggestion already refuses to commit.
+    age_days: int
+    # Present in the schema since module 005 and unreachable today: the
+    # valuation writer accepts no band. Carried so the card can say the
+    # comparand states no interval, rather than implying a precision one
+    # figure does not have.
+    low_estimate: Decimal | None
+    high_estimate: Decimal | None
+    provenance_kind: str
+    confidence: float
+    source_label: str | None
+
+
+class AssessmentFinding(BaseModel):
+    """One assessing body's claim about this property in one tax year, tested.
+
+    `assessment` is the SAME projection the dossier renders, so the card and
+    the dossier can never disagree about what the notice said.
+    """
+
+    assessment: assessments.AssessmentOut
+    ratio: RatioOut | None
+    implied_market_value: Decimal | None
+    over_market_amount: Decimal | None
+    over_market_pct: Decimal | None
+    # The SIGN of a subtraction. Not a recommendation, and not a threshold.
+    over_assessed: bool | None
+    gaps: list[AppealGap]
+
+
+class WindowOut(BaseModel):
+    """The next appeal window, as the sweep wrote it, plus the paperwork."""
+
+    opens_on: dt.date | None
+    closes_on: dt.date
+    citation: str
+    instructions: RuleTextOut | None
+    form: RuleTextOut | None
+    conference: RuleTextOut | None
+    # The window's CALENDAR year is not the tax year it contests. None where
+    # no appeal.contests_tax_year_offset rule resolves — and that None is why
+    # `pairing` reads "unknown" rather than pairing them anyway.
+    contests_tax_year: int | None
+    contests_tax_year_citation: str | None
+
+
+class AppealCase(BaseModel):
+    property_id: str
+    state: str
+    as_of: dt.date
+    tax_year: int | None
+    findings: list[AssessmentFinding]
+    market_opinion: MarketOpinionOut | None
+    # Prose that travels with the ratio: any assessment_ratio rule carrying
+    # text and no number. Tennessee's attorney-general caveat is one, and it
+    # renders whether or not a ratio was produced.
+    ratio_notes: list[RuleTextOut]
+    window: WindowOut | None
+    pairing: Pairing
+    gaps: list[AppealGap]
+
+
+ANCHOR_SQL = """
+SELECT p.id::text AS property_id, p.state,
+       COALESCE(p.jurisdiction_id, s.id) AS start_id
+FROM properties p
+LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+WHERE p.id = %(property_id)s
+"""
+
+RULES_SQL = """
+SELECT DISTINCT ON (r.code)
+       r.code, r.value_numeric, r.value_text, r.citation, j.name AS source
+FROM jurisdiction_chain(%(start_id)s) c
+JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+JOIN jurisdictions j ON j.id = c.jurisdiction_id
+WHERE r.domain = %(domain)s
+  AND r.superseded_by IS NULL
+  AND r.effective_from <= %(as_of)s
+  AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+ORDER BY r.code, c.depth ASC, r.effective_from DESC
+"""
+
+COMPARAND_SQL = """
+SELECT v.value, v.source::text AS source, v.as_of,
+       v.low_estimate, v.high_estimate,
+       pr.kind::text AS provenance_kind, pr.confidence::float AS confidence,
+       pr.source_label
+FROM valuations v JOIN provenance pr ON pr.id = v.provenance_id
+WHERE v.property_id = %(property_id)s
+  AND v.source = ANY(%(admissible)s::valuation_source[])
+  -- money_amount is a bare NUMERIC(18,2): the DOMAIN permits zero and
+  -- negatives, and only the writer's own gt=0 keeps them out of the one
+  -- writer that exists today. The divisor is guarded here, in SQL.
+  AND v.value > 0
+  AND v.as_of <= %(as_of)s
+-- The id tail is not decoration. created_at defaults to now(), which is the
+-- TRANSACTION timestamp and therefore identical across every row of a bulk
+-- load, so two rows sharing as_of would otherwise be ordered by whatever the
+-- planner returned. A percentage that changes when nothing changed gets
+-- reported as data corruption.
+ORDER BY v.as_of DESC, v.created_at DESC, v.id DESC
+LIMIT 1
+"""
+
+PRESENT_SOURCES_SQL = """
+SELECT DISTINCT v.source::text AS source FROM valuations v
+WHERE v.property_id = %(property_id)s ORDER BY 1
+"""
+
+WINDOW_SQL = """
+SELECT d.due_on, d.window_opens_on, d.citation
+FROM deadlines d
+WHERE d.property_id = %(property_id)s
+  AND d.kind = 'assessment_appeal_window'
+  AND d.due_on >= %(as_of)s
+ORDER BY d.due_on ASC, d.id ASC
+LIMIT 1
+"""
+
+
+def _rules(conn: Conn, start_id: str, domain: str, as_of: dt.date) -> dict[str, Any]:
+    """Every rule this chain carries in one domain, most specific body first,
+    newest effective rule within that body, superseded and expired excluded.
+
+    The ORDER BY is the sweep's, the deposit panel's and the coverage report's
+    verbatim, because jurisdiction_chain() exists so that readers cannot
+    disagree about which row wins.
+    """
+    return {
+        row["code"]: row
+        for row in conn.execute(
+            RULES_SQL, {"start_id": start_id, "domain": domain, "as_of": as_of}
+        ).fetchall()
+    }
+
+
+def _rule_text(row: Any) -> RuleTextOut:
+    return RuleTextOut(
+        code=row["code"],
+        text=row["value_text"],
+        citation=row["citation"],
+        source=row["source"],
+    )
+
+
+def _ratio_for(ratio_rules: dict[str, Any], basis: str) -> tuple[RatioOut | None, AppealGap | None]:
+    """The ratio this row's basis calls for, or the reason there is none.
+
+    The discrimination is by ARITY and SHAPE, never by code name. A pack that
+    carries one numeric ratio has answered; a pack that carries two has said
+    the answer depends on a classification, and Tennessee's own caveat row
+    opens "No bright-line rule" — so two is a question, not a menu to pick
+    from. Choosing between them here would put a governance fact in dispatch
+    logic, which is the ADR 0003 failure mode that the state-literal ratchet
+    provably cannot catch, because the code would contain no state literal.
+    """
+    numeric = [row for row in ratio_rules.values() if row["value_numeric"] is not None]
+    if basis == "market":
+        # The comparison never needed it. Cited anyway, unapplied, so a reader
+        # can see the ratio was considered and correctly withheld.
+        if len(numeric) != 1:
+            return None, None
+        row = numeric[0]
+        return (
+            RatioOut(
+                code=row["code"],
+                value=row["value_numeric"],
+                class_text=row["value_text"],
+                citation=row["citation"],
+                source=row["source"],
+                applied=False,
+                applied_reason=(
+                    "the notice states a market value, so no ratio converts it —"
+                    " it is already the figure a market opinion compares against"
+                ),
+            ),
+            None,
+        )
+    if not numeric:
+        return None, AppealGap(
+            code="assessment.ratio",
+            reason="no_rule_for_domain",
+            detail=(
+                "this notice states a taxable value and no assessment ratio resolves"
+                " for its chain, so the full value it implies cannot be recovered;"
+                " it is not assumed to be one"
+            ),
+        )
+    if len(numeric) > 1:
+        return None, AppealGap(
+            code="assessment.ratio",
+            reason="ambiguous_ratio",
+            detail=(
+                "the pack carries "
+                + ", ".join(
+                    f"{row['code']} = {row['value_numeric']}"
+                    for row in sorted(numeric, key=lambda r: str(r["code"]))
+                )
+                + "; which one governs depends on how this property is classified,"
+                " and the pack does not say"
+            ),
+        )
+    row = numeric[0]
+    if row["value_numeric"] <= 0:
+        return None, AppealGap(
+            code="assessment.ratio",
+            reason="unusable_ratio",
+            detail=(
+                f"{row['code']} resolves to {row['value_numeric']} for"
+                f" {row['source']}, which nothing can be divided by"
+            ),
+        )
+    return (
+        RatioOut(
+            code=row["code"],
+            value=row["value_numeric"],
+            class_text=row["value_text"],
+            citation=row["citation"],
+            source=row["source"],
+            applied=True,
+            applied_reason=(
+                "the notice states a taxable value, so the full value it implies is"
+                f" the total divided by {row['value_numeric']}"
+            ),
+        ),
+        None,
+    )
+
+
+def _finding(
+    row: assessments.AssessmentOut,
+    ratio_rules: dict[str, Any],
+    market: MarketOpinionOut | None,
+) -> AssessmentFinding:
+    ratio, gap = _ratio_for(ratio_rules, row.value_basis)
+    gaps = [gap] if gap is not None else []
+    implied: Decimal | None = None
+    if row.value_basis == "market":
+        implied = row.assessed_total
+    elif ratio is not None:
+        implied = (row.assessed_total / ratio.value).quantize(CENT, rounding=ROUND_HALF_EVEN)
+    if implied is None or market is None:
+        return AssessmentFinding(
+            assessment=row,
+            ratio=ratio,
+            implied_market_value=implied,
+            over_market_amount=None,
+            over_market_pct=None,
+            over_assessed=None,
+            gaps=gaps,
+        )
+    over = (implied - market.value).quantize(CENT, rounding=ROUND_HALF_EVEN)
+    return AssessmentFinding(
+        assessment=row,
+        ratio=ratio,
+        implied_market_value=implied,
+        over_market_amount=over,
+        over_market_pct=(over / market.value).quantize(RATE, rounding=ROUND_HALF_EVEN),
+        # The sign of a subtraction. Whether it is worth a filing fee is a
+        # question no jurisdiction publishes an answer to, so none is invented.
+        over_assessed=over > 0,
+        gaps=gaps,
+    )
+
+
+def _market_opinion(
+    conn: Conn, property_id: str, as_of: dt.date
+) -> tuple[MarketOpinionOut | None, AppealGap | None]:
+    """The most recent independent opinion of value, or why there is none."""
+    row = conn.execute(
+        COMPARAND_SQL,
+        {"property_id": property_id, "admissible": list(ADMISSIBLE_SOURCES), "as_of": as_of},
+    ).fetchone()
+    if row is not None:
+        return (
+            MarketOpinionOut(
+                value=row["value"],
+                source=row["source"],
+                as_of=row["as_of"],
+                age_days=(as_of - row["as_of"]).days,
+                low_estimate=row["low_estimate"],
+                high_estimate=row["high_estimate"],
+                provenance_kind=row["provenance_kind"],
+                confidence=row["confidence"],
+                source_label=row["source_label"],
+            ),
+            None,
+        )
+    present = [
+        found["source"]
+        for found in conn.execute(PRESENT_SOURCES_SQL, {"property_id": property_id}).fetchall()
+    ]
+    inadmissible = sorted(set(present) - set(ADMISSIBLE_SOURCES))
+    # Naming what WAS on file is the difference between "nobody has valued
+    # this" and "the only value on file is the assessor's own, which is the
+    # number under test". The second reads as an answer if it is not said.
+    detail = (
+        "no independent opinion of value is on file; an assessment can only be tested against one"
+        if not inadmissible
+        else (
+            "the only values on file come from "
+            + ", ".join(inadmissible)
+            + ", none of which is independent of the assessment being tested;"
+            " an assessor's own figure compared to itself is never over-assessed"
+        )
+    )
+    return None, AppealGap(code="valuations", reason="no_market_opinion", detail=detail)
+
+
+def _window(
+    conn: Conn, property_id: str, appeal_rules: dict[str, Any], as_of: dt.date
+) -> tuple[WindowOut | None, AppealGap | None]:
+    """The window the sweep already wrote, plus the paperwork around it.
+
+    Read rather than re-resolved: the sweep is the sole authority on which of
+    the three window shapes governs — a published date beats a computed one,
+    and a published date already past is a gap rather than a roll-forward —
+    and a second opinion here could disagree with the calendar the owner is
+    looking at.
+    """
+    row = conn.execute(WINDOW_SQL, {"property_id": property_id, "as_of": as_of}).fetchone()
+    if row is None:
+        return None, AppealGap(
+            code="assessment_appeal_window",
+            reason="no_window_scheduled",
+            detail=(
+                "no upcoming appeal window is on the calendar for this property;"
+                " run a deadline sweep, and if none appears the coverage report"
+                " says which jurisdiction fact is missing"
+            ),
+        )
+    offset_rule = appeal_rules.get("appeal.contests_tax_year_offset")
+    contests = (
+        None if offset_rule is None else row["due_on"].year + int(offset_rule["value_numeric"])
+    )
+    return (
+        WindowOut(
+            opens_on=row["window_opens_on"],
+            closes_on=row["due_on"],
+            citation=row["citation"],
+            instructions=(
+                _rule_text(appeal_rules["appeal.instructions"])
+                if "appeal.instructions" in appeal_rules
+                else None
+            ),
+            form=(
+                _rule_text(appeal_rules["appeal.form"]) if "appeal.form" in appeal_rules else None
+            ),
+            conference=(
+                _rule_text(appeal_rules["appeal.conference_required"])
+                if "appeal.conference_required" in appeal_rules
+                else None
+            ),
+            contests_tax_year=contests,
+            contests_tax_year_citation=(None if offset_rule is None else offset_rule["citation"]),
+        ),
+        None,
+    )
+
+
+def read(conn: Conn, property_id: str, *, as_of: dt.date) -> AppealCase:
+    """The card: every body's claim about the latest tax year on file, each
+    converted if its basis calls for it, against one independent opinion."""
+    anchor = conn.execute(ANCHOR_SQL, {"property_id": property_id}).fetchone()
+    assert anchor is not None  # the endpoint has already proven the property exists
+    empty = AppealCase(
+        property_id=property_id,
+        state=anchor["state"],
+        as_of=as_of,
+        tax_year=None,
+        findings=[],
+        market_opinion=None,
+        ratio_notes=[],
+        window=None,
+        pairing="unknown",
+        gaps=[],
+    )
+    if anchor["start_id"] is None:
+        empty.gaps.append(
+            AppealGap(
+                code="jurisdiction",
+                reason="no_state_jurisdiction",
+                detail=f"no jurisdiction pack is loaded for {anchor['state']}",
+            )
+        )
+        return empty
+
+    rows = assessments.for_property(conn, property_id)
+    if not rows:
+        empty.gaps.append(
+            AppealGap(
+                code="assessments",
+                reason="no_assessment_on_file",
+                detail=(
+                    "nothing is recorded about what this property is assessed at;"
+                    " enter the notice, or upload it"
+                ),
+            )
+        )
+        return empty
+
+    # tax_year DESC is the only defensible ordering: there is no as_of column,
+    # notice_received_on is nullable and may legitimately sit years after the
+    # year it assesses, and created_at says when somebody typed. Every row of
+    # that year is a finding — two bases for one body and two bodies for one
+    # year are both legal, and a LIMIT 1 would fabricate an answer about the
+    # row it dropped.
+    tax_year = rows[0].tax_year
+    current = [row for row in rows if row.tax_year == tax_year]
+
+    # The ratio in force IN THE ASSESSED YEAR, not the one in force the day the
+    # card is opened. Today they agree everywhere; the day a state changes its
+    # ratio they will not, and a card that quietly used today's would be
+    # answering about a notice with a rule that postdates it.
+    ratio_rules = _rules(conn, anchor["start_id"], "assessment_ratio", dt.date(tax_year, 1, 1))
+    appeal_rules = _rules(conn, anchor["start_id"], "assessment_appeal", as_of)
+
+    market, market_gap = _market_opinion(conn, property_id, as_of)
+    window, window_gap = _window(conn, property_id, appeal_rules, as_of)
+    gaps = [gap for gap in (market_gap, window_gap) if gap is not None]
+
+    pairing: Pairing = "unknown"
+    if window is not None and window.contests_tax_year is not None:
+        pairing = (
+            "contests_this_assessment"
+            if window.contests_tax_year == tax_year
+            else "contests_a_different_year"
+        )
+
+    return AppealCase(
+        property_id=property_id,
+        state=anchor["state"],
+        as_of=as_of,
+        tax_year=tax_year,
+        findings=[_finding(row, ratio_rules, market) for row in current],
+        market_opinion=market,
+        ratio_notes=[
+            _rule_text(row) for row in ratio_rules.values() if row["value_numeric"] is None
+        ],
+        window=window,
+        pairing=pairing,
+        gaps=gaps,
+    )

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -66,6 +66,9 @@ class TestContract:
             "/properties/{property_id}/dossier",
             "/sweep/deadlines",
             "/coverage/jurisdictions",
+            "/assessments",
+            "/documents/{document_id}/apply-assessment",
+            "/properties/{property_id}/appeal",
         ):
             assert path in spec["paths"], path
         # Two gap models exist on purpose (sweep vs coverage); both must keep

--- a/services/api/tests/test_appeal.py
+++ b/services/api/tests/test_appeal.py
@@ -1,0 +1,461 @@
+"""The over-assessment card: what a body said against what the market says.
+
+Issue #9's acceptance, executable — and the two ways it can be wrong by a
+factor of three. A Kentucky notice states a value that already IS market; an
+Ohio taxable notice states 35% of it. Which of those a row holds is recorded
+per row, never inferred, and this suite pins both directions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from fastapi.testclient import TestClient
+
+CAMPBELL_COUNTY = "a0000000-0000-4000-8000-000000000021"
+HAMILTON_COUNTY_OH = "a0000000-0039-4000-8000-000000000021"
+DAVIDSON_COUNTY = "a0000000-0047-4000-8000-000000000021"
+
+
+def make_property(
+    client: TestClient, *, city: str, state: str, postal: str, label: str | None = None
+) -> str:
+    entity = client.post("/entities", json={"name": f"{city} LLC", "kind": "llc"}).json()
+    return client.post(
+        "/properties",
+        json={
+            "entity_id": entity["id"],
+            "label": label or city,
+            "street_1": "1 Main St",
+            "city": city,
+            "state": state,
+            "postal_code": postal,
+            "kind": "single_family",
+        },
+    ).json()["id"]
+
+
+def record(
+    client: TestClient,
+    property_id: str,
+    *,
+    basis: str,
+    total: str,
+    year: int = 2026,
+    jurisdiction_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "property_id": property_id,
+        "tax_year": year,
+        "value_basis": basis,
+        "assessed_total": total,
+    }
+    if jurisdiction_id is not None:
+        payload["jurisdiction_id"] = jurisdiction_id
+    created = client.post("/assessments", json=payload)
+    assert created.status_code == 201, created.text
+    return created.json()
+
+
+def value(
+    client: TestClient, property_id: str, *, amount: str, source: str, as_of: str = "2026-03-01"
+) -> None:
+    created = client.post(
+        "/valuations",
+        json={"property_id": property_id, "value": amount, "source": source, "as_of": as_of},
+    )
+    assert created.status_code == 201, created.text
+
+
+def card(client: TestClient, property_id: str, as_of: str = "2026-06-01") -> dict[str, Any]:
+    got = client.get(f"/properties/{property_id}/appeal?as_of={as_of}")
+    assert got.status_code == 200, got.text
+    return got.json()
+
+
+class TestTheAcceptanceWalk:
+    def test_newport_flags_with_kentucky_citations(self, clean: None, client: TestClient) -> None:
+        """A Kentucky notice states fair cash value, which already IS market —
+        so the ratio is cited and NOT applied, and the comparison is direct."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(
+            client,
+            property_id,
+            basis="market",
+            total="200000.00",
+            jurisdiction_id=CAMPBELL_COUNTY,
+        )
+        value(client, property_id, amount="160000.00", source="appraisal")
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+
+        body = card(client, property_id)
+        assert body["state"] == "KY"
+        assert body["tax_year"] == 2026
+        (finding,) = body["findings"]
+
+        assert finding["ratio"]["applied"] is False
+        assert Decimal(finding["ratio"]["value"]) == Decimal("1.000000")
+        assert "s.172" in finding["ratio"]["citation"]
+        assert "Russman" in finding["ratio"]["citation"]
+        # Stated at market, so the implied full value is the stated total.
+        assert Decimal(finding["implied_market_value"]) == Decimal("200000.00")
+        assert Decimal(finding["over_market_amount"]) == Decimal("40000.00")
+        assert Decimal(finding["over_market_pct"]) == Decimal("0.250000")
+        assert finding["over_assessed"] is True
+        assert finding["gaps"] == []
+
+        assert body["market_opinion"]["source"] == "appraisal"
+        assert body["window"] is not None
+        assert "KRS 133.045" in body["window"]["citation"]
+        assert "62F031" in body["window"]["form"]["text"]
+
+    def test_cincinnati_applies_the_thirty_five_percent_ratio(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The same finding through Ohio's ratio. A taxable notice of 70,000 is
+        an assertion that the property is worth 200,000 — and without the
+        ratio it would read as wildly UNDER-assessed against a 160,000
+        appraisal, which is the error the ticket exists to prevent."""
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        record(
+            client,
+            property_id,
+            basis="taxable",
+            total="70000.00",
+            jurisdiction_id=HAMILTON_COUNTY_OH,
+        )
+        value(client, property_id, amount="160000.00", source="appraisal")
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        assert finding["ratio"]["applied"] is True
+        assert Decimal(finding["ratio"]["value"]) == Decimal("0.350000")
+        assert "5715.01" in finding["ratio"]["citation"]
+        assert Decimal(finding["implied_market_value"]) == Decimal("200000.00")
+        assert Decimal(finding["over_market_amount"]) == Decimal("40000.00")
+        assert finding["over_assessed"] is True
+        assert "DTE Form 1" in body["window"]["form"]["text"]
+        assert "ORC 5715.19" in body["window"]["citation"]
+
+    def test_the_same_figures_without_the_ratio_would_read_as_under_assessed(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The counterfactual, pinned. 70,000 compared naively against 160,000
+        is 56% under — the opposite conclusion, on the same paper."""
+        property_id = make_property(client, city="Norwood", state="OH", postal="45212")
+        record(client, property_id, basis="taxable", total="70000.00")
+        value(client, property_id, amount="160000.00", source="appraisal")
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        assert Decimal(finding["implied_market_value"]) == Decimal("200000.00")
+        assert finding["over_assessed"] is True
+        naive = Decimal("70000.00") - Decimal("160000.00")
+        assert naive < 0 and Decimal(finding["over_market_amount"]) > 0
+
+
+class TestTheBasisDecidesEverything:
+    def test_an_ohio_market_row_is_not_divided(self, clean: None, client: TestClient) -> None:
+        """An Ohio value notice states MARKET and nothing else, so the same
+        pack, the same property and the same ratio must leave it alone."""
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        record(client, property_id, basis="market", total="200000.00")
+        value(client, property_id, amount="160000.00", source="appraisal")
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        assert finding["ratio"]["applied"] is False
+        assert (
+            "already the figure a market opinion compares against"
+            in (finding["ratio"]["applied_reason"])
+        )
+        assert Decimal(finding["implied_market_value"]) == Decimal("200000.00")
+
+    def test_both_bases_of_one_notice_are_each_a_finding(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """A Tennessee card states both. Neither row is dropped, and the two
+        reach different places — the market half compares, the taxable half
+        gaps because Tennessee's pack carries two ratios."""
+        property_id = make_property(client, city="Nashville", state="TN", postal="37206")
+        record(
+            client,
+            property_id,
+            basis="market",
+            total="200000.00",
+            jurisdiction_id=DAVIDSON_COUNTY,
+        )
+        record(
+            client,
+            property_id,
+            basis="taxable",
+            total="50000.00",
+            jurisdiction_id=DAVIDSON_COUNTY,
+        )
+        value(client, property_id, amount="160000.00", source="broker_opinion")
+        body = card(client, property_id)
+        assert len(body["findings"]) == 2
+        by_basis = {f["assessment"]["value_basis"]: f for f in body["findings"]}
+        assert Decimal(by_basis["market"]["implied_market_value"]) == Decimal("200000.00")
+        assert by_basis["market"]["over_assessed"] is True
+        taxable = by_basis["taxable"]
+        assert taxable["implied_market_value"] is None
+        assert taxable["over_assessed"] is None
+        (gap,) = taxable["gaps"]
+        assert gap["reason"] == "ambiguous_ratio"
+        assert "assessment.ratio" in gap["detail"]
+        assert "assessment.ratio.commercial" in gap["detail"]
+
+    def test_the_tennessee_caveat_travels_with_the_ratio(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The attorney-general opinion that says there is no bright-line rule
+        is why the ambiguity above is a gap rather than a guess."""
+        property_id = make_property(client, city="Nashville", state="TN", postal="37206")
+        record(client, property_id, basis="market", total="200000.00")
+        body = card(client, property_id)
+        notes = {note["code"]: note for note in body["ratio_notes"]}
+        assert "assessment.ratio.caveat" in notes
+        assert "No bright-line rule" in notes["assessment.ratio.caveat"]["text"]
+        assert "25-016" in notes["assessment.ratio.caveat"]["citation"]
+
+
+class TestWhatItRefusesToCompare:
+    def test_the_assessors_own_number_is_not_a_comparand(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The circular comparison. An assessor-sourced valuation against the
+        assessment reports 0.00% over-assessed with a statute attached, and
+        nothing about that looks broken — so the source is refused and the gap
+        NAMES what was on file."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        value(client, property_id, amount="200000.00", source="assessor")
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        assert finding["over_assessed"] is None
+        assert body["market_opinion"] is None
+        (gap,) = [g for g in body["gaps"] if g["reason"] == "no_market_opinion"]
+        assert "assessor" in gap["detail"]
+        assert "never over-assessed" in gap["detail"]
+
+    def test_an_owners_own_estimate_is_not_a_comparand_either(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The number in dispute cannot also be the evidence."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        value(client, property_id, amount="120000.00", source="owner_estimate")
+        body = card(client, property_id)
+        assert body["market_opinion"] is None
+        (gap,) = [g for g in body["gaps"] if g["reason"] == "no_market_opinion"]
+        assert "owner_estimate" in gap["detail"]
+
+    def test_no_valuation_at_all_says_so_differently(self, clean: None, client: TestClient) -> None:
+        """ "Nobody has valued this" and "the only value on file is the one
+        under test" are different sentences."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        body = card(client, property_id)
+        (gap,) = [g for g in body["gaps"] if g["reason"] == "no_market_opinion"]
+        assert "no independent opinion of value is on file" in gap["detail"]
+
+    def test_nothing_recorded_is_a_named_gap(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        body = card(client, property_id)
+        assert body["findings"] == []
+        assert body["tax_year"] is None
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_assessment_on_file"
+
+    def test_a_state_with_no_pack_says_which_state(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client, city="Indianapolis", state="IN", postal="46204")
+        body = card(client, property_id)
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_state_jurisdiction"
+        assert "IN" in gap["detail"]
+
+    def test_an_unknown_property_is_the_only_error_status(
+        self, clean: None, client: TestClient
+    ) -> None:
+        assert client.get(f"/properties/{uuid.uuid4()}/appeal").status_code == 404
+
+
+class TestTheWindowAndTheYearItContests:
+    def test_kentucky_contests_the_same_year(self, clean: None, client: TestClient) -> None:
+        """Kentucky's May inspection period is held on that year's own roll."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00", year=2027)
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        body = card(client, property_id)
+        assert body["window"]["contests_tax_year"] == 2027
+        assert "133.045" in body["window"]["contests_tax_year_citation"]
+        assert body["pairing"] == "contests_this_assessment"
+
+    def test_ohio_contests_the_year_before(self, clean: None, client: TestClient) -> None:
+        """Ohio's complaint is filed in the year FOLLOWING the tax year, so an
+        owner holding a 2026 notice beside a 2027 window is correctly paired
+        — and one holding a 2027 notice is not."""
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        record(client, property_id, basis="market", total="200000.00", year=2026)
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        body = card(client, property_id)
+        assert body["window"]["closes_on"] == "2027-03-31"
+        assert body["window"]["contests_tax_year"] == 2026
+        assert body["pairing"] == "contests_this_assessment"
+
+    def test_a_window_contesting_another_year_says_so(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        record(client, property_id, basis="market", total="200000.00", year=2024)
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        body = card(client, property_id)
+        assert body["window"]["contests_tax_year"] == 2026
+        assert body["pairing"] == "contests_a_different_year"
+
+    def test_tennessee_will_not_claim_which_year_its_window_contests(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Nothing in the Tennessee pack sources the offset, and the
+        authorities it does carry are authorities for the window, not for the
+        year it contests. Unknown is the honest answer."""
+        property_id = make_property(client, city="Nashville", state="TN", postal="37206")
+        record(client, property_id, basis="market", total="200000.00")
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        body = card(client, property_id)
+        assert body["window"] is not None
+        assert body["window"]["contests_tax_year"] is None
+        assert body["pairing"] == "unknown"
+
+    def test_no_window_on_the_calendar_is_a_named_gap(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """The card reads the deadline the sweep wrote rather than resolving a
+        second opinion, so an unswept property says exactly that."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        body = card(client, property_id)
+        assert body["window"] is None
+        assert body["pairing"] == "unknown"
+        (gap,) = [g for g in body["gaps"] if g["reason"] == "no_window_scheduled"]
+        assert "deadline sweep" in gap["detail"]
+
+
+class TestTheComparandIsChosenStably:
+    def test_the_newest_admissible_opinion_wins(self, clean: None, client: TestClient) -> None:
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        value(client, property_id, amount="100000.00", source="avm", as_of="2025-01-01")
+        value(client, property_id, amount="160000.00", source="appraisal", as_of="2026-03-01")
+        body = card(client, property_id)
+        assert Decimal(body["market_opinion"]["value"]) == Decimal("160000.00")
+        assert body["market_opinion"]["age_days"] == 92
+
+    def test_an_opinion_dated_after_the_as_of_is_not_used(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        value(client, property_id, amount="160000.00", source="appraisal", as_of="2026-03-01")
+        value(client, property_id, amount="999000.00", source="appraisal", as_of="2026-12-01")
+        body = card(client, property_id)
+        assert Decimal(body["market_opinion"]["value"]) == Decimal("160000.00")
+
+    def test_two_opinions_on_one_day_resolve_the_same_way_twice(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """created_at is the TRANSACTION timestamp, so a bulk load leaves it
+        identical across rows; without the id tail the winner would be
+        whatever the planner returned, and a percentage that moves when
+        nothing moved gets reported as data corruption."""
+        property_id = make_property(client, city="Newport", state="KY", postal="41071")
+        record(client, property_id, basis="market", total="200000.00")
+        provenance = conn.execute(
+            "INSERT INTO provenance (kind, confidence, source_label)"
+            " VALUES ('market_data', 0.8, 'bulk') RETURNING id"
+        ).fetchone()
+        for amount in ("150000.00", "170000.00", "160000.00"):
+            conn.execute(
+                "INSERT INTO valuations (property_id, as_of, source, value, provenance_id)"
+                " VALUES (%s, '2026-03-01', 'avm', %s, %s)",
+                (property_id, amount, provenance["id"]),
+            )
+        conn.commit()
+        first = card(client, property_id)["market_opinion"]["value"]
+        second = card(client, property_id)["market_opinion"]["value"]
+        assert first == second
+
+
+class TestARatioThatCannotBeUsed:
+    """Sandboxed synthetic packs. jurisdiction_rules is append-only, so a
+    bogus rule planted on a real chain would poison every later test."""
+
+    def _plant(
+        self, conn: psycopg.Connection[Any], state: str, name: str, ratio: str | None
+    ) -> None:
+        if (
+            conn.execute(
+                "SELECT 1 AS x FROM jurisdictions WHERE state = %s AND level = 'state'",
+                (state,),
+            ).fetchone()
+            is None
+        ):
+            conn.execute(
+                """
+                WITH state_row AS (
+                  INSERT INTO jurisdictions (level, name, state, parent_id)
+                  SELECT 'state', %s, %s, id FROM jurisdictions WHERE level = 'federal'
+                  RETURNING id
+                )
+                INSERT INTO jurisdictions (level, name, state, parent_id)
+                SELECT 'municipality', %s, %s, id FROM state_row
+                """,
+                (name, state, f"{name}ville", state),
+            )
+            if ratio is not None:
+                conn.execute(
+                    """
+                    INSERT INTO jurisdiction_rules
+                      (jurisdiction_id, domain, code, value_numeric, citation, effective_from)
+                    SELECT id, 'assessment_ratio', 'assessment.ratio', %s,
+                           'Test Rev. Stat. 1.1 (fixture)', DATE '2000-01-01'
+                    FROM jurisdictions WHERE state = %s AND level = 'state'
+                    """,
+                    (ratio, state),
+                )
+            conn.commit()
+
+    def test_a_taxable_notice_with_no_ratio_is_not_assumed_to_be_one(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The failure mode the Kentucky row existed to prevent: without a
+        seeded ratio, `ratio or 1` would silently be right in Kentucky and
+        wrong by a factor of three in Ohio, and no ratchet catches it because
+        the expression contains no state literal."""
+        self._plant(conn, "QZ", "Quozland", None)
+        property_id = make_property(client, city="Quozlandville", state="QZ", postal="00000")
+        record(client, property_id, basis="taxable", total="70000.00")
+        value(client, property_id, amount="160000.00", source="appraisal")
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        assert finding["ratio"] is None
+        assert finding["implied_market_value"] is None
+        assert finding["over_assessed"] is None
+        (gap,) = finding["gaps"]
+        assert gap["reason"] == "no_rule_for_domain"
+        assert "not assumed to be one" in gap["detail"]
+
+    def test_a_ratio_of_zero_is_refused_rather_than_divided_by(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        self._plant(conn, "QV", "Quovland", "0")
+        property_id = make_property(client, city="Quovlandville", state="QV", postal="00000")
+        record(client, property_id, basis="taxable", total="70000.00")
+        body = card(client, property_id)
+        (finding,) = body["findings"]
+        (gap,) = finding["gaps"]
+        assert gap["reason"] == "unusable_ratio"
+        assert "nothing can be divided by" in gap["detail"]

--- a/services/api/tests/test_coverage.py
+++ b/services/api/tests/test_coverage.py
@@ -52,7 +52,13 @@ def test_the_report_answers_every_domain(
     ltl = covered["domains"]["landlord_tenant_act"]
     assert ltl["status"] == "covered"
     assert ltl["source"] == "Newport"  # the municipal adoption row wins over the state
-    assert covered["domains"]["assessment_ratio"]["status"] == "no_rules_loaded"
+    # Kentucky's 100% ratio is seeded now (seed/950). It was absent for as long
+    # as nothing divided by it, and "obvious" is exactly why it went missing:
+    # Ohio's 35% and Tennessee's 25% were seeded because they surprise.
+    ratio = covered["domains"]["assessment_ratio"]
+    assert ratio["status"] == "covered"
+    assert ratio["source"] == "Kentucky"
+    assert "s.172" in ratio["citation"]
 
     # The enum drives the domain list: every member is answered, none invented.
     enum_domains = {


### PR DESCRIPTION
Closes #9. `GET /properties/{id}/appeal` compares what an assessing body said against an independent opinion of value, converting first only where the notice's own basis calls for it, and naming every question it cannot answer.

## The arithmetic turns on one column, and never on a state

#46's `value_basis` decides whether the ratio applies at all:

| basis | implied market value | ratio |
|---|---|---|
| `market` | the stated total | resolved, **cited, not applied** |
| `taxable` | total ÷ ratio | applied — or a named gap, never an assumed 1.0 |

Kentucky, Ohio and Tennessee travel the same two lines. **The Cincinnati case is why this matters:** a taxable notice of 70,000 asserts the property is worth 200,000. Compared naively against a 160,000 appraisal it reads as **56% *under*-assessed** — the opposite conclusion, on the same paper. Both directions are pinned by tests, including the counterfactual.

A `market` row still carries the ratio, unapplied, with a reason — so a reader can see it was considered and correctly withheld rather than forgotten.

## Tennessee's ambiguity is dissolved, not decided

Tennessee's pack carries **two** numeric ratios (25% residential, 40% commercial) and its own caveat row opens *"No bright-line rule"*. So the ratio resolves by **arity**: one numeric rule is an answer, two is a question. Tennessee gaps with `ambiguous_ratio` naming both candidates.

No code name is dispatched on and no state literal exists — which matters, because choosing in code would be the ADR 0003 failure mode that `check_state_literals.sh` provably *cannot* catch.

## The comparand is a whitelist

Only `appraisal`, `broker_opinion`, `comparable_sales`, `avm`.

- **`assessor`** — is the assessment. Compared against itself it reports **0.00% over-assessed with a statute attached**, and nothing about that looks broken.
- **`purchase_price`** — one transaction on one day, stale by construction.
- **`owner_estimate`** — the owner's own number, in the one proceeding where it is the number in dispute.

A whitelist, not a blacklist: a ninth `valuation_source` added later is inadmissible until somebody decides it belongs. When nothing admissible is on file, the gap **names what was** — "the only values on file come from assessor" is a different sentence from "nobody has valued this."

## No threshold, anywhere

Every numeric threshold in this repository traces to a named authority. No jurisdiction publishes a materiality figure for appeals, so the card states the gap between two numbers and refuses to decide whether it is worth a filing fee. `over_assessed` is the sign of a subtraction, nothing more.

## The window is read, not re-derived

The sweep is the sole authority on which of the three window shapes governs. A second resolver here could disagree with the calendar the owner is already looking at, so the card reads the deadline row and adds only the paperwork the sweep does not carry.

## Seeds

**`950` — Kentucky's ratio.** Missing because it is obvious, and an obvious fact that lives nowhere is the one a reader supplies from memory. Seeded as **transcription, not inference**: KRS 132.191(1) states *"one hundred percent (100%)"* in words. Carries *Russman v. Luckett*, 391 S.W.2d 694 (Ky. 1965), which ended Kentucky's fractional assessment at a statewide median ratio of 27% — verified still good law, and the 1965 special session's rollback changed **rates**, not the standard.

The seed also records three numbers that look like a ratio and are not: the **90% ratio-*study* band** (county compliance policy from a DOR manual — it would understate every Kentucky assessment by seven percent), **agricultural use value** (a different definition of value), and the **homestead exemption** (a subtraction).

**`951` — `appeal.contests_tax_year_offset`.** The window's calendar year is not the tax year it contests: Kentucky 0, Ohio −1, Tennessee **deliberately unseeded** and reported as `unknown`. That sentence lived in two docstrings where no read model could reach it. Also Kentucky's appeal form (62F031, with 62A307 the conference record attached, neither mandatory — the statute accepts a letter).

## Found on the way, filed not fixed

- **#97** — Ohio's `appeal.instructions` states "January 1 to March 31" citing ORC 5715.19(A). January 1 is not in that section, and March 31 is not the flat deadline (it is that *or* the close of first-half collection, whichever is later). The emitted date errs safe, but the citation overstates. Correcting an applied pack needs the supersede drill, which is #7.
- **`reports.financials`** selects the latest valuation with **neither a source filter nor a stable tie-break**, so the hold/sell and coinsurance cards may already be reading the assessor's own number as "the valuation". Not this ticket's to fix; noted for the handoff.

## Gates

- schema verified, **247** seeded rules, kentucky pack at 7 checks
- `services/api` — **335** passed at 100% line and branch
- `services/sim`, `services/ingest` — 100%
- `pnpm run verify` green; ruff, state-literal ratchet, config audit, regenerated contract — clean
