### PR TITLE
The gate stops replaying a pass it never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,10 @@ jobs:
         run: uv run python scripts/tests/test_migrate.py
       - name: Bundle budget self-test
         run: uv run python scripts/tests/test_bundle_budget.py
+      - name: Turbo inputs law + self-test
+        run: |
+          uv run python scripts/tests/test_turbo_inputs.py
+          uv run python scripts/check_turbo_inputs.py
       # Unconditional: the simulation service exists, so a skip-guard here
       # would be a gate that can quietly stop gating.
       - name: Simulation tests with coverage gate

--- a/scripts/check_turbo_inputs.py
+++ b/scripts/check_turbo_inputs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Turbo's declared inputs must cover every directory its tasks actually read.
+
+A task whose ``inputs`` omit a file it reads will replay a cached success
+after that file changes -- a gate reporting a run that never happened. It
+happened: ``apps/web`` keeps its whole suite in ``tests/``, ``packages/design``
+keeps the livery laws there, and neither was hashed, so a broken law returned
+"FULL TURBO" in 14ms.
+
+This walks every workspace package, reads the globs its vitest config actually
+includes, and asserts turbo hashes the directories those globs live in.
+
+Runs against a checkout. No network, no running stack, no third-party packages.
+Exit 0 means every test task hashes what it reads; 1 means a gate can lie.
+
+    python3 scripts/check_turbo_inputs.py [--root .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+TEST_TASKS = ("test", "test:coverage", "test:mutation")
+# The task reads these whether or not a glob names them.
+ALWAYS_READ = {"fixtures"}
+
+
+def top_dirs(globs: list[str]) -> set[str]:
+    """The first path segment of each glob -- the directory turbo must hash."""
+    return {g.split("/", 1)[0] for g in globs if "/" in g and not g.startswith("!")}
+
+
+def vitest_includes(pkg: Path) -> list[str]:
+    """The include globs a package's vitest config declares, if any."""
+    for name in ("vitest.config.ts", "vitest.config.mts", "vitest.config.js"):
+        cfg = pkg / name
+        if not cfg.exists():
+            continue
+        match = re.search(r"include:\s*\[(.*?)\]", cfg.read_text(), re.S)
+        if match:
+            return re.findall(r"['\"]([^'\"]+)['\"]", match.group(1))
+        # No explicit include: vitest's default sweeps the whole package.
+        return ["src/**", "tests/**", "test/**"]
+    return []
+
+
+def packages(root: Path) -> list[Path]:
+    found: list[Path] = []
+    for parent in ("packages", "apps", "services"):
+        base = root / parent
+        if base.is_dir():
+            found += [p for p in sorted(base.iterdir()) if (p / "package.json").exists()]
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".")
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    turbo = json.loads((root / "turbo.json").read_text())
+    tasks = turbo["tasks"]
+    findings: list[str] = []
+
+    for pkg in packages(root):
+        includes = vitest_includes(pkg)
+        if not includes:
+            continue
+        needed = {d for d in top_dirs(includes) if (pkg / d).is_dir()}
+        needed |= {d for d in ALWAYS_READ if (pkg / d).is_dir()}
+        for task in TEST_TASKS:
+            spec = tasks.get(f"{pkg.name}#{task}") or tasks.get(task)
+            if spec is None or "inputs" not in spec:
+                continue  # no declared inputs: turbo hashes the package, which is safe
+            hashed = top_dirs(spec["inputs"])
+            for missing in sorted(needed - hashed):
+                findings.append(
+                    f"{pkg.as_posix()}: task '{task}' reads {missing}/ but does not hash it"
+                )
+
+    for finding in findings:
+        print(finding)
+    if findings:
+        print(f"\n{len(findings)} task(s) can replay a pass they never ran")
+        return 1
+    print("every test task hashes the directories it reads")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_turbo_inputs.py
+++ b/scripts/tests/test_turbo_inputs.py
@@ -1,0 +1,90 @@
+"""Tests for the turbo-inputs law.
+
+The real repository is checked by the script itself in CI; these own the
+arithmetic of the check -- that a hole is found, that a covered directory is
+not reported, and that the two shapes turbo allows (no declared inputs, a
+package-specific task override) are read correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_turbo_inputs
+
+
+def make_repo(
+    turbo: dict,
+    pkg: str = "apps/web",
+    include: str | None = None,
+    dirs: tuple[str, ...] = ("src", "tests"),
+) -> Path:
+    root = Path(tempfile.mkdtemp())
+    (root / "turbo.json").write_text(json.dumps(turbo))
+    p = root / pkg
+    p.mkdir(parents=True)
+    (p / "package.json").write_text('{"name": "web"}')
+    for d in dirs:
+        (p / d).mkdir()
+    if include is not None:
+        (p / "vitest.config.ts").write_text(
+            f"export default {{ test: {{ include: [{include}] }} }}"
+        )
+    return root
+
+
+TASKS_NARROW = {"tasks": {"test": {"inputs": ["src/**", "vitest.config.*"]}}}
+TASKS_WIDE = {"tasks": {"test": {"inputs": ["src/**", "tests/**", "fixtures/**"]}}}
+
+
+class LawTest(unittest.TestCase):
+    def test_names_a_directory_the_task_reads_but_does_not_hash(self) -> None:
+        root = make_repo(TASKS_NARROW, include="'tests/**/*.test.ts'")
+        code = check_turbo_inputs.main(["--root", str(root)])
+        self.assertEqual(code, 1)
+
+    def test_passes_when_the_inputs_cover_the_globs(self) -> None:
+        root = make_repo(TASKS_WIDE, include="'tests/**/*.test.ts'")
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 0)
+
+    def test_a_directory_the_globs_never_touch_is_not_demanded(self) -> None:
+        # src-only suite under narrow inputs: nothing missing, even though
+        # a tests/ directory happens to exist on disk.
+        root = make_repo(TASKS_NARROW, include="'src/**/*.test.ts'")
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 0)
+
+    def test_fixtures_are_demanded_whenever_the_directory_exists(self) -> None:
+        # The engines read fixtures/engine-fixtures.json without any glob
+        # naming it, which is exactly how that hole stayed open.
+        root = make_repo(TASKS_NARROW, include="'src/**/*.test.ts'", dirs=("src", "fixtures"))
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 1)
+
+    def test_a_package_specific_task_override_is_read_instead_of_the_default(self) -> None:
+        turbo = {
+            "tasks": {
+                "test": {"inputs": ["src/**"]},
+                "web#test": {"inputs": ["src/**", "tests/**"]},
+            }
+        }
+        root = make_repo(turbo, include="'tests/**/*.test.ts'")
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 0)
+
+    def test_a_task_with_no_declared_inputs_is_safe_by_default(self) -> None:
+        # Turbo hashes the whole package when inputs are omitted, so there is
+        # nothing to refuse -- the law must not manufacture a finding.
+        root = make_repo({"tasks": {"test": {}}}, include="'tests/**/*.test.ts'")
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 0)
+
+    def test_a_package_without_vitest_is_ignored(self) -> None:
+        root = make_repo(TASKS_NARROW, include=None)
+        self.assertEqual(check_turbo_inputs.main(["--root", str(root)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/turbo.json
+++ b/turbo.json
@@ -1,4 +1,5 @@
 {
+  "//": "Task inputs are the hash. A task whose inputs omit a file it reads will replay a cached pass after that file changes -- which is a gate reporting a run that never happened. tests/** and fixtures/** are listed because apps/web keeps its entire suite in tests/, packages/design keeps the livery laws there, and packages/engines proves itself against fixtures/engine-fixtures.json.",
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
   "globalDependencies": ["tsconfig.base.json", "biome.json", ".nvmrc", "pnpm-workspace.yaml"],
@@ -10,22 +11,22 @@
     },
     "typecheck": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "tsconfig*.json"],
+      "inputs": ["src/**", "tests/**", "e2e/**", "tsconfig*.json"],
       "outputs": []
     },
     "test": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "vitest.config.*"],
+      "inputs": ["src/**", "tests/**", "fixtures/**", "vitest.config.*"],
       "outputs": []
     },
     "test:coverage": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "vitest.config.*"],
+      "inputs": ["src/**", "tests/**", "fixtures/**", "vitest.config.*"],
       "outputs": ["coverage/**"]
     },
     "test:mutation": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "stryker.config.*", "vitest.config.*"],
+      "inputs": ["src/**", "tests/**", "fixtures/**", "stryker.config.*", "vitest.config.*"],
       "outputs": ["reports/mutation/**"]
     },
     "@hestia/web#build": {


### PR DESCRIPTION
Closes #111.

Turbo's test tasks hashed `src/**` and not the directories they actually read. `apps/web` keeps its entire suite in `tests/`, `packages/design` keeps the livery laws there, and `packages/engines` proves itself against `fixtures/engine-fixtures.json`.

**Demonstrated before fixing**, the way #6 proved the axe gate — break a livery law and run the old config:

```
Tasks:    1 successful, 1 total
Cached:   1 cached, 1 total
Time:     14ms >>> FULL TURBO
```

A failing brand law, reported as a pass, in 14ms. The same broken law against the fixed inputs:

```
Tasks:    0 successful, 1 total
Failed:   @hestia/design#test
```

## What landed

- `turbo.json` inputs now name `tests/**` and `fixtures/**` on the three test tasks, and `tests/**`/`e2e/**` on `typecheck` (which type-checks them today without hashing them). The file carries a `"//"` note explaining why, since the omission looked deliberate.
- **A ratchet, because a point-in-time fix reopens the moment someone adds a test directory.** `scripts/check_turbo_inputs.py` reads each package's own vitest `include` globs and asserts turbo hashes the directories they live in. Against the previous config it finds all nine holes; against this one it passes. Seven unit tests own its arithmetic, including the two turbo shapes that are legitimately safe (no declared `inputs`, and a package-specific task override).
- Both run in the python CI job beside the bundle-budget law.

Ladder: `pnpm run verify` green, ruff clean, config audit clean, self-tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)