### PR TITLE
The state rate leaves the profile, because it never belonged there

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -399,6 +399,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/entities/{entity_id}/tax-rates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Entity Tax Rates
+         * @description The cross-river case: one entity, each property answering from its own
+         *     chain. Nothing is aggregated — an entity owning across a state line is
+         *     reached by more than one government, and no single rate is true of it.
+         */
+        get: operations["entity_tax_rates_entities__entity_id__tax_rates_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/healthz": {
         parameters: {
             query?: never;
@@ -757,6 +779,30 @@ export interface paths {
         };
         /** Schedule E Report */
         get: operations["schedule_e_report_properties__property_id__reports_schedule_e_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/properties/{property_id}/tax-rates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Property Tax Rates
+         * @description Every taxing body that reaches this property, and what each levies.
+         *
+         *     tax_year is required and has no default: a rate is a fact about a year,
+         *     and defaulting to today's would silently answer a different question than
+         *     the one a filing asks.
+         */
+        get: operations["property_tax_rates_properties__property_id__tax_rates_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1404,6 +1450,26 @@ export interface components {
             nickname: string;
             /** Property Id */
             property_id?: string | null;
+        };
+        /**
+         * BodyRateOut
+         * @description One taxing body's rate, with the body's own authority.
+         */
+        BodyRateOut: {
+            /** Citation */
+            citation: string;
+            /** Code */
+            code: string;
+            /** Depth */
+            depth: number;
+            /** Jurisdiction */
+            jurisdiction: string;
+            /** Jurisdiction Id */
+            jurisdiction_id: string;
+            /** Level */
+            level: string;
+            /** Rate */
+            rate: string;
         };
         /** Body_import_bank_statement_bank_accounts__account_id__imports_post */
         Body_import_bank_statement_bank_accounts__account_id__imports_post: {
@@ -2144,6 +2210,26 @@ export interface components {
             /** Name */
             name: string;
         };
+        /**
+         * EntityTaxRates
+         * @description Every property this entity owns, each resolving its own chain.
+         *
+         *     This is issue #8's first acceptance clause as the schema can honestly meet
+         *     it. The entity carries no rates — an entity has no situs, and
+         *     entities.formation_state is explicitly not one. Its PROPERTIES carry them,
+         *     and this is the union, unaggregated: no combined rate, no apportionment,
+         *     no total.
+         */
+        EntityTaxRates: {
+            /** Entity */
+            entity: string;
+            /** Entity Id */
+            entity_id: string;
+            /** Properties */
+            properties: components["schemas"]["PropertyTaxRates"][];
+            /** Tax Year */
+            tax_year: number;
+        };
         /** ExcludedAmount */
         ExcludedAmount: {
             /** Amount */
@@ -2762,6 +2848,47 @@ export interface components {
             /** Year Built */
             year_built: number | null;
         };
+        /** PropertyTaxRates */
+        PropertyTaxRates: {
+            /**
+             * As Of
+             * Format: date
+             */
+            as_of: string;
+            /** Disposed On */
+            disposed_on: string | null;
+            /** Gaps */
+            gaps: components["schemas"]["RateGap"][];
+            /** Label */
+            label: string;
+            /** Notes */
+            notes: components["schemas"]["RuleNoteOut"][];
+            /** Property Id */
+            property_id: string;
+            /** Rates */
+            rates: components["schemas"]["BodyRateOut"][];
+            /** State */
+            state: string;
+            /** Tax Year */
+            tax_year: number;
+        };
+        /**
+         * RateGap
+         * @description A question this chain cannot answer. Named, never defaulted.
+         *
+         *     Field-identical to appeal.AppealGap and deposit.GapOut and deliberately
+         *     NOT shared, for the reason the appeal card's own docstring gives: two
+         *     classes with one name make FastAPI qualify both and rename the very
+         *     schema the separation protects. Named differently instead.
+         */
+        RateGap: {
+            /** Code */
+            code: string;
+            /** Detail */
+            detail: string;
+            /** Reason */
+            reason: string;
+        };
         /**
          * RatioOut
          * @description The pack's ratio, and whether this row's BASIS called for it.
@@ -2968,6 +3095,32 @@ export interface components {
             field_path: string;
             /** Value */
             value?: string | null;
+        };
+        /**
+         * RuleNoteOut
+         * @description Everything else the domain carries at a body, whole and unparsed.
+         *
+         *     Number AND words: income.entity_excise_rate states 0.065 in value_numeric
+         *     and its subject in value_text, and a note dropping either half would be
+         *     lossy. Not parsed — the pack's leading-token convention already has two
+         *     implementations that must agree, and a third would be a third place to
+         *     disagree. This prints what the pack wrote.
+         */
+        RuleNoteOut: {
+            /** Citation */
+            citation: string;
+            /** Code */
+            code: string;
+            /** Depth */
+            depth: number;
+            /** Jurisdiction */
+            jurisdiction: string;
+            /** Level */
+            level: string;
+            /** Text */
+            text: string | null;
+            /** Value */
+            value: string | null;
         };
         /**
          * RuleTextOut
@@ -4416,6 +4569,39 @@ export interface operations {
             };
         };
     };
+    entity_tax_rates_entities__entity_id__tax_rates_get: {
+        parameters: {
+            query: {
+                tax_year: number;
+            };
+            header?: never;
+            path: {
+                entity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EntityTaxRates"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     healthz_healthz_get: {
         parameters: {
             query?: never;
@@ -5209,6 +5395,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ScheduleEReport"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    property_tax_rates_properties__property_id__tax_rates_get: {
+        parameters: {
+            query: {
+                tax_year: number;
+            };
+            header?: never;
+            path: {
+                property_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PropertyTaxRates"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -868,6 +868,51 @@
         "title": "BankAccountOut",
         "type": "object"
       },
+      "BodyRateOut": {
+        "description": "One taxing body's rate, with the body's own authority.",
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "depth": {
+            "title": "Depth",
+            "type": "integer"
+          },
+          "jurisdiction": {
+            "title": "Jurisdiction",
+            "type": "string"
+          },
+          "jurisdiction_id": {
+            "title": "Jurisdiction Id",
+            "type": "string"
+          },
+          "level": {
+            "title": "Level",
+            "type": "string"
+          },
+          "rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Rate",
+            "type": "string"
+          }
+        },
+        "required": [
+          "jurisdiction_id",
+          "jurisdiction",
+          "level",
+          "depth",
+          "code",
+          "rate",
+          "citation"
+        ],
+        "title": "BodyRateOut",
+        "type": "object"
+      },
       "Body_import_bank_statement_bank_accounts__account_id__imports_post": {
         "properties": {
           "file": {
@@ -3308,6 +3353,38 @@
         "title": "EntityOut",
         "type": "object"
       },
+      "EntityTaxRates": {
+        "description": "Every property this entity owns, each resolving its own chain.\n\nThis is issue #8's first acceptance clause as the schema can honestly meet\nit. The entity carries no rates \u2014 an entity has no situs, and\nentities.formation_state is explicitly not one. Its PROPERTIES carry them,\nand this is the union, unaggregated: no combined rate, no apportionment,\nno total.",
+        "properties": {
+          "entity": {
+            "title": "Entity",
+            "type": "string"
+          },
+          "entity_id": {
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "properties": {
+            "items": {
+              "$ref": "#/components/schemas/PropertyTaxRates"
+            },
+            "title": "Properties",
+            "type": "array"
+          },
+          "tax_year": {
+            "title": "Tax Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "entity_id",
+          "entity",
+          "tax_year",
+          "properties"
+        ],
+        "title": "EntityTaxRates",
+        "type": "object"
+      },
       "ExcludedAmount": {
         "properties": {
           "amount": {
@@ -5262,6 +5339,101 @@
         "title": "PropertySummary",
         "type": "object"
       },
+      "PropertyTaxRates": {
+        "properties": {
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "disposed_on": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disposed On"
+          },
+          "gaps": {
+            "items": {
+              "$ref": "#/components/schemas/RateGap"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/components/schemas/RuleNoteOut"
+            },
+            "title": "Notes",
+            "type": "array"
+          },
+          "property_id": {
+            "title": "Property Id",
+            "type": "string"
+          },
+          "rates": {
+            "items": {
+              "$ref": "#/components/schemas/BodyRateOut"
+            },
+            "title": "Rates",
+            "type": "array"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "tax_year": {
+            "title": "Tax Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "property_id",
+          "label",
+          "state",
+          "tax_year",
+          "as_of",
+          "disposed_on",
+          "rates",
+          "notes",
+          "gaps"
+        ],
+        "title": "PropertyTaxRates",
+        "type": "object"
+      },
+      "RateGap": {
+        "description": "A question this chain cannot answer. Named, never defaulted.\n\nField-identical to appeal.AppealGap and deposit.GapOut and deliberately\nNOT shared, for the reason the appeal card's own docstring gives: two\nclasses with one name make FastAPI qualify both and rename the very\nschema the separation protects. Named differently instead.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "reason",
+          "detail"
+        ],
+        "title": "RateGap",
+        "type": "object"
+      },
       "RatioOut": {
         "description": "The pack's ratio, and whether this row's BASIS called for it.",
         "properties": {
@@ -5944,6 +6116,65 @@
           "field_path"
         ],
         "title": "ReviewIn",
+        "type": "object"
+      },
+      "RuleNoteOut": {
+        "description": "Everything else the domain carries at a body, whole and unparsed.\n\nNumber AND words: income.entity_excise_rate states 0.065 in value_numeric\nand its subject in value_text, and a note dropping either half would be\nlossy. Not parsed \u2014 the pack's leading-token convention already has two\nimplementations that must agree, and a third would be a third place to\ndisagree. This prints what the pack wrote.",
+        "properties": {
+          "citation": {
+            "title": "Citation",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "depth": {
+            "title": "Depth",
+            "type": "integer"
+          },
+          "jurisdiction": {
+            "title": "Jurisdiction",
+            "type": "string"
+          },
+          "level": {
+            "title": "Level",
+            "type": "string"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "jurisdiction",
+          "level",
+          "depth",
+          "code",
+          "value",
+          "text",
+          "citation"
+        ],
+        "title": "RuleNoteOut",
         "type": "object"
       },
       "RuleTextOut": {
@@ -9173,6 +9404,58 @@
         "summary": "Create Entity"
       }
     },
+    "/entities/{entity_id}/tax-rates": {
+      "get": {
+        "description": "The cross-river case: one entity, each property answering from its own\nchain. Nothing is aggregated \u2014 an entity owning across a state line is\nreached by more than one government, and no single rate is true of it.",
+        "operationId": "entity_tax_rates_entities__entity_id__tax_rates_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entity_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Entity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tax_year",
+            "required": true,
+            "schema": {
+              "maximum": 2200,
+              "minimum": 1990,
+              "title": "Tax Year",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityTaxRates"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Entity Tax Rates"
+      }
+    },
     "/healthz": {
       "get": {
         "operationId": "healthz_healthz_get",
@@ -10462,6 +10745,58 @@
           }
         },
         "summary": "Schedule E Report"
+      }
+    },
+    "/properties/{property_id}/tax-rates": {
+      "get": {
+        "description": "Every taxing body that reaches this property, and what each levies.\n\ntax_year is required and has no default: a rate is a fact about a year,\nand defaulting to today's would silently answer a different question than\nthe one a filing asks.",
+        "operationId": "property_tax_rates_properties__property_id__tax_rates_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Property Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tax_year",
+            "required": true,
+            "schema": {
+              "maximum": 2200,
+              "minimum": 1990,
+              "title": "Tax Year",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PropertyTaxRates"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Property Tax Rates"
       }
     },
     "/readyz": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -18,3 +18,4 @@
 \ir 017_replacement_history.sql
 \ir 018_screening.sql
 \ir 019_assessment_records.sql
+\ir 020_income_tax_rates_leave_the_profile.sql

--- a/packages/domain/schema/020_income_tax_rates_leave_the_profile.sql
+++ b/packages/domain/schema/020_income_tax_rates_leave_the_profile.sql
@@ -1,0 +1,84 @@
+-- ===========================================================================
+--  020 — The state rate leaves the profile, because it never belonged there.
+--
+--  Module 008 gave tax_profiles one state_marginal_rate per entity per year.
+--  A single LLC owning in Newport and in Cincinnati is reached by Kentucky,
+--  by Ohio and by the city of Cincinnati, and one column could name only one
+--  of them — which is the defect issue #8 opened against.
+--
+--  The fix is not a wider key. It is that the number was already in the
+--  packs. Kentucky's rate has sat in jurisdiction_rules since the pack
+--  shipped — domain income_tax, code income.flat_rate, 0.035, citing
+--  "KRS 141.020 (as amended; 3.5% effective for tax year 2026)" — and
+--  Cincinnati's municipal rate sits beside it at 0.018 under ORC ch. 718.
+--  Neither is a fact about a taxpayer: nobody chose them, and no two
+--  taxpayers on one street have different ones. ADR 0003 says in so many
+--  words that a cited statutory number is data, resolved through
+--  jurisdiction_chain().
+--
+--  A second, entity-side copy keyed by jurisdiction_id would be a THIRD copy
+--  of KRS 141.020's rate — the seed, tests/constraints.sql, and now the
+--  profile — and the ADR's own convention, that three copies are acceptable
+--  only because CI fails when any copy moves alone, has no job comparing
+--  them. Worse, that copy would carry no state literal, so
+--  scripts/check_state_literals.sh would stay green while the rule it exists
+--  to protect was being broken.
+--
+--  So this module SUBTRACTS, and the reader ships beside it:
+--  GET /properties/{id}/tax-rates walks the property's own chain and answers
+--  per taxing body, each with that body's own citation, or names a gap.
+--
+--  WHY A DROP IS LEGAL HERE. The applied-once rule polices FILE TEXT through
+--  the sha256 recorded in schema_migrations. Module 008's bytes are
+--  untouched and its checksum still matches; this is a new file applied
+--  forward-only. Module 019 already did the harder version of this to a
+--  module-004 table, dropping a shipped unique constraint and adding a NOT
+--  NULL column with no default.
+--
+--  WHY THE DROP IS SAFE, as evidence rather than assumption. tax_profiles
+--  has never had a writer OR a reader: across the repository the table
+--  appears only in 008 itself, a cross-reference comment in 019's header,
+--  the manifest line, four assertions in tests/constraints.sql, and
+--  conftest's clean list. `state_marginal_rate` appears in exactly two
+--  places: its declaration and one constraint assertion. There are no rows
+--  anywhere to discard, and one test to fix.
+--
+--  Keeping the column was the weaker option. It is a second place a state
+--  rate can live, one of them structurally unable to say WHICH state it
+--  means, and the first reader to pick the wrong one prints a Kentucky
+--  number on an Ohio card with a citation attached.
+-- ===========================================================================
+
+ALTER TABLE tax_profiles DROP COLUMN state_marginal_rate;
+
+-- `capital_gains_rate` named neither a government nor a schedule. It could
+-- honestly have meant the federal 0/15/20 brackets (which is NOT
+-- federal_marginal_rate), a state rate, or somebody's blend of the two — and
+-- the blend is the reading that silently double-counts state tax in the
+-- disposal counterfactual this ticket was opened to unblock. Renamed rather
+-- than merely commented, because a comment is not in the query text the next
+-- reader writes. Free to rename: it has no reader in the repository.
+ALTER TABLE tax_profiles RENAME COLUMN capital_gains_rate TO federal_capital_gains_rate;
+
+COMMENT ON TABLE tax_profiles IS
+  'One row per entity per filing year, carrying the facts that are true of '
+  'the taxpayer wherever it owns: how it is taxed, its filing status, its '
+  'MAGI, its federal rates. What is NOT here is any rate belonging to a '
+  'particular government. Those are jurisdiction data (ADR 0003), cited to a '
+  'statute, resolved through jurisdiction_chain() from the property that '
+  'sourced the income — because an entity owning across a state line is '
+  'reached by more than one government, and a column cannot say which.';
+
+COMMENT ON COLUMN tax_profiles.federal_marginal_rate IS
+  'The taxpayer''s top federal bracket rate — half statute (IRC s.1) and half '
+  'this taxpayer''s own income, which is why it is an estimate carried with '
+  'provenance rather than a pack row. State and local rates are NOT here: '
+  'they resolve from jurisdiction_rules through the property''s own chain, '
+  'per taxing body, in hestia_api/income_tax.py.';
+
+COMMENT ON COLUMN tax_profiles.federal_capital_gains_rate IS
+  'The federal long-term rate — one of the 0/15/20 brackets, a different '
+  'schedule from federal_marginal_rate and not derivable from it. The 3.8 '
+  'percent net investment income tax (IRC s.1411) is a fourth number again '
+  'and is NOT modelled here; a reader must not fold it in. Nothing state or '
+  'local belongs in this column.';

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -744,10 +744,29 @@ END $$;
 \echo 'tax profiles, elections, disclosures'
 SELECT assert_accepted(
   $$INSERT INTO tax_profiles (entity_id, tax_year, treatment, filing_status,
-      magi_estimate, federal_marginal_rate, state_marginal_rate)
+      magi_estimate, federal_marginal_rate, federal_capital_gains_rate)
     VALUES ('11111111-1111-1111-1111-111111111111', 2026, 'disregarded',
-            'married_filing_jointly', 165000, 0.32, 0.035)$$,
-  'a profile carrying the rates every tax card must cite');
+            'married_filing_jointly', 165000, 0.32, 0.15)$$,
+  'a profile carrying the FEDERAL rates, which are all a profile may carry');
+-- The subtraction module 020 made, asserted as an effect rather than assumed.
+-- The old assertion here carried state_marginal_rate 0.035 — the same figure
+-- as Kentucky's own pack row for the same year, in a second place, with no
+-- job comparing them. A rate belonging to a government now has exactly one
+-- home, and an INSERT naming the old column fails to parse rather than
+-- quietly writing a number no reader can attribute to a state.
+DO $$
+BEGIN
+  BEGIN
+    EXECUTE $q$INSERT INTO tax_profiles (entity_id, tax_year, treatment,
+                                         state_marginal_rate)
+               VALUES ('11111111-1111-1111-1111-111111111111', 2029,
+                       'disregarded', 0.035)$q$;
+    RAISE EXCEPTION 'COLUMN STILL PRESENT: a state rate can be written to a '
+      'profile again, where nothing can say which state it means';
+  EXCEPTION WHEN undefined_column THEN
+    RAISE NOTICE '  ok      a state rate has no home on an entity profile';
+  END;
+END $$;
 SELECT assert_rejected(
   $$INSERT INTO tax_profiles (entity_id, tax_year, treatment)
     VALUES ('11111111-1111-1111-1111-111111111111', 2026, 'partnership')$$,

--- a/packages/domain/schema/tests/packs/kentucky.sql
+++ b/packages/domain/schema/tests/packs/kentucky.sql
@@ -23,6 +23,8 @@ DECLARE
   phaseout NUMERIC;
   ratio NUMERIC;
   ratio_citation TEXT;
+  income_rate NUMERIC;
+  income_citation TEXT;
   distinct_ratios INT;
 BEGIN
   -- The load-bearing URLTA contrast: one street across the Newport line is a
@@ -133,4 +135,26 @@ BEGIN
     RAISE EXCEPTION 'expected three distinct assessment ratios, found %', distinct_ratios;
   END IF;
   RAISE NOTICE '  ok      100, 35 and 25 percent: three states, three ratios';
+
+  -- The income_tax domain had no pin in any pack test until #8 gave it a
+  -- reader. Until module 020 this same figure also sat in a tax_profiles
+  -- assertion in tests/constraints.sql, where nothing compared the two; the
+  -- rate now has one home and this is the assertion that keeps it there.
+  SELECT r.value_numeric, r.citation INTO income_rate, income_citation
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND r.code = 'income.flat_rate' AND r.superseded_by IS NULL;
+  IF income_rate IS DISTINCT FROM 0.035000::NUMERIC THEN
+    RAISE EXCEPTION 'Kentucky income tax is %, expected 0.035', income_rate;
+  END IF;
+  IF income_citation NOT LIKE '%141.020%' THEN
+    RAISE EXCEPTION 'the Kentucky income rate does not cite KRS 141.020: %',
+      income_citation;
+  END IF;
+  -- A rate, not a percentage. jurisdiction_rules.value_numeric carries no
+  -- unit, so 3.5 and 0.035 are equally storable and differ by a hundredfold.
+  IF income_rate >= 1 THEN
+    RAISE EXCEPTION 'the Kentucky income rate is stored in percent form: %',
+      income_rate;
+  END IF;
+  RAISE NOTICE '  ok      Kentucky taxes income at 3.5 percent, stored as a rate';
 END $$;

--- a/packages/domain/schema/tests/packs/ohio.sql
+++ b/packages/domain/schema/tests/packs/ohio.sql
@@ -22,6 +22,7 @@ DECLARE
   ky_key TEXT;
   ky_citation TEXT;
   oh_citation TEXT;
+  municipal NUMERIC;
 BEGIN
   -- Cincinnati -> Hamilton County -> Ohio -> United States.
   SELECT count(*) INTO chain_len
@@ -97,4 +98,33 @@ BEGIN
     RAISE EXCEPTION 'Newport resolves %, expected us-ky.open-inspection', ky_key;
   END IF;
   RAISE NOTICE '  ok      one bridge, two regimes: Newport and Cincinnati diverge';
+
+  -- TWO GOVERNMENTS, ONE DOLLAR. Kentucky's chain answers income tax once;
+  -- Cincinnati's answers at the city while the state row states no rate at
+  -- all. A reader that collapsed the chain to one winner per code — which is
+  -- right for an appeal window, where one body governs — would drop whichever
+  -- of these lost, so the shape is pinned here rather than only in the API.
+  IF (SELECT count(*) FROM jurisdiction_chain(
+        (SELECT id FROM jurisdictions WHERE name = 'Cincinnati'
+          AND level = 'municipality')) c
+      JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+      WHERE r.domain = 'income_tax' AND r.superseded_by IS NULL) < 2 THEN
+    RAISE EXCEPTION 'the Cincinnati chain carries fewer than two income_tax rows';
+  END IF;
+  SELECT r.value_numeric INTO municipal
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Cincinnati' AND r.code = 'income.municipal_rate'
+    AND r.superseded_by IS NULL;
+  IF municipal IS DISTINCT FROM 0.018000::NUMERIC THEN
+    RAISE EXCEPTION 'Cincinnati municipal income tax is %, expected 0.018', municipal;
+  END IF;
+  -- Ohio's own state row states a KIND and no number, on purpose. A reader
+  -- that treated it as a rate would be inventing one.
+  IF (SELECT r.value_numeric FROM jurisdiction_rules r
+      JOIN jurisdictions j ON j.id = r.jurisdiction_id
+      WHERE j.name = 'Ohio' AND r.code = 'income.type'
+        AND r.superseded_by IS NULL) IS NOT NULL THEN
+    RAISE EXCEPTION 'the Ohio income.type row carries a number; it states a kind';
+  END IF;
+  RAISE NOTICE '  ok      two governments tax one Cincinnati dollar, and only one states a rate';
 END $$;

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -42,6 +42,7 @@ from hestia_api import (
     deposit,
     documents,
     dossier,
+    income_tax,
     jurisdiction,
     ledger,
     maintenance,
@@ -903,6 +904,36 @@ def cash_flow_report(
 @app.get("/reports/rent-roll", response_model=list[reports.RentRollRow])
 def rent_roll_report(conn: Conn) -> list[reports.RentRollRow]:
     return reports.rent_roll(conn)
+
+
+@app.get("/properties/{property_id}/tax-rates", response_model=income_tax.PropertyTaxRates)
+def property_tax_rates(
+    property_id: uuid.UUID,
+    conn: Conn,
+    tax_year: Annotated[int, Query(ge=1990, le=2200)],
+) -> income_tax.PropertyTaxRates:
+    """Every taxing body that reaches this property, and what each levies.
+
+    tax_year is required and has no default: a rate is a fact about a year,
+    and defaulting to today's would silently answer a different question than
+    the one a filing asks."""
+    _require_property(conn, property_id)
+    return income_tax.for_property(conn, str(property_id), tax_year=tax_year)
+
+
+@app.get("/entities/{entity_id}/tax-rates", response_model=income_tax.EntityTaxRates)
+def entity_tax_rates(
+    entity_id: uuid.UUID,
+    conn: Conn,
+    tax_year: Annotated[int, Query(ge=1990, le=2200)],
+) -> income_tax.EntityTaxRates:
+    """The cross-river case: one entity, each property answering from its own
+    chain. Nothing is aggregated — an entity owning across a state line is
+    reached by more than one government, and no single rate is true of it."""
+    try:
+        return income_tax.for_entity(conn, str(entity_id), tax_year=tax_year)
+    except income_tax.UnknownEntity as error:
+        raise HTTPException(status_code=404, detail="entity not found") from error
 
 
 @app.get("/properties/{property_id}/appeal", response_model=appeal.AppealCase)

--- a/services/api/hestia_api/income_tax.py
+++ b/services/api/hestia_api/income_tax.py
@@ -1,0 +1,304 @@
+"""The income-tax rates a property's own chain resolves, per taxing body.
+
+Issue #8 asked for a per-jurisdiction state rate on tax_profiles. The rate was
+already in the packs — Kentucky's flat 3.5% has cited KRS 141.020 since the
+pack shipped, Cincinnati's 1.8% cites ORC ch. 718 — so what ships here is the
+reader that was missing, and module 020 removed the entity-side column that
+would have become a second place for the same number to live. ADR 0003: a
+cited statutory number is jurisdiction data, resolved through
+jurisdiction_chain(), never copied into a taxpayer's row.
+
+TWO THINGS THIS DOES DIFFERENTLY FROM appeal._rules, both deliberate.
+
+Resolution is PER BODY, not collapsed across the chain. The appeal card takes
+one winner per code over the whole chain because exactly one appeal window
+governs. Income tax is levied by more than one government at once — Kentucky
+at the state and Cincinnati at the city, both owed, on the same dollar — and
+collapsing would silently drop whichever body lost. The ordering WITHIN a body
+is the shared one, so no reader disagrees with another about which ROW wins;
+they differ only in how many BODIES answer, which is the fact being measured.
+
+The as-of date is derived from the tax year and never from the clock:
+December 31 of the year asked for, because an income tax is a full-year
+measure applied on a return filed after the year closes. The appeal card
+anchors its ratio at January 1 of the assessed year, which is the lien date —
+a different fact with a different anchor, not a drift from this one. A card
+for 2026 must read the same in 2029.
+
+NOTHING IS SUMMED, and no combined rate is published. Whether a municipal rate
+stacks on a state rate, is deductible against it, or is credited by the state
+of residence is a governance fact; Ohio's own reciprocity and residence-credit
+rules differ by municipality and no pack states any of it. This lists bodies.
+And nothing here is after-tax anything: Schedule E computes taxable rental
+income and is deliberately untouched, the rate applying downstream.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from pydantic import BaseModel
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+DOMAIN = "income_tax"
+
+# Which income_tax codes state a RATE this card may present as one. A
+# whitelist and not a blacklist, on the appeal card's reasoning: a code seeded
+# later is carried as a note until somebody decides it belongs, which is the
+# safe direction. A domain constant rather than pack data — the code
+# vocabulary is the packs' shared language and means the same thing in all
+# fifty states, so fifty identical rows would only create fifty chances for
+# one of them to disagree.
+#
+#   income.flat_rate      — a state taxing at one rate (Kentucky, KRS 141.020)
+#   income.municipal_rate — a city levying its own (Cincinnati, ORC ch. 718)
+#
+# INADMISSIBLE, each for a stated reason, and each still carried verbatim in
+# `notes` so nothing is dropped:
+#
+#   income.entity_excise_rate, income.entity_franchise_rate — a different
+#     taxpayer's tax. Tennessee's own seed says so in the file: the entity
+#     "still meets the franchise and excise taxes, which is a different
+#     question from the owner's own return".
+#   income.entity_franchise_minimum — 100 is one hundred DOLLARS.
+#     jurisdiction_rules.value_numeric carries no unit, the code name is the
+#     only thing that says which figures are rates, and a card that treated
+#     this one as a rate would be off by a factor of a hundred.
+#   income.type, income.entity_exemption — prose. They carry no number.
+ADMISSIBLE_RATE_CODES = ("income.flat_rate", "income.municipal_rate")
+
+
+class UnknownEntity(Exception):
+    """No such entity."""
+
+
+class RateGap(BaseModel):
+    """A question this chain cannot answer. Named, never defaulted.
+
+    Field-identical to appeal.AppealGap and deposit.GapOut and deliberately
+    NOT shared, for the reason the appeal card's own docstring gives: two
+    classes with one name make FastAPI qualify both and rename the very
+    schema the separation protects. Named differently instead.
+    """
+
+    code: str
+    reason: str
+    detail: str
+
+
+class BodyRateOut(BaseModel):
+    """One taxing body's rate, with the body's own authority."""
+
+    jurisdiction_id: str
+    jurisdiction: str
+    level: str
+    # Depth 0 is the property's own most specific body. Published so a reader
+    # can see WHY two rates are both owed rather than one overriding the other.
+    depth: int
+    code: str
+    rate: Decimal
+    citation: str
+
+
+class RuleNoteOut(BaseModel):
+    """Everything else the domain carries at a body, whole and unparsed.
+
+    Number AND words: income.entity_excise_rate states 0.065 in value_numeric
+    and its subject in value_text, and a note dropping either half would be
+    lossy. Not parsed — the pack's leading-token convention already has two
+    implementations that must agree, and a third would be a third place to
+    disagree. This prints what the pack wrote.
+    """
+
+    jurisdiction: str
+    level: str
+    depth: int
+    code: str
+    value: Decimal | None
+    text: str | None
+    citation: str
+
+
+class PropertyTaxRates(BaseModel):
+    property_id: str
+    label: str
+    state: str
+    tax_year: int
+    as_of: dt.date
+    # Carried, not filtered on: an entity that sold its Ohio property in the
+    # filing year still owes Ohio on the gain, and the disposal year is
+    # precisely when the rate matters. The coverage report excludes disposed
+    # properties because a deadline for a sold house is noise; a rate for the
+    # year it sold is not.
+    disposed_on: dt.date | None
+    rates: list[BodyRateOut]
+    notes: list[RuleNoteOut]
+    gaps: list[RateGap]
+
+
+class EntityTaxRates(BaseModel):
+    """Every property this entity owns, each resolving its own chain.
+
+    This is issue #8's first acceptance clause as the schema can honestly meet
+    it. The entity carries no rates — an entity has no situs, and
+    entities.formation_state is explicitly not one. Its PROPERTIES carry them,
+    and this is the union, unaggregated: no combined rate, no apportionment,
+    no total.
+    """
+
+    entity_id: str
+    entity: str
+    tax_year: int
+    properties: list[PropertyTaxRates]
+
+
+ANCHOR_SQL = """
+SELECT p.id::text AS property_id, p.label, p.state, p.disposed_on,
+       COALESCE(p.jurisdiction_id, s.id) AS start_id
+FROM properties p
+LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+WHERE p.id = %(property_id)s
+"""
+
+# One winner per (BODY, code) — not per code across the chain.
+RULES_SQL = """
+SELECT resolved.* FROM (
+  SELECT DISTINCT ON (c.jurisdiction_id, r.code)
+         c.depth,
+         j.id::text    AS jurisdiction_id,
+         j.name        AS jurisdiction,
+         j.level::text AS level,
+         r.code, r.value_numeric, r.value_text, r.citation
+  FROM jurisdiction_chain(%(start_id)s) c
+  JOIN jurisdictions j ON j.id = c.jurisdiction_id
+  JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+  WHERE r.domain = %(domain)s
+    AND r.superseded_by IS NULL
+    AND r.effective_from <= %(as_of)s
+    AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+  -- The id tail is not decoration. jurisdiction_rules has no uniqueness
+  -- constraint covering same-day corrections, so two rows can share an
+  -- effective_from and would otherwise be ordered by whatever the planner
+  -- returned. A rate that changes when nothing changed gets reported as data
+  -- corruption.
+  ORDER BY c.jurisdiction_id, r.code, r.effective_from DESC, r.id DESC
+) resolved
+ORDER BY resolved.depth ASC, resolved.code
+"""
+
+ENTITY_SQL = "SELECT name FROM entities WHERE id = %(entity_id)s"
+
+ENTITY_PROPERTIES_SQL = """
+SELECT id::text AS property_id FROM properties
+WHERE entity_id = %(entity_id)s
+ORDER BY created_at, id
+"""
+
+
+def for_property(conn: Conn, property_id: str, *, tax_year: int) -> PropertyTaxRates:
+    """Every taxing body that reaches this property, and what each levies."""
+    # December 31: an income tax is a full-year measure, so the year decides
+    # the as-of and the clock never does. A 2026 card reads the same in 2029.
+    as_of = dt.date(tax_year, 12, 31)
+    anchor = conn.execute(ANCHOR_SQL, {"property_id": property_id}).fetchone()
+    assert anchor is not None  # the endpoint has already proven it exists
+    empty = PropertyTaxRates(
+        property_id=property_id,
+        label=anchor["label"],
+        state=anchor["state"],
+        tax_year=tax_year,
+        as_of=as_of,
+        disposed_on=anchor["disposed_on"],
+        rates=[],
+        notes=[],
+        gaps=[],
+    )
+    if anchor["start_id"] is None:
+        empty.gaps.append(
+            RateGap(
+                code="jurisdiction",
+                reason="no_state_jurisdiction",
+                detail=f"no jurisdiction pack is loaded for {anchor['state']}",
+            )
+        )
+        return empty
+
+    rows = conn.execute(
+        RULES_SQL, {"start_id": anchor["start_id"], "domain": DOMAIN, "as_of": as_of}
+    ).fetchall()
+    rates = [
+        BodyRateOut(
+            jurisdiction_id=row["jurisdiction_id"],
+            jurisdiction=row["jurisdiction"],
+            level=row["level"],
+            depth=row["depth"],
+            code=row["code"],
+            rate=row["value_numeric"],
+            citation=row["citation"],
+        )
+        for row in rows
+        if row["code"] in ADMISSIBLE_RATE_CODES and row["value_numeric"] is not None
+    ]
+    notes = [
+        RuleNoteOut(
+            jurisdiction=row["jurisdiction"],
+            level=row["level"],
+            depth=row["depth"],
+            code=row["code"],
+            value=row["value_numeric"],
+            text=row["value_text"],
+            citation=row["citation"],
+        )
+        for row in rows
+        if row["code"] not in ADMISSIBLE_RATE_CODES or row["value_numeric"] is None
+    ]
+    gaps: list[RateGap] = []
+    if not rates:
+        # Not the same as "this state has no income tax". Tennessee says that
+        # in a note, with its authority; a state whose pack simply carries no
+        # rate says nothing at all, and the two must not read alike.
+        gaps.append(
+            RateGap(
+                code="income_tax",
+                reason="no_rate_for_chain",
+                detail=(
+                    "no taxing body on this property's chain states a rate this"
+                    " build reads as one"
+                    + (
+                        "; the domain's other rows are carried below as notes"
+                        if notes
+                        else ", and the domain carries nothing else either"
+                    )
+                ),
+            )
+        )
+    return PropertyTaxRates(
+        property_id=property_id,
+        label=anchor["label"],
+        state=anchor["state"],
+        tax_year=tax_year,
+        as_of=as_of,
+        disposed_on=anchor["disposed_on"],
+        rates=rates,
+        notes=notes,
+        gaps=gaps,
+    )
+
+
+def for_entity(conn: Conn, entity_id: str, *, tax_year: int) -> EntityTaxRates:
+    """The cross-river case: one entity, two states, each property answering
+    from its own chain rather than from a column that could name one."""
+    entity = conn.execute(ENTITY_SQL, {"entity_id": entity_id}).fetchone()
+    if entity is None:
+        raise UnknownEntity(entity_id)
+    owned = conn.execute(ENTITY_PROPERTIES_SQL, {"entity_id": entity_id}).fetchall()
+    return EntityTaxRates(
+        entity_id=entity_id,
+        entity=entity["name"],
+        tax_year=tax_year,
+        properties=[for_property(conn, row["property_id"], tax_year=tax_year) for row in owned],
+    )

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -69,6 +69,8 @@ class TestContract:
             "/assessments",
             "/documents/{document_id}/apply-assessment",
             "/properties/{property_id}/appeal",
+            "/properties/{property_id}/tax-rates",
+            "/entities/{entity_id}/tax-rates",
         ):
             assert path in spec["paths"], path
         # Two gap models exist on purpose (sweep vs coverage); both must keep

--- a/services/api/tests/test_income_tax.py
+++ b/services/api/tests/test_income_tax.py
@@ -1,0 +1,238 @@
+"""Income-tax rates, resolved from the property's own chain.
+
+Issue #8's acceptance as the schema can honestly meet it. The ticket asked for
+a per-jurisdiction rate column on tax_profiles; the rate was already in the
+packs, so what is tested here is that a two-state entity gets both answers
+from the properties that sourced the income — and that nothing sums them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from fastapi.testclient import TestClient
+
+
+def make_entity(client: TestClient, name: str = "Cross River LLC") -> str:
+    return client.post("/entities", json={"name": name, "kind": "llc"}).json()["id"]
+
+
+def add_property(client: TestClient, entity_id: str, *, city: str, state: str, postal: str) -> str:
+    return client.post(
+        "/properties",
+        json={
+            "entity_id": entity_id,
+            "label": f"{city} parcel",
+            "street_1": "1 Riverfront Way",
+            "city": city,
+            "state": state,
+            "postal_code": postal,
+            "kind": "single_family",
+        },
+    ).json()["id"]
+
+
+def rates(client: TestClient, property_id: str, year: int = 2026) -> dict[str, Any]:
+    got = client.get(f"/properties/{property_id}/tax-rates?tax_year={year}")
+    assert got.status_code == 200, got.text
+    return got.json()
+
+
+class TestTheCrossRiverCase:
+    def test_one_entity_two_states_two_answers(self, clean: None, client: TestClient) -> None:
+        """#8's acceptance. The entity carries no rate — it has no situs — and
+        each property answers from the chain that actually reaches it."""
+        entity_id = make_entity(client)
+        add_property(client, entity_id, city="Newport", state="KY", postal="41071")
+        add_property(client, entity_id, city="Cincinnati", state="OH", postal="45202")
+
+        got = client.get(f"/entities/{entity_id}/tax-rates?tax_year=2026")
+        assert got.status_code == 200, got.text
+        body = got.json()
+        assert len(body["properties"]) == 2
+        by_state = {p["state"]: p for p in body["properties"]}
+
+        # Kentucky: one body, one rate, the statute the pack cites.
+        (kentucky,) = by_state["KY"]["rates"]
+        assert kentucky["jurisdiction"] == "Kentucky"
+        assert kentucky["level"] == "state"
+        assert Decimal(kentucky["rate"]) == Decimal("0.035000")
+        assert "KRS 141.020" in kentucky["citation"]
+
+        # Ohio: the CITY levies too, and both are owed on the same dollar.
+        ohio = {r["jurisdiction"]: r for r in by_state["OH"]["rates"]}
+        assert set(ohio) == {"Cincinnati"}
+        assert Decimal(ohio["Cincinnati"]["rate"]) == Decimal("0.018000")
+        assert "718" in ohio["Cincinnati"]["citation"]
+        assert ohio["Cincinnati"]["level"] == "municipality"
+        assert ohio["Cincinnati"]["depth"] == 0
+
+    def test_nothing_is_summed_into_one_number(self, clean: None, client: TestClient) -> None:
+        """Whether a municipal rate stacks, is deductible, or is credited by
+        the state of residence is a governance fact no pack states. So the
+        card lists bodies and publishes no total — there is nothing in the
+        payload a reader could mistake for a combined rate."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Cincinnati", state="OH", postal="45202")
+        body = rates(client, property_id)
+        assert "total" not in body
+        assert "combined_rate" not in body
+        assert "effective_rate" not in body
+
+    def test_ohio_state_row_is_a_note_because_it_states_no_rate(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Ohio's pack says "graduated; brackets not yet loaded". That is a
+        real answer about Ohio and it is carried whole — but it is not a rate,
+        and a card that rendered it as one would be inventing a number."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Cincinnati", state="OH", postal="45202")
+        body = rates(client, property_id)
+        notes = {(n["jurisdiction"], n["code"]): n for n in body["notes"]}
+        state_note = notes[("Ohio", "income.type")]
+        assert "brackets not yet loaded" in state_note["text"]
+        assert state_note["value"] is None
+        assert "5747.02" in state_note["citation"]
+        assert all(rate["code"] != "income.type" for rate in body["rates"])
+
+
+class TestWhatItWillNotPresentAsARate:
+    def test_tennessee_owes_nothing_personally_and_says_why(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Tennessee has no individual income tax, and its pack says so with
+        its authority. That is a finding, so it arrives as a note — and the
+        gap that accompanies it must not read as "we know nothing"."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Nashville", state="TN", postal="37206")
+        body = rates(client, property_id)
+        assert body["rates"] == []
+        notes = {n["code"]: n for n in body["notes"]}
+        assert notes["income.type"]["text"].startswith("none;")
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_rate_for_chain"
+        assert "carried below as notes" in gap["detail"]
+
+    def test_an_entity_level_tax_is_not_the_owners_rate(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Tennessee's franchise and excise rates are a different taxpayer's
+        tax — the pack file says so in as many words. Folding them in would
+        answer the wrong question with a number."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Nashville", state="TN", postal="37206")
+        body = rates(client, property_id)
+        codes = {n["code"] for n in body["notes"]}
+        assert "income.entity_excise_rate" in codes
+        assert all("entity_" not in rate["code"] for rate in body["rates"])
+        # The excise rate is carried WHOLE: its number and its words.
+        excise = next(n for n in body["notes"] if n["code"] == "income.entity_excise_rate")
+        assert Decimal(excise["value"]) == Decimal("0.065000")
+        assert "excise" in excise["text"]
+
+    def test_a_dollar_minimum_is_never_read_as_a_rate(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """income.entity_franchise_minimum is 100 — one hundred DOLLARS.
+        value_numeric carries no unit, so the code name is the only thing that
+        says which figures are rates; read as one it is off by a factor of a
+        hundred."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Nashville", state="TN", postal="37206")
+        body = rates(client, property_id)
+        minimum = next(n for n in body["notes"] if n["code"] == "income.entity_franchise_minimum")
+        assert Decimal(minimum["value"]) == Decimal("100.000000")
+        assert all(Decimal(rate["rate"]) < 1 for rate in body["rates"])
+
+
+class TestWhenTheChainAnswersNothing:
+    def test_a_state_with_no_pack_names_the_state(self, clean: None, client: TestClient) -> None:
+        entity_id = make_entity(client)
+        property_id = add_property(
+            client, entity_id, city="Indianapolis", state="IN", postal="46204"
+        )
+        body = rates(client, property_id)
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_state_jurisdiction"
+        assert "IN" in gap["detail"]
+
+    def test_a_chain_that_carries_nothing_at_all_says_so_differently(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """ "No rate, but here is what the pack does say" and "the domain is
+        empty" are different sentences. Sandboxed in a synthetic state, since
+        jurisdiction_rules is append-only."""
+        if (
+            conn.execute(
+                "SELECT 1 AS x FROM jurisdictions WHERE state = 'QT' AND level = 'state'"
+            ).fetchone()
+            is None
+        ):
+            conn.execute(
+                """
+                WITH state_row AS (
+                  INSERT INTO jurisdictions (level, name, state, parent_id)
+                  SELECT 'state', 'Quotland', 'QT', id FROM jurisdictions
+                  WHERE level = 'federal' RETURNING id
+                )
+                INSERT INTO jurisdictions (level, name, state, parent_id)
+                SELECT 'municipality', 'Quotville', 'QT', id FROM state_row
+                """
+            )
+            conn.commit()
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Quotville", state="QT", postal="00000")
+        body = rates(client, property_id)
+        assert body["rates"] == [] and body["notes"] == []
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_rate_for_chain"
+        assert "carries nothing else either" in gap["detail"]
+
+    def test_an_unknown_property_and_an_unknown_entity_are_both_404(
+        self, clean: None, client: TestClient
+    ) -> None:
+        assert client.get(f"/properties/{uuid.uuid4()}/tax-rates?tax_year=2026").status_code == 404
+        assert client.get(f"/entities/{uuid.uuid4()}/tax-rates?tax_year=2026").status_code == 404
+
+
+class TestTheYearDecidesTheAnswer:
+    def test_the_year_is_required_and_not_defaulted_to_today(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """A rate is a fact about a year. Defaulting to the clock would answer
+        a different question than the one a filing asks, and would make a 2026
+        card read differently in 2029."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Newport", state="KY", postal="41071")
+        assert client.get(f"/properties/{property_id}/tax-rates").status_code == 422
+
+    def test_a_year_before_the_rule_took_effect_resolves_nothing(
+        self, clean: None, client: TestClient
+    ) -> None:
+        """Kentucky's row is effective from 2026. Asked about 2024 the chain
+        answers with a gap rather than with a rate that did not exist yet."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Newport", state="KY", postal="41071")
+        body = rates(client, property_id, year=2024)
+        assert body["as_of"] == "2024-12-31"
+        assert body["rates"] == []
+        (gap,) = body["gaps"]
+        assert gap["reason"] == "no_rate_for_chain"
+
+    def test_a_sold_property_still_answers_for_its_disposal_year(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The year a property sold is precisely the year its state rate
+        matters, so unlike the coverage report this does not filter it out."""
+        entity_id = make_entity(client)
+        property_id = add_property(client, entity_id, city="Newport", state="KY", postal="41071")
+        conn.execute(
+            "UPDATE properties SET disposed_on = '2026-07-01' WHERE id = %s", (property_id,)
+        )
+        conn.commit()
+        body = rates(client, property_id)
+        assert body["disposed_on"] == "2026-07-01"
+        assert len(body["rates"]) == 1


### PR DESCRIPTION
Closes #8 — **by subtraction rather than by the table the ticket asked for.**

`tax_profiles` held one `state_marginal_rate` per entity per year, so a single LLC owning in Newport and Cincinnati could not be modelled. The obvious fix is a child table keyed by jurisdiction. It is the wrong one.

## The number was already in the packs

Kentucky's rate has sat in `jurisdiction_rules` since the pack shipped — `income.flat_rate` 0.035, citing KRS 141.020 — and Cincinnati's municipal rate sits beside it at 0.018 under ORC ch. 718. **Neither is a fact about a taxpayer.** Nobody chose them, and no two taxpayers on one street have different ones. ADR 0003 already says a cited statutory number is jurisdiction data.

An entity-side copy keyed by `jurisdiction_id` would have been a **third** copy of KRS 141.020's rate — the seed, a `constraints.sql` assertion, and now the profile — with no CI job comparing them. And it would have carried **no state literal**, so `check_state_literals.sh` would have stayed green while the rule it exists to protect was being broken.

What #8 was missing was a **reader**, not a table. Verified: `income_tax` was the only seeded rule domain with no anti-drift pin in any pack test, and no code in the repository resolved it.

## Module 020 subtracts

- **Drops `state_marginal_rate`.** Safe because `tax_profiles` has never had a writer *or* a reader — across the repo the table appears only in its own module, four constraint assertions, and a test cleanup list.
- **Renames `capital_gains_rate` → `federal_capital_gains_rate`.** That column named neither a government nor a schedule. It could have meant the federal 0/15/20 brackets, a state rate, or somebody's blend — and the blend is the reading that silently **double-counts state tax in the very disposal counterfactual this ticket was opened to unblock**.

The drop is legal under the applied-once rule, which polices file *text* via checksum: 008's bytes are untouched. Module 019 already did the harder version of this to a module-004 table.

## The reader

`GET /properties/{id}/tax-rates` and `GET /entities/{id}/tax-rates`. Two deliberate differences from the appeal card:

- **Per body, not collapsed across the chain.** An appeal window has exactly one governing body. Income tax is levied by more than one government at once — Kentucky at the state and Cincinnati at the city, both owed on the same dollar — and collapsing would silently drop whichever lost.
- **The as-of comes from the tax year, December 31, never from the clock.** A 2026 card must read the same in 2029.

**Nothing is summed.** Whether a municipal rate stacks, is deductible, or is credited by the state of residence is a governance fact that differs by municipality and no pack states any of it. The payload carries no total, no combined rate, no effective rate — a test asserts there is nothing in it a reader could mistake for one.

## What will not be presented as a rate

A whitelist, on the appeal card's reasoning:

- `income.entity_excise_rate`, `income.entity_franchise_rate` — a **different taxpayer's tax**. Tennessee's own seed file says so in as many words.
- `income.entity_franchise_minimum` — **100 is one hundred dollars.** `value_numeric` carries no unit, so the code name is the only thing that says which figures are rates; read as one it is off by a factor of a hundred.
- `income.type`, `income.entity_exemption` — prose, no number. Ohio's *"graduated; brackets not yet loaded"* is a real answer about Ohio and is carried whole.

All of them are still returned, as notes. Nothing is dropped.

## Redefined acceptance, stated plainly

The ticket asked that *"an entity with KY and OH properties carries both rates"*. **An entity has no situs** — `entities.formation_state` is explicitly not one — so it carries neither. Its *properties* carry them, each resolving its own chain, and the entity endpoint returns that union unaggregated. That is the same acceptance the schema can honestly meet, and it ships tested as the cross-river case.

## Gates

- schema verified, **153** constraint assertions; kentucky pack 8 checks, ohio 7
- `services/api` — **347** passed at 100% line and branch
- `services/sim`, `services/ingest` — 100%; `pnpm run verify` green
- ruff, state-literal ratchet, config audit, regenerated contract — clean
