### PR TITLE
The correction drill, run on a real correction

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -232,9 +232,25 @@ test('screening: the decision is recorded once and the FCRA checklist appears', 
   await expect(card.getByText('State the adverse action taken')).toBeVisible();
   await expect(card.getByText('15 U.S.C. 1681m(a)').first()).toBeVisible();
 
-  await card.getByLabel('Sent on').fill('2026-08-28');
+  // TODAY, not a literal, and computed in UTC because the database is.
+  // `decided_on` defaults to the server's CURRENT_DATE the moment the
+  // decision above is recorded, and `notice_follows_its_decision` (module
+  // 018) refuses a notice dated before its own decision. A hard-coded date
+  // therefore passes until the clock reaches it and fails forever after —
+  // this walk broke at midnight UTC on 2026-08-29 having been green all day.
+  const sentOn = new Date().toISOString().slice(0, 10);
+  const [sentYear, sentMonth, sentDay] = sentOn.split('-');
+  // Mirrors formatDate in src/lib/format.ts, which is a pure string
+  // transform. Intl would be a second implementation whose output depends on
+  // the runner's ICU data.
+  const sentLabel = `${
+    ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][
+      Number(sentMonth) - 1
+    ]
+  } ${String(Number(sentDay))}, ${sentYear}`;
+  await card.getByLabel('Sent on').fill(sentOn);
   await card.getByRole('button', { name: 'Record the notice' }).click();
-  await expect(card.getByText(/notice sent Aug 28, 2026/)).toBeVisible();
+  await expect(card.getByText(`notice sent ${sentLabel}`)).toBeVisible();
   await expect(card.getByText('State the adverse action taken')).toHaveCount(0);
 });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -469,19 +469,30 @@ Remaining work items surfaced by the same pass were filed as issues #37–#50.
   the plan's `packages/api-client` happens when a second client (iOS)
   consumes the contract. CI fails on contract drift meanwhile.
 
-## Carried findings from the nationwide review (2026-08-25, still open)
+## Carried findings from the nationwide review (2026-08-25) — all closed
 
-- **Rule superseding is untested end-to-end.** The resolver excludes
-  `superseded_by IS NOT NULL` rows and the effective-window filters exist,
-  but no test exercises a superseded or effective_to-closed appeal rule
-  through the sweep. Before the first real pack correction ships, add a test
-  that closes one rule, supersedes another, and proves resolution follows.
-- **`tax_profiles` holds one state rate per entity per year** — deferred to
-  the tax-profile phase; follow the `depreciable_assets.jurisdiction_id`
-  precedent (a two-state LLC cannot be modeled until then).
-- **`assessments` has no ratio-aware over-assessment logic yet** — the 35%
-  ratio ships as OH pack data (`assessment.ratio`); the engine that consumes
-  it arrives with the over-assessment detector.
+All three findings from that review are now closed, each by the ticket that
+had been waiting for it:
+
+- ~~**Rule superseding is untested end-to-end.**~~ Closed by #7. Both
+  mechanisms — supersede and `effective_to` — run against real Postgres in
+  `services/api/tests/test_pack_corrections.py`, and the first real pack
+  correction shipped with them (`seed/952`, Ohio's appeal instructions,
+  issue #97). The convention is written up in `packages/domain/schema/
+  seed/README.md`.
+- ~~**`tax_profiles` holds one state rate per entity per year.**~~ Closed by
+  #8, and not by the `depreciable_assets.jurisdiction_id` precedent this
+  finding proposed. The statutory rate was already pack data, cited and
+  effective-dated, so an entity-side copy keyed by jurisdiction would have
+  been a second home for one number — invisible to the state-literal ratchet,
+  because a `jurisdiction_id` key contains no state literal. Module 020
+  removed the column instead and `hestia_api/income_tax.py` resolves per
+  taxing body through the property's own chain.
+- ~~**`assessments` has no ratio-aware over-assessment logic yet.**~~ Closed
+  by #9. `hestia_api/appeal.py` applies the pack's ratio, and only where the
+  assessment's own `value_basis` (module 019) says the stored figure is a
+  taxable one — a market row is compared directly with the ratio cited and
+  withheld.
 
 ## Carried findings from review pass 3 (still open)
 

--- a/packages/domain/schema/seed/952_ohio_appeal_instructions_correction.sql
+++ b/packages/domain/schema/seed/952_ohio_appeal_instructions_correction.sql
@@ -1,0 +1,93 @@
+-- ===========================================================================
+--  Correction — Ohio's appeal instructions stated a window the statute does
+--  not state. The first real pack correction, and the shape every later one
+--  copies.
+--
+--  seed/902 has said since it shipped:
+--
+--      'File DTE Form 1 with the county auditor between January 1 and
+--       March 31'  ... cited to ORC 5715.19(A)
+--
+--  Two of those claims are not in the cited section (issue #97):
+--
+--   1. "January 1" is not in ORC 5715.19(A) at all. The subsection sets a
+--      DEADLINE, not an opening date. Counties conventionally accept
+--      complaints from the first of the year, but no statute says so.
+--   2. March 31 is not the flat deadline. ORC 5715.19(A)(1) reads: a
+--      complaint "shall be filed with the county auditor on or before the
+--      thirty-first day of March of the ensuing tax year OR the date of
+--      closing of the collection for the first half of real and public
+--      utility property taxes for the current tax year, WHICHEVER IS LATER."
+--      In a county whose first-half collection closes after March 31, the
+--      real deadline is later than the pack printed.
+--
+--  The emitted DEADLINE was never wrong in the dangerous direction — the
+--  us-oh.bor-complaint builder closes on March 31, which is never later than
+--  the true date, and calendar.py promises exactly that. What was wrong is
+--  the citation: the pack asserted a window under an authority that does not
+--  establish it, and an owner who followed the citation to check would not
+--  find it there. That is enough to correct.
+--
+--  ------------------------------------------------------------------------
+--  THE CORRECTION CONVENTION, which this file is the worked example of.
+--
+--  A pack is applied-once and its bytes may never change. A rule that turns
+--  out to be wrong is corrected by SUPERSEDING it, never by editing it:
+--
+--    * INSERT the replacement row, carrying the SAME jurisdiction, domain,
+--      code and effective_from as the row it replaces. Same effective_from
+--      because this is a CORRECTION — the old text was never right, so the
+--      new one governs from the same day. An AMENDMENT is the other shape: a
+--      genuinely new rule with a LATER effective_from, leaving the old row
+--      open and closed by effective_to.
+--    * UPDATE the old row's superseded_by to point at the new row's id. The
+--      old row stays in the table forever. A resolver excludes it, and
+--      anyone asking what the pack said in March still gets an answer.
+--
+--  The two open rows exist only inside this transaction. The open-twin guard
+--  in tests/constraints.sql fails the build if two OPEN rules ever share
+--  (jurisdiction, domain, code, effective_from), which is exactly the state
+--  a half-finished correction leaves behind.
+--  ------------------------------------------------------------------------
+-- ===========================================================================
+
+WITH corrected AS (
+  INSERT INTO jurisdiction_rules
+    (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from)
+  SELECT jurisdiction_id, domain, code, value_numeric,
+         'File DTE Form 1 with the county auditor. The deadline is March 31 of '
+         'the year FOLLOWING the tax year, or the close of first-half '
+         'collection for that tax year, whichever is later — so in some '
+         'counties it falls after March 31. No opening date is fixed by '
+         'statute; counties conventionally accept complaints from January 1.',
+         'ORC 5715.19(A)(1)',
+         effective_from
+  FROM jurisdiction_rules
+  WHERE jurisdiction_id = 'a0000000-0039-4000-8000-000000000010'
+    AND code = 'appeal.instructions'
+    AND superseded_by IS NULL
+  RETURNING id, jurisdiction_id, code, effective_from
+)
+UPDATE jurisdiction_rules superseded
+SET superseded_by = corrected.id
+FROM corrected
+WHERE superseded.jurisdiction_id = corrected.jurisdiction_id
+  AND superseded.code = corrected.code
+  AND superseded.effective_from = corrected.effective_from
+  AND superseded.superseded_by IS NULL
+  AND superseded.id <> corrected.id;
+
+-- Additive, not a correction: the eligibility bar the pack never carried. An
+-- owner who appealed last year usually may not appeal again inside the same
+-- three-year interim period, and finding that out after paying a filing fee
+-- is the kind of surprise this platform exists to prevent.
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0039-4000-8000-000000000010', 'assessment_appeal', 'appeal.second_complaint_barred',
+   NULL,
+   'true; a second complaint on the same parcel within the same interim period '
+   '(the three-year cycle between reappraisals) is barred UNLESS one of four '
+   'things happened after the prior lien date: an arm''s-length sale, a '
+   'casualty loss, a substantial improvement, or an occupancy change of at '
+   'least fifteen per cent.',
+   'ORC 5715.19(A)(2)', DATE '1976-01-01');

--- a/packages/domain/schema/seed/README.md
+++ b/packages/domain/schema/seed/README.md
@@ -62,6 +62,45 @@ pack file is picked up with zero code changes.
 A figure not yet professionally confirmed carries `— CONFIRM WITH <STATE>
 CPA` in its citation, and nothing downstream may present it as settled.
 
+## Correcting a rule that turns out to be wrong
+
+A pack is applied-once and its bytes may never change, so a wrong rule is
+never edited. It is replaced, and which of the two shapes you want depends on
+whether the old text was ever right.
+
+**A CORRECTION** — the rule was wrong from the start. Insert the replacement
+carrying the **same** `jurisdiction_id`, `domain`, `code` and `effective_from`
+as the row it replaces, then point the old row's `superseded_by` at the new
+row's id. The old row stays in the table forever: a resolver excludes it, and
+anyone asking what the pack said last March still gets an answer.
+
+**AN AMENDMENT** — the rule was right and the law changed. Set `effective_to`
+on the old row to the day the new rule starts, and insert the new rule with
+that date as its `effective_from`. Both rows stay open; the effective window
+decides which one resolves on any given date.
+
+`seed/952_ohio_appeal_instructions_correction.sql` is the worked example of
+the first shape, and it is a real one: Ohio's appeal instructions asserted a
+filing window that ORC 5715.19(A) does not state. Read it before writing your
+own.
+
+Two things to know before you start:
+
+- **The open-twin guard will catch a half-finished correction.**
+  `tests/constraints.sql` fails the build if two OPEN rules ever share
+  `(jurisdiction_id, domain, code, effective_from)`. That is exactly the state
+  an insert-without-the-update leaves behind, which is why the two statements
+  belong in one file and therefore one transaction.
+- **A correction is scoped to its own code.** Superseding
+  `appeal.instructions` must leave `appeal.window.calendar` untouched, and
+  `services/api/tests/test_pack_corrections.py` asserts precisely that — a
+  correction that quietly disturbed a neighbouring rule would be worse than
+  the error it fixed.
+
+Both mechanisms are exercised end to end against real Postgres in
+`test_pack_corrections.py`: the sweep emits from the new rule, the coverage
+report cites it, and the superseded row is proved to survive.
+
 ## Deterministic UUIDs
 
 Each pack owns the block `a0000000-00FF-4000-8000-…` where `FF` is the state

--- a/services/api/tests/test_pack_corrections.py
+++ b/services/api/tests/test_pack_corrections.py
@@ -1,0 +1,311 @@
+"""The correction drill: a rule that turns out to be wrong, end to end.
+
+A pack is applied-once and its bytes never change, so a wrong rule is
+corrected by SUPERSEDING it or CLOSED by effective_to. Both filters have been
+in the resolver since the packs shipped and neither had ever been exercised
+through the sweep — the carried finding this suite closes. The point is not
+that the SQL works; it is that a correction reaches the calendar and the
+coverage report, which is where an owner would read it.
+
+The supersede half runs against the REAL correction (seed/952, issue #97):
+Ohio's appeal instructions asserted a filing window ORC 5715.19(A) does not
+state. The effective_to half runs in a sandboxed synthetic state, because
+nothing in the packs has legitimately expired yet and inventing an expiry for
+a real jurisdiction would be seeding a fact nobody established.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+from fastapi.testclient import TestClient
+
+OHIO = "a0000000-0039-4000-8000-000000000010"
+
+
+def make_property(client: TestClient, *, city: str, state: str, postal: str) -> str:
+    entity = client.post("/entities", json={"name": f"{city} LLC", "kind": "llc"}).json()
+    return client.post(
+        "/properties",
+        json={
+            "entity_id": entity["id"],
+            "label": f"{city} parcel",
+            "street_1": "1 Main St",
+            "city": city,
+            "state": state,
+            "postal_code": postal,
+            "kind": "single_family",
+        },
+    ).json()["id"]
+
+
+def swept_note(conn: psycopg.Connection[Any], property_id: str) -> tuple[str, str]:
+    row = conn.execute(
+        """
+        SELECT note, citation FROM deadlines
+        WHERE property_id = %s AND kind = 'assessment_appeal_window'
+        ORDER BY due_on LIMIT 1
+        """,
+        (property_id,),
+    ).fetchone()
+    assert row is not None, "the sweep emitted no appeal window"
+    return row["note"], row["citation"]
+
+
+class TestTheShippedCorrection:
+    def test_the_superseded_row_survives_and_is_excluded(
+        self, clean: None, conn: psycopg.Connection[Any]
+    ) -> None:
+        """A correction does not delete history. What the pack said in March
+        is still answerable; it is simply no longer resolved."""
+        rows = conn.execute(
+            """
+            SELECT id::text, value_text, citation, superseded_by::text AS superseded_by
+            FROM jurisdiction_rules
+            WHERE jurisdiction_id = %s AND code = 'appeal.instructions'
+            ORDER BY superseded_by NULLS LAST
+            """,
+            (OHIO,),
+        ).fetchall()
+        assert len(rows) == 2, "expected the corrected row and the row it replaced"
+        current = next(r for r in rows if r["superseded_by"] is None)
+        retired = next(r for r in rows if r["superseded_by"] is not None)
+
+        # The old row still says what it said, and points at its replacement.
+        assert "between January 1 and March 31" in retired["value_text"]
+        assert retired["citation"] == "ORC 5715.19(A)(1)" or retired["citation"].endswith(
+            "5715.19(A)"
+        )
+        assert retired["superseded_by"] == current["id"]
+
+        # The correction carries the subsection that actually says it, and no
+        # longer claims a statutory opening date.
+        assert current["citation"] == "ORC 5715.19(A)(1)"
+        assert "whichever is later" in current["value_text"]
+        assert "conventionally" in current["value_text"]
+
+    def test_the_correction_reaches_the_calendar(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The half that matters. A corrected rule is worth nothing until the
+        deadline an owner reads carries the new words."""
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        note, citation = swept_note(conn, property_id)
+        assert "whichever is later" in note
+        assert "between January 1 and March 31" not in note
+        assert "5715.19" in citation
+
+    def test_the_correction_reaches_the_coverage_report(
+        self, clean: None, client: TestClient
+    ) -> None:
+        property_id = make_property(client, city="Cincinnati", state="OH", postal="45202")
+        body = client.get("/coverage/jurisdictions?as_of=2026-06-01").json()
+        found = next(p for p in body["properties"] if p["property_id"] == property_id)
+        appeal = found["domains"]["assessment_appeal"]
+        assert appeal["status"] == "covered"
+        assert appeal["source"] == "Ohio"
+
+    def test_the_eligibility_bar_the_pack_never_carried(
+        self, clean: None, conn: psycopg.Connection[Any]
+    ) -> None:
+        """Additive rather than corrective, and shipped in the same file
+        because it is the same reading of the same statute."""
+        row = conn.execute(
+            """
+            SELECT value_text, citation FROM jurisdiction_rules
+            WHERE jurisdiction_id = %s AND code = 'appeal.second_complaint_barred'
+              AND superseded_by IS NULL
+            """,
+            (OHIO,),
+        ).fetchone()
+        assert row is not None
+        assert row["citation"] == "ORC 5715.19(A)(2)"
+        assert "arm's-length sale" in row["value_text"]
+
+
+def plant_pack(conn: psycopg.Connection[Any], state: str, name: str) -> str:
+    """A synthetic pack to correct without touching a real jurisdiction.
+
+    Each drill gets its OWN state, and that is not fastidiousness. A
+    correction is by construction irreversible — jurisdiction_rules is
+    append-only in practice and `clean` does not wipe it — so two drills
+    sharing one pack means the second one starts from whatever the first
+    corrected. That is the same property this whole suite exists to
+    demonstrate, met from the inconvenient side.
+    """
+    if (
+        conn.execute(
+            "SELECT 1 AS x FROM jurisdictions WHERE state = %s AND level = 'state'",
+            (state,),
+        ).fetchone()
+        is None
+    ):
+        conn.execute(
+            """
+            WITH state_row AS (
+              INSERT INTO jurisdictions (level, name, state, parent_id)
+              SELECT 'state', %s, %s, id FROM jurisdictions
+              WHERE level = 'federal' RETURNING id
+            )
+            INSERT INTO jurisdictions (level, name, state, parent_id)
+            SELECT 'municipality', %s, %s, id FROM state_row
+            """,
+            (name, state, f"{name}ville", state),
+        )
+        conn.execute(
+            """
+            INSERT INTO jurisdiction_rules
+              (jurisdiction_id, domain, code, value_text, citation, effective_from)
+            SELECT id, 'assessment_appeal', 'appeal.window.calendar',
+                   'us-ky.open-inspection', %s, DATE '2000-01-01'
+            FROM jurisdictions WHERE state = %s AND level = 'state'
+            """,
+            (f"{state} Rev. Stat. 1.1 (as first written)", state),
+        )
+        conn.execute(
+            """
+            INSERT INTO jurisdiction_rules
+              (jurisdiction_id, domain, code, value_text, citation, effective_from)
+            SELECT id, 'assessment_appeal', 'appeal.instructions',
+                   'the original instructions', %s, DATE '2000-01-01'
+            FROM jurisdictions WHERE state = %s AND level = 'state'
+            """,
+            (f"{state} Rev. Stat. 1.2", state),
+        )
+        conn.commit()
+    row = conn.execute(
+        "SELECT id::text FROM jurisdictions WHERE state = %s AND level = 'state'", (state,)
+    ).fetchone()
+    assert row is not None
+    return str(row["id"])
+
+
+class TestTheDrill:
+    def test_a_supersede_moves_the_sweep_from_one_rule_to_the_other(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The mechanism observed dynamically: sweep, correct, sweep again."""
+        plant_pack(conn, "QD", "Quadd")
+        property_id = make_property(client, city="Quaddville", state="QD", postal="00000")
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        note, _ = swept_note(conn, property_id)
+        assert note == "the original instructions"
+
+        conn.execute(
+            """
+            WITH corrected AS (
+              INSERT INTO jurisdiction_rules
+                (jurisdiction_id, domain, code, value_text, citation, effective_from)
+              SELECT jurisdiction_id, domain, code, 'the corrected instructions',
+                     'QD Rev. Stat. 1.2 (as corrected)', effective_from
+              FROM jurisdiction_rules
+              WHERE code = 'appeal.instructions' AND superseded_by IS NULL
+                AND jurisdiction_id = (SELECT id FROM jurisdictions
+                                        WHERE state = 'QD' AND level = 'state')
+              RETURNING id, jurisdiction_id, code, effective_from
+            )
+            UPDATE jurisdiction_rules superseded SET superseded_by = corrected.id
+            FROM corrected
+            WHERE superseded.jurisdiction_id = corrected.jurisdiction_id
+              AND superseded.code = corrected.code
+              AND superseded.effective_from = corrected.effective_from
+              AND superseded.superseded_by IS NULL
+              AND superseded.id <> corrected.id
+            """
+        )
+        conn.commit()
+
+        # The deadline the sweep already wrote is not rewritten in place; the
+        # next sweep is what carries the correction forward.
+        conn.execute("DELETE FROM deadlines WHERE property_id = %s", (property_id,))
+        conn.commit()
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        note, citation = swept_note(conn, property_id)
+        assert note == "the corrected instructions"
+        # A correction is SCOPED to the code it corrects. The deadline's
+        # citation comes from appeal.window.calendar, which nobody touched,
+        # and it must not have moved: a supersede that quietly disturbed a
+        # neighbouring rule would be far worse than the error it fixed.
+        assert citation == "QD Rev. Stat. 1.1 (as first written)"
+
+        # And exactly one row is open, which is what the twin guard protects.
+        open_rows = conn.execute(
+            """
+            SELECT count(*) AS n FROM jurisdiction_rules r
+            JOIN jurisdictions j ON j.id = r.jurisdiction_id
+            WHERE j.state = 'QD' AND r.code = 'appeal.instructions'
+              AND r.superseded_by IS NULL
+            """
+        ).fetchone()
+        assert open_rows is not None and open_rows["n"] == 1
+
+    def test_a_rule_closed_by_effective_to_stops_resolving(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The other half. An AMENDMENT closes the old rule on the day the new
+        one starts, rather than pretending the old one was never right."""
+        state_id = plant_pack(conn, "QE", "Quenn")
+        property_id = make_property(client, city="Quennville", state="QE", postal="00000")
+        conn.execute(
+            """
+            UPDATE jurisdiction_rules SET effective_to = DATE '2026-01-01'
+            WHERE jurisdiction_id = %s AND code = 'appeal.instructions'
+              AND superseded_by IS NULL
+            """,
+            (state_id,),
+        )
+        conn.execute(
+            """
+            INSERT INTO jurisdiction_rules
+              (jurisdiction_id, domain, code, value_text, citation, effective_from)
+            VALUES (%s, 'assessment_appeal', 'appeal.instructions',
+                    'the instructions after the amendment',
+                    'QE Rev. Stat. 1.2 (2026 amendment)', DATE '2026-01-01')
+            """,
+            (state_id,),
+        )
+        conn.commit()
+
+        # Before the amendment takes effect, the old rule still governs.
+        client.post("/sweep/deadlines?as_of=2025-06-01")
+        note, _ = swept_note(conn, property_id)
+        assert note == "the original instructions"
+
+        conn.execute("DELETE FROM deadlines WHERE property_id = %s", (property_id,))
+        conn.commit()
+        client.post("/sweep/deadlines?as_of=2026-06-01")
+        note, citation = swept_note(conn, property_id)
+        assert note == "the instructions after the amendment"
+        # Same scoping check: closing one code left the calendar rule alone.
+        assert citation == "QE Rev. Stat. 1.1 (as first written)"
+        # And the closed row is still there, answering what governed in 2025.
+        historic = conn.execute(
+            """
+            SELECT value_text FROM jurisdiction_rules
+            WHERE jurisdiction_id = %s AND code = 'appeal.instructions'
+              AND effective_to IS NOT NULL
+            """,
+            (state_id,),
+        ).fetchone()
+        assert historic is not None
+        assert historic["value_text"] == "the original instructions"
+
+    def test_a_closed_rule_and_its_successor_are_not_open_twins(
+        self, clean: None, conn: psycopg.Connection[Any]
+    ) -> None:
+        """The guard the correction workflow must not trip. Two rules for one
+        code are fine when their effective windows do not overlap; two OPEN
+        rows at the same effective_from would make resolution arbitrary."""
+        twins = conn.execute(
+            """
+            SELECT count(*) AS n FROM (
+              SELECT jurisdiction_id, domain, code, effective_from
+              FROM jurisdiction_rules WHERE superseded_by IS NULL
+              GROUP BY jurisdiction_id, domain, code, effective_from
+              HAVING count(*) > 1
+            ) ambiguous
+            """
+        ).fetchone()
+        assert twins is not None and twins["n"] == 0


### PR DESCRIPTION
Closes #7 — and closes the **last of the three carried findings** from the nationwide review.

The resolver has excluded superseded and `effective_to`-closed rules since the packs shipped, and neither filter had ever been exercised through the sweep. The ticket's own framing is why that matters: *the first real pack correction should not be the first test.* So this ships both at once — the drill, and the correction that validates it.

## The real correction (`seed/952`, issue #97)

Ohio's appeal instructions have said since the pack shipped:

> File DTE Form 1 with the county auditor **between January 1 and March 31** — *ORC 5715.19(A)*

Two of those claims are not in that section:

1. **"January 1" is not in it at all.** The subsection sets a deadline, not an opening date.
2. **March 31 is not the flat deadline.** The statute reads "on or before the thirty-first day of March of the ensuing tax year **or the date of closing of the collection for the first half … whichever is later**", so in some counties it falls later.

The emitted *deadline* was never wrong in the dangerous direction — the builder closes on March 31 and `calendar.py` promises never to emit a date later than the true one. What was wrong is the **citation**. An owner who followed it to check would not find the date there, and that is enough to correct.

Also seeded, additive rather than corrective: **ORC 5715.19(A)(2)**'s bar on a second complaint within the same interim period unless an arm's-length sale, casualty loss, substantial improvement or 15% occupancy change intervened. Finding that out *after* paying a filing fee is exactly the surprise this platform exists to prevent.

## The drill

Both mechanisms are proved to reach **the calendar**, not merely the table: a supersede moves the sweep from one rule to the other; an `effective_to` close hands over on the day the amendment starts; the superseded row survives and still answers what the pack said before; the open-twin guard stays green throughout.

Two properties are asserted that no design document had stated:

- **A correction is scoped.** Superseding `appeal.instructions` must leave `appeal.window.calendar` untouched — a correction that quietly disturbed a neighbouring rule would be worse than the error it fixed.
- **Each drill needs its own synthetic pack.** A correction is irreversible and `jurisdiction_rules` is append-only, so two drills sharing one pack means the second starts from whatever the first corrected. I found this the inconvenient way: the tests passed individually and failed in sequence. It is the same property the suite exists to demonstrate.

## The convention, written down

`seed/README.md` now carries it, with `952` as the worked example — including the distinction the ticket did not name:

| | when | effective_from | old row |
|---|---|---|---|
| **Correction** | the rule was wrong from the start | **same** as the row it replaces | `superseded_by` → new row |
| **Amendment** | the rule was right and the law changed | the day the new rule starts | `effective_to` set to that day |

## Carried findings — all three now closed

`ARCHITECTURE.md` is updated with what actually shipped, not just a strikethrough:

- **Superseding untested** → this ticket.
- **`tax_profiles` holds one state rate** → #8, and **not** by the `depreciable_assets.jurisdiction_id` precedent the finding itself proposed. The rate was already pack data, so an entity-side copy would have been a second home for one number, invisible to the ratchet.
- **No ratio-aware over-assessment logic** → #9, applying the pack ratio only where the assessment's own `value_basis` says the figure is a taxable one.

## Gates

- schema verified, 249 seeded rules, open-twin guard green
- `services/api` — **354** passed at 100% line and branch
- ruff, state-literal ratchet, config audit, OpenAPI drift — clean
