### PR TITLE
The budget measures a route with the layout that wraps it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,15 @@ jobs:
         run: >-
           pnpm --filter @hestia/web run lighthouse --
           --collect.settings.chromeFlags="--no-sandbox"
+      # Known gap, stated rather than left to be inferred: the dossier
+      # (/property/[id]) is the heaviest and most shift-prone surface in the
+      # app and cannot be listed here, because its URL needs a real property
+      # id that only the walk above creates. Measuring it needs lhci driven
+      # from a run that knows the id — tracked with the layout-shift work.
+      #
       # The wire truth from the build's own manifest: every route's
-      # first-load JavaScript stays under the gzip budget.
+      # first-load JavaScript stays under the gzip budget, counted WITH the
+      # layouts that wrap it (#112).
       - name: First-load JS budget
         run: python3 scripts/check_bundle_budget.py
       - uses: actions/upload-artifact@v4

--- a/apps/web/lighthouserc.json
+++ b/apps/web/lighthouserc.json
@@ -6,6 +6,7 @@
       "url": [
         "http://localhost:3000/",
         "http://localhost:3000/transactions",
+        "http://localhost:3000/transactions/import",
         "http://localhost:3000/vendors",
         "http://localhost:3000/calendar"
       ],
@@ -16,9 +17,24 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.9 }],
-        "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.95 }]
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.95
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.95
+          }
+        ]
       }
     }
   }

--- a/scripts/check_bundle_budget.py
+++ b/scripts/check_bundle_budget.py
@@ -7,6 +7,13 @@ JavaScript — the chunks a browser must fetch before React hydrates — under
 a fixed gzip budget, computed from the build's own manifest rather than a
 framework's summary table, so the number is the wire truth.
 
+Two things this learned the hard way (#112). Next's per-route entries do
+NOT include the chunks of the layouts that wrap them, so a route measured
+on its own entry is measured without the code that ships on every page --
+here, the command palette and the emergency dispatch overlay. And a gate
+that only fails when a route is over budget will pass cheerfully when it
+measured no routes at all, which is how a gate stops gating.
+
 Runs against a completed ``next build``. Requires no running stack, no
 network, and no third-party packages. Exit code 0 means every route is
 under budget; 1 means at least one route is over, each named with its
@@ -24,6 +31,9 @@ import sys
 from pathlib import Path
 
 DEFAULT_BUDGET_KB = 180
+# The app has fourteen page routes today; a build that yields almost none
+# has failed in a way the per-route budget cannot see.
+MIN_ROUTES = 5
 
 
 def gzipped_size(path: Path) -> int:
@@ -31,20 +41,44 @@ def gzipped_size(path: Path) -> int:
     return len(gzip.compress(path.read_bytes(), compresslevel=6))
 
 
+def wrapping_layouts(route: str, keys: set[str]) -> list[str]:
+    """Every layout key that wraps ``route``, outermost first.
+
+    A route at ``/a/b/page`` is wrapped by ``/layout``, ``/a/layout`` and
+    ``/a/b/layout`` — whichever the manifest actually holds. Next lists a
+    layout's chunks only under its own key, never inside the routes it
+    wraps, so a route measured without these is measured without the code
+    that ships on every page under it.
+    """
+    segments = route.split("/")[1:-1]  # drop the leading "" and the trailing "page"
+    prefixes = ["/layout"]
+    for depth in range(len(segments)):
+        prefixes.append("/" + "/".join(segments[: depth + 1]) + "/layout")
+    return [p for p in prefixes if p in keys]
+
+
 def route_sizes(next_dir: Path) -> dict[str, int]:
     """Map each app route to the gzipped bytes of its first-load JS.
 
-    ``app-build-manifest.json`` lists, per route, every asset the route
-    needs on first load — shared framework chunks included, which is the
-    point: a shared chunk that bloats bloats every route.
+    Each route's own assets plus the assets of every layout that wraps it —
+    shared framework chunks included, which is the point: a shared chunk
+    that bloats bloats every route. Layout keys are not reported as routes
+    of their own; nobody navigates to a layout.
     """
     manifest_path = next_dir / "app-build-manifest.json"
     manifest = json.loads(manifest_path.read_text())
+    pages = manifest["pages"]
+    keys = set(pages)
     sizes: dict[str, int] = {}
     cache: dict[str, int] = {}
-    for route, assets in manifest["pages"].items():
+    for route, assets in pages.items():
+        if not route.endswith("/page"):
+            continue
+        wanted: list[str] = list(assets)
+        for layout in wrapping_layouts(route, keys):
+            wanted += pages[layout]
         total = 0
-        for asset in assets:
+        for asset in dict.fromkeys(wanted):  # de-duplicated, order preserved
             if not asset.endswith(".js"):
                 continue
             if asset not in cache:
@@ -57,6 +91,12 @@ def route_sizes(next_dir: Path) -> dict[str, int]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--app", default="apps/web", help="app directory holding .next")
+    parser.add_argument(
+        "--min-routes",
+        type=int,
+        default=MIN_ROUTES,
+        help="fail if fewer than this many routes were measured",
+    )
     parser.add_argument(
         "--budget-kb",
         type=int,
@@ -71,8 +111,19 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     budget = args.budget_kb * 1024
+    sizes = route_sizes(next_dir)
+    # A gate that passes when it measured nothing is not a gate. An empty
+    # manifest, or one whose shape a Next upgrade changed under us, must be
+    # a failure rather than a cheerful zero-route success.
+    if len(sizes) < args.min_routes:
+        print(
+            f"measured {len(sizes)} route(s), expected at least {args.min_routes} — "
+            "the manifest is empty or its shape changed; refusing to pass"
+        )
+        return 1
+
     over: list[str] = []
-    for route, size in sorted(route_sizes(next_dir).items()):
+    for route, size in sorted(sizes.items()):
         verdict = "over budget" if size > budget else "ok"
         print(f"{route:42s} {size / 1024:8.1f} KB gz  {verdict}")
         if size > budget:

--- a/scripts/tests/test_bundle_budget.py
+++ b/scripts/tests/test_bundle_budget.py
@@ -75,7 +75,8 @@ class GateTest(unittest.TestCase):
 
     def test_under_budget_passes(self) -> None:
         app = make_build({"/page": [("static/chunks/tiny.js", b"1;")]})
-        code, out = self.run_main(["--app", str(app), "--budget-kb", "180"])
+        # --min-routes 1: this case exercises the budget, not the floor.
+        code, out = self.run_main(["--app", str(app), "--budget-kb", "180", "--min-routes", "1"])
         self.assertEqual(code, 0)
         self.assertIn("every route under", out)
 
@@ -91,7 +92,7 @@ class GateTest(unittest.TestCase):
             chunks.append(block)
         heavy = b"".join(chunks)
         app = make_build({"/reports/page": [("static/chunks/heavy.js", heavy)]})
-        code, out = self.run_main(["--app", str(app), "--budget-kb", "1"])
+        code, out = self.run_main(["--app", str(app), "--budget-kb", "1", "--min-routes", "1"])
         self.assertEqual(code, 1)
         self.assertIn("/reports/page", out)
         self.assertIn("over the 1 KB", out)
@@ -101,6 +102,76 @@ class GateTest(unittest.TestCase):
         code, out = self.run_main(["--app", str(empty)])
         self.assertEqual(code, 1)
         self.assertIn("no build manifest", out)
+
+    def test_a_manifest_that_measures_nothing_is_a_failure(self) -> None:
+        # The hole this gate had: only routes OVER budget failed it, so an
+        # empty or shape-shifted manifest passed having measured nothing.
+        app = make_build({})
+        code, out = self.run_main(["--app", str(app)])
+        self.assertEqual(code, 1)
+        self.assertIn("measured 0 route(s)", out)
+
+    def test_a_thin_manifest_trips_the_floor(self) -> None:
+        app = make_build({"/page": [("static/chunks/a.js", b"1;")]})
+        code, out = self.run_main(["--app", str(app), "--min-routes", "5"])
+        self.assertEqual(code, 1)
+        self.assertIn("refusing to pass", out)
+
+
+class LayoutTest(unittest.TestCase):
+    """A route is measured with the layouts that wrap it, or it is not measured."""
+
+    def test_route_size_includes_the_root_layout_chunk(self) -> None:
+        page = b"const page = 1;" * 50
+        layout = b"const palette = 2;" * 200
+        app = make_build(
+            {
+                "/layout": [("static/chunks/app/layout.js", layout)],
+                "/page": [("static/chunks/app/page.js", page)],
+            }
+        )
+        sizes = check_bundle_budget.route_sizes(app / ".next")
+        expected = len(gzip.compress(page, compresslevel=6)) + len(
+            gzip.compress(layout, compresslevel=6)
+        )
+        self.assertEqual(sizes["/page"], expected)
+
+    def test_a_layout_is_not_reported_as_a_route(self) -> None:
+        app = make_build(
+            {
+                "/layout": [("static/chunks/app/layout.js", b"x;")],
+                "/page": [("static/chunks/app/page.js", b"y;")],
+            }
+        )
+        self.assertEqual(list(check_bundle_budget.route_sizes(app / ".next")), ["/page"])
+
+    def test_a_nested_layout_wraps_only_its_own_subtree(self) -> None:
+        # Pure key arithmetic: no build needed, only the manifest's key set.
+        make_build(
+            {
+                "/layout": [("static/chunks/root.js", b"r;")],
+                "/property/layout": [("static/chunks/prop.js", b"p;")],
+                "/property/[id]/page": [("static/chunks/dossier.js", b"d;")],
+                "/vendors/page": [("static/chunks/vendors.js", b"v;")],
+            }
+        )
+        keys = {"/layout", "/property/layout", "/property/[id]/page", "/vendors/page"}
+        self.assertEqual(
+            check_bundle_budget.wrapping_layouts("/property/[id]/page", keys),
+            ["/layout", "/property/layout"],
+        )
+        self.assertEqual(check_bundle_budget.wrapping_layouts("/vendors/page", keys), ["/layout"])
+
+    def test_a_chunk_shared_by_route_and_layout_is_counted_once(self) -> None:
+        shared = b"const framework = 1;" * 40
+        app = make_build(
+            {
+                "/layout": [("static/chunks/shared.js", shared)],
+                "/page": [("static/chunks/shared.js", shared)],
+            }
+        )
+        sizes = check_bundle_budget.route_sizes(app / ".next")
+        self.assertEqual(sizes["/page"], len(gzip.compress(shared, compresslevel=6)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #112.

Next lists a layout's chunks only under its own manifest key, never inside the routes it wraps. The gate summed each route's own entry, so every route was measured **without the code that ships on all of them** — here, the ⌘K palette and the emergency dispatch overlay. It then reported `/layout` as a route, which nobody navigates to and which hid the omission in plain sight.

## The honest numbers

Measured against a production build of `main`:

| Route | Reported before | Actual |
|---|---|---|
| `/property/[id]/page` (dossier) | 134.6 KB | **142.7 KB** |
| `/lease/[id]/page` | 126.0 KB | 133.2 KB |
| `/page` | 103.8 KB | 112.6 KB |
| `/layout` | 108.4 KB *(as a "route")* | — gone |

Every route is still inside the 180 KB budget, so **no verdict changes today** — the numbers are simply true now. Layout resolution walks ancestors, so a future nested layout counts for its own subtree and not its siblings, and a chunk shared between route and layout is counted once.

## The gate could also pass having measured nothing

Only routes *over* budget failed it, so an empty manifest — or one whose shape a Next upgrade changed under us — returned a cheerful "every route under the 180 KB first-load budget". It now refuses to pass below a floor of measured routes. That is the same species as #111 in a different gate, which is why both were worth doing together.

## Lighthouse

`/transactions/import` joins the URL list, having never been measured. **The dossier cannot join it**: its URL needs a property id that only the e2e walk creates. Rather than leave that to be inferred from what the file happens not to list, the gap is now stated in the workflow next to the step, and belongs with the layout-shift work in #115 — which is precisely the route where that defect lives.

Ladder: `pnpm run verify` green, 11 unit tests (4 new for layout resolution, 2 for the floor), ruff clean, config audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)