### PR TITLE
The split follows the money's date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,15 @@ jobs:
         run: >-
           pnpm --filter @hestia/web run lighthouse --
           --collect.settings.chromeFlags="--no-sandbox"
+      # Known gap, stated rather than left to be inferred: the dossier
+      # (/property/[id]) is the heaviest and most shift-prone surface in the
+      # app and cannot be listed here, because its URL needs a real property
+      # id that only the walk above creates. Measuring it needs lhci driven
+      # from a run that knows the id — tracked with the layout-shift work.
+      #
       # The wire truth from the build's own manifest: every route's
-      # first-load JavaScript stays under the gzip budget.
+      # first-load JavaScript stays under the gzip budget, counted WITH the
+      # layouts that wrap it (#112).
       - name: First-load JS budget
         run: python3 scripts/check_bundle_budget.py
       - uses: actions/upload-artifact@v4

--- a/apps/web/lighthouserc.json
+++ b/apps/web/lighthouserc.json
@@ -6,6 +6,7 @@
       "url": [
         "http://localhost:3000/",
         "http://localhost:3000/transactions",
+        "http://localhost:3000/transactions/import",
         "http://localhost:3000/vendors",
         "http://localhost:3000/calendar"
       ],
@@ -16,9 +17,24 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.9 }],
-        "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.95 }]
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.95
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.95
+          }
+        ]
       }
     }
   }

--- a/apps/web/src/app/transactions/import/page.tsx
+++ b/apps/web/src/app/transactions/import/page.tsx
@@ -41,36 +41,41 @@ export default function ImportPage() {
     setQueue(await api.reviewQueue(batchId, 'pending'));
   }, []);
 
-  // The engine splits for each property in the queue, fetched once per
-  // property. A property with no live amortizing note maps to an empty
-  // list, which is the honest no-offer state.
-  const [splitsByProperty, setSplitsByProperty] = useState<Record<string, NoteSplit[]>>({});
+  // The engine splits for each (property, posted_on) in the queue. The DATE
+  // is half the key: a statement imported in August carries rows from May,
+  // June and July, and each row's split is the split for ITS period — the
+  // level payment is identical across periods, so a period-blind split
+  // matches the amount exactly and posts the wrong figures silently (#99).
+  // A property with no live amortizing note maps to an empty list, which is
+  // the honest no-offer state.
+  const [splitsByRow, setSplitsByRow] = useState<Record<string, NoteSplit[]>>({});
   useEffect(() => {
     const pending = [
       ...new Set(
         queue
-          .map((row) => row.suggested_property_id)
-          .filter((id): id is string => id !== null && id !== undefined),
+          .filter((row) => row.suggested_property_id)
+          .map((row) => `${String(row.suggested_property_id)}|${row.posted_on}`),
       ),
-    ].filter((id) => !(id in splitsByProperty));
-    for (const propertyId of pending) {
+    ].filter((key) => !(key in splitsByRow));
+    for (const key of pending) {
+      const [propertyId, postedOn] = key.split('|') as [string, string];
       void (async () => {
         try {
           const debts = await api.listDebts({ propertyId });
           const loaded: NoteSplit[] = [];
           for (const debt of debts) {
             if (debt.paid_off_on !== null || debt.scheduled_payment === null) continue;
-            const split = noteSplit(debt, await api.debtSchedule(debt.id));
+            const split = noteSplit(debt, await api.debtSchedule(debt.id, postedOn));
             if (split) loaded.push(split);
           }
-          setSplitsByProperty((current) => ({ ...current, [propertyId]: loaded }));
+          setSplitsByRow((current) => ({ ...current, [key]: loaded }));
         } catch {
           // No offer is an honest state; plain accept still works.
-          setSplitsByProperty((current) => ({ ...current, [propertyId]: [] }));
+          setSplitsByRow((current) => ({ ...current, [key]: [] }));
         }
       })();
     }
-  }, [queue, splitsByProperty]);
+  }, [queue, splitsByRow]);
 
   const upload = async () => {
     if (!file) return;
@@ -215,7 +220,9 @@ export default function ImportPage() {
               void decide(() => api.excludeBankTransaction(txnId));
             }}
             noteSplits={(row) =>
-              row.suggested_property_id ? (splitsByProperty[row.suggested_property_id] ?? []) : []
+              row.suggested_property_id
+                ? (splitsByRow[`${row.suggested_property_id}|${row.posted_on}`] ?? [])
+                : []
             }
             onAcceptSplit={(row, split) => {
               void decide(() =>

--- a/apps/web/src/components/DebtPanel.tsx
+++ b/apps/web/src/components/DebtPanel.tsx
@@ -66,24 +66,41 @@ function ScheduleTable({ schedule }: { schedule: ScheduleOut }) {
 
 function PaymentForm({
   debt,
-  schedule,
+  amortizing,
   today,
   onRecord,
 }: {
   debt: DebtOut;
-  schedule: ScheduleOut | null;
+  amortizing: boolean;
   today: string;
   onRecord: (debtId: string, body: Parameters<typeof api.recordDebtPayment>[1]) => void;
 }) {
   const [paidOn, setPaidOn] = useState(today);
+  // `null` means the operator has not touched the field, so the figure shown
+  // is the engine's suggestion and travels as null — the server recomputes
+  // it from paid_on and gets the same answer. A figure they typed travels
+  // verbatim, because that is them stating what the lender actually applied.
   const [interest, setInterest] = useState<string | null>(null);
   const [principal, setPrincipal] = useState<string | null>(null);
   const [extraPrincipal, setExtraPrincipal] = useState('0');
   const [postToLedger, setPostToLedger] = useState(true);
-  // The engine's split for the period is the suggestion; a cleared field
-  // means "take the engine's figure", which is also what the server does.
-  const interestValue = interest ?? schedule?.next_interest ?? '';
-  const principalValue = principal ?? schedule?.next_principal ?? '';
+  // The suggestion is fetched AS OF the date the money carries. A payment
+  // dated in June is split by June's row, not by the row for the day the
+  // panel happened to load (#99).
+  const [suggestion, setSuggestion] = useState<ScheduleOut | null>(null);
+  useEffect(() => {
+    if (!amortizing || paidOn === '') return;
+    api
+      .debtSchedule(debt.id, paidOn)
+      .then(setSuggestion)
+      .catch(() => {
+        setSuggestion(null);
+      });
+  }, [debt.id, amortizing, paidOn]);
+
+  const stated = (value: string | null) => (value === null || value === '' ? null : value);
+  const interestValue = interest ?? suggestion?.next_interest ?? '';
+  const principalValue = principal ?? suggestion?.next_principal ?? '';
   return (
     <form
       className="form-row"
@@ -91,8 +108,8 @@ function PaymentForm({
         event.preventDefault();
         onRecord(debt.id, {
           paid_on: paidOn,
-          interest: interestValue === '' ? null : interestValue,
-          principal: principalValue === '' ? null : principalValue,
+          interest: stated(interest),
+          principal: stated(principal),
           extra_principal: extraPrincipal === '' ? '0' : extraPrincipal,
           // Escrow stays out of the v1 form; the default it means is zero.
           escrow: '0',
@@ -233,7 +250,7 @@ function NoteCard({
       ) : null}
       {retired ? null : (
         <>
-          <PaymentForm debt={debt} schedule={schedule} today={today} onRecord={onRecord} />
+          <PaymentForm debt={debt} amortizing={amortizing} today={today} onRecord={onRecord} />
           <p>
             <Button
               variant="quiet"

--- a/apps/web/src/components/MortgagePaymentOffer.tsx
+++ b/apps/web/src/components/MortgagePaymentOffer.tsx
@@ -2,7 +2,7 @@
 
 import { Button, CitationChip } from '@hestia/design';
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api, type DebtOut } from '../lib/api';
 import { type NoteSplit, noteSplit } from '../lib/mortgage-split';
 import { formatMoney } from './TransactionsTable';
 
@@ -27,33 +27,70 @@ export function MortgagePaymentOffer({
   occurredOn,
   onRecorded,
 }: MortgagePaymentOfferProps) {
+  const [notes, setNotes] = useState<DebtOut[]>([]);
   const [splits, setSplits] = useState<NoteSplit[]>([]);
   const [chosen, setChosen] = useState('');
   const [error, setError] = useState<string | null>(null);
 
+  // Which notes could settle this — knowable without a date, so the path is
+  // discoverable before one is picked.
   useEffect(() => {
+    api
+      .listDebts({ propertyId })
+      .then((debts) => {
+        setNotes(debts.filter((d) => d.paid_off_on === null && d.scheduled_payment !== null));
+      })
+      .catch(() => {
+        // No offer is an honest state; the plain form still records.
+        setNotes([]);
+      });
+  }, [propertyId]);
+
+  // The figures, which are NOT knowable without a date: the split is fetched
+  // as of the day the money carries, so what is promised here is what the
+  // server will write for that date (#99).
+  useEffect(() => {
+    if (occurredOn === '' || notes.length === 0) {
+      setSplits([]);
+      return;
+    }
     (async () => {
       try {
-        const debts = await api.listDebts({ propertyId });
-        const live = debts.filter(
-          (debt) => debt.paid_off_on === null && debt.scheduled_payment !== null,
-        );
         const loaded: NoteSplit[] = [];
-        for (const debt of live) {
-          const split = noteSplit(debt, await api.debtSchedule(debt.id));
+        for (const debt of notes) {
+          const split = noteSplit(debt, await api.debtSchedule(debt.id, occurredOn));
           if (split) loaded.push(split);
         }
         setSplits(loaded);
-        setChosen(loaded[0]?.debtId ?? '');
+        setChosen((current) =>
+          loaded.some((l) => l.debtId === current) ? current : (loaded[0]?.debtId ?? ''),
+        );
       } catch {
-        // No offer is an honest state; the plain form still records.
         setSplits([]);
       }
     })();
-  }, [propertyId]);
+  }, [notes, occurredOn]);
+
+  if (notes.length === 0) {
+    return null;
+  }
 
   const split = splits.find((candidate) => candidate.debtId === chosen);
   if (!split) {
+    // Two different silences, and only one of them is worth breaking. No
+    // date yet: name the path, because the operator cannot discover it
+    // otherwise. A date with no split (a spent schedule, a fetch that
+    // failed): say nothing — the plain form below records it honestly.
+    if (occurredOn === '') {
+      return (
+        <div className="card">
+          <p>
+            <strong>This looks like a note payment.</strong> Pick the date above and the
+            engine&rsquo;s split for that period appears here, ready to record as the linked pair.
+          </p>
+        </div>
+      );
+    }
     return null;
   }
 
@@ -102,16 +139,16 @@ export function MortgagePaymentOffer({
         </div>
       ) : null}
       {error ? <p className="error-note">{error}</p> : null}
+      {/* A split only exists once a date does, so the button cannot be
+          reached without one — the dateless case returned above. */}
       <Button
         type="button"
-        disabled={occurredOn === ''}
         onClick={() => {
           void record();
         }}
       >
         Record through {split.lender}
-      </Button>{' '}
-      {occurredOn === '' ? <span className="muted">— pick the date above first</span> : null}
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/lib/mortgage-split.ts
+++ b/apps/web/src/lib/mortgage-split.ts
@@ -6,7 +6,16 @@
  * arithmetic of its own beyond exact money comparison: the figures are the
  * engine's, passed through.
  */
-import { abs, add, equals, lessThan, money, subtract, toDecimalString } from '@hestia/domain';
+import {
+  abs,
+  add,
+  equals,
+  isZero,
+  lessThan,
+  money,
+  subtract,
+  toDecimalString,
+} from '@hestia/domain';
 import type { DebtOut, LedgerEventOut, ScheduleOut } from './api';
 
 export interface NoteSplit {
@@ -85,17 +94,28 @@ export function matchOffers(
 }
 
 /** The AcceptIn splits for a row settled by a note: the engine's figures,
- * carrying the row's own sign so the pair sums to the row exactly. */
+ * carrying the row's own sign so the pair sums to the row exactly.
+ *
+ * A zero leg is omitted, mirroring the server's own convention: the ledger
+ * refuses a zero amount, so emitting one turned an offered accept into a 422
+ * for every 0%-rate note and for a final row whose interest rounds away. The
+ * surviving leg still sums to the row exactly, because the other was zero. */
 export function acceptSplits(
   rowAmount: string,
   split: NoteSplit,
 ): { category: 'mortgage_interest' | 'mortgage_principal'; amount: string }[] {
   const outflow = lessThan(money(rowAmount), money('0'));
   const signed = (value: string) => (outflow ? `-${value}` : value);
-  return [
-    { category: 'mortgage_interest', amount: signed(split.interest) },
-    { category: 'mortgage_principal', amount: signed(split.principal) },
-  ];
+  const legs: { category: 'mortgage_interest' | 'mortgage_principal'; amount: string }[] = [];
+  for (const [category, value] of [
+    ['mortgage_interest', split.interest],
+    ['mortgage_principal', split.principal],
+  ] as const) {
+    if (!isZero(money(value))) {
+      legs.push({ category, amount: signed(value) });
+    }
+  }
+  return legs;
 }
 
 export type RegisterLine =

--- a/apps/web/tests/debt-panel.test.tsx
+++ b/apps/web/tests/debt-panel.test.tsx
@@ -131,7 +131,10 @@ describe('DebtPanel', () => {
     await waitFor(() => {
       expect(record).toHaveBeenCalledWith('n1', {
         paid_on: '2026-09-01',
-        interest: '985.61',
+        // Interest was never touched, so it travels as null and the server
+        // splits September by September's row — the figure on screen was a
+        // suggestion, never a statement (#99).
+        interest: null,
         principal: '200.00',
         extra_principal: '100.00',
         escrow: '0',
@@ -164,6 +167,54 @@ describe('DebtPanel', () => {
         escrow: '0',
         post_to_ledger: false,
       });
+    });
+  });
+
+  it('asks the engine for the split AS OF the date being recorded', async () => {
+    const { scheduleSpy } = arrange([NOTE]);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect(scheduleSpy).toHaveBeenCalledWith('n1', TODAY);
+    });
+    // Backdating a catch-up payment re-asks for THAT period's row rather
+    // than keeping the figures for the day the panel happened to load.
+    fireEvent.change(screen.getByLabelText('Paid on'), { target: { value: '2026-06-01' } });
+    await waitFor(() => {
+      expect(scheduleSpy).toHaveBeenCalledWith('n1', '2026-06-01');
+    });
+  });
+
+  it('re-prefills from the backdated period, and still states nothing', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockImplementation((_id, asOf) =>
+      Promise.resolve(
+        asOf === '2026-06-01'
+          ? ({
+              ...SCHEDULE,
+              next_month: 6,
+              next_interest: '984.84',
+              next_principal: '185.02',
+            } as ScheduleOut)
+          : SCHEDULE,
+      ),
+    );
+    const record = vi.spyOn(api, 'recordDebtPayment').mockResolvedValue({} as never);
+    render(<DebtPanel propertyId="p1" today={TODAY} />);
+    await waitFor(() => {
+      expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('985.61');
+    });
+    fireEvent.change(screen.getByLabelText('Paid on'), { target: { value: '2026-06-01' } });
+    // The suggestion follows the date: June's row, not August's.
+    await waitFor(() => {
+      expect((screen.getByLabelText('Interest') as HTMLInputElement).value).toBe('984.84');
+    });
+    expect((screen.getByLabelText('Principal') as HTMLInputElement).value).toBe('185.02');
+    fireEvent.click(screen.getByRole('button', { name: 'Record the payment' }));
+    await waitFor(() => {
+      expect(record).toHaveBeenCalledWith(
+        'n1',
+        expect.objectContaining({ paid_on: '2026-06-01', interest: null, principal: null }),
+      );
     });
   });
 

--- a/apps/web/tests/mortgage-payment-offer.test.tsx
+++ b/apps/web/tests/mortgage-payment-offer.test.tsx
@@ -80,17 +80,43 @@ describe('MortgagePaymentOffer', () => {
     });
   });
 
-  it('waits for a date rather than guessing one', async () => {
+  it('names the path without a date, but promises no figures', async () => {
     vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
-    vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
+    const scheduleSpy = vi.spyOn(api, 'debtSchedule').mockResolvedValue(SCHEDULE);
     render(<MortgagePaymentOffer propertyId="p1" occurredOn="" onRecorded={vi.fn()} />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Record through/ })).toBeDefined();
+      expect(screen.getByText(/This looks like a note payment/)).toBeDefined();
     });
-    expect(
-      (screen.getByRole('button', { name: /Record through/ }) as HTMLButtonElement).disabled,
-    ).toBe(true);
-    expect(screen.getByText(/pick the date above first/)).toBeDefined();
+    // A split is a fact about a period. With no date there is no period, so
+    // the engine is not asked and no figure is shown (#99).
+    expect(scheduleSpy).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /Record through/ })).toBeNull();
+    expect(screen.queryByText(/interest,/)).toBeNull();
+  });
+
+  it('asks the engine as of the date being recorded, and follows it', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    const scheduleSpy = vi
+      .spyOn(api, 'debtSchedule')
+      .mockImplementation((_id, asOf) =>
+        Promise.resolve(
+          asOf === '2026-06-01'
+            ? ({ ...SCHEDULE, next_interest: '984.84', next_principal: '185.02' } as ScheduleOut)
+            : SCHEDULE,
+        ),
+      );
+    const { rerender } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/\$985\.61 interest/)).toBeDefined();
+    });
+    expect(scheduleSpy).toHaveBeenCalledWith('n1', '2026-08-28');
+    rerender(<MortgagePaymentOffer propertyId="p1" occurredOn="2026-06-01" onRecorded={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/\$984\.84 interest/)).toBeDefined();
+    });
+    expect(scheduleSpy).toHaveBeenCalledWith('n1', '2026-06-01');
   });
 
   it('renders nothing without a live amortizing note', async () => {
@@ -123,6 +149,53 @@ describe('MortgagePaymentOffer', () => {
       expect(api.debtSchedule).toHaveBeenCalled();
     });
     expect(container.firstElementChild).toBeNull();
+  });
+
+  it('a schedule that will not load leaves the plain form to do the work', async () => {
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE]);
+    vi.spyOn(api, 'debtSchedule').mockRejectedValue(new Error('schedule unavailable'));
+    const { container } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(api.debtSchedule).toHaveBeenCalled();
+    });
+    // The note exists and the date is known, so there is no path to name —
+    // and no figures to promise. Silence, and the form below still records.
+    await waitFor(() => {
+      expect(container.firstElementChild).toBeNull();
+    });
+  });
+
+  it('keeps the operator\u2019s chosen note when the date changes', async () => {
+    const junior = { ...NOTE, id: 'n2', lender: 'Second Street' } as DebtOut;
+    vi.spyOn(api, 'listDebts').mockResolvedValue([NOTE, junior]);
+    vi.spyOn(api, 'debtSchedule').mockImplementation((debtId) =>
+      Promise.resolve(
+        debtId === 'n1'
+          ? SCHEDULE
+          : ({
+              ...SCHEDULE,
+              debt_id: 'n2',
+              next_interest: '100.00',
+              next_principal: '50.00',
+            } as ScheduleOut),
+      ),
+    );
+    const { rerender } = render(
+      <MortgagePaymentOffer propertyId="p1" occurredOn="2026-08-28" onRecorded={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText('Which note')).toBeDefined();
+    });
+    fireEvent.change(screen.getByLabelText('Which note'), { target: { value: 'n2' } });
+    expect(screen.getByRole('button', { name: 'Record through Second Street' })).toBeDefined();
+    rerender(<MortgagePaymentOffer propertyId="p1" occurredOn="2026-07-01" onRecorded={vi.fn()} />);
+    // Refetching for a new period must not silently reset which note the
+    // operator said they were paying.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Record through Second Street' })).toBeDefined();
+    });
   });
 
   it('a failed fetch is a quiet no-offer, never a broken form', async () => {

--- a/apps/web/tests/mortgage-split.test.ts
+++ b/apps/web/tests/mortgage-split.test.ts
@@ -152,6 +152,30 @@ describe('acceptSplits', () => {
   });
 });
 
+describe('acceptSplits and the zero leg', () => {
+  it('omits a zero interest leg, which the ledger refuses', () => {
+    // A 0%-rate note (seller financing) has no interest in any period. The
+    // old shape emitted a 0.00 leg and every offered accept 422'd (#99).
+    const free: NoteSplit = { ...SPLIT, interest: '0.00', principal: '250.00', payment: '250.00' };
+    expect(acceptSplits('-250.00', free)).toEqual([
+      { category: 'mortgage_principal', amount: '-250.00' },
+    ]);
+  });
+
+  it('omits a zero principal leg the same way', () => {
+    const io: NoteSplit = { ...SPLIT, interest: '400.00', principal: '0.00', payment: '400.00' };
+    expect(acceptSplits('-400.00', io)).toEqual([
+      { category: 'mortgage_interest', amount: '-400.00' },
+    ]);
+  });
+
+  it('the surviving leg still sums to the row exactly', () => {
+    const free: NoteSplit = { ...SPLIT, interest: '0.00', principal: '250.00', payment: '250.00' };
+    const legs = acceptSplits('-250.00', free);
+    expect(legs.reduce((total, leg) => total + Number(leg.amount), 0)).toBe(-250);
+  });
+});
+
 describe('pairMortgageEvents', () => {
   it('folds the pair into one payment with the exact total', () => {
     const lines = pairMortgageEvents(pairEvents());

--- a/scripts/check_bundle_budget.py
+++ b/scripts/check_bundle_budget.py
@@ -7,6 +7,13 @@ JavaScript — the chunks a browser must fetch before React hydrates — under
 a fixed gzip budget, computed from the build's own manifest rather than a
 framework's summary table, so the number is the wire truth.
 
+Two things this learned the hard way (#112). Next's per-route entries do
+NOT include the chunks of the layouts that wrap them, so a route measured
+on its own entry is measured without the code that ships on every page --
+here, the command palette and the emergency dispatch overlay. And a gate
+that only fails when a route is over budget will pass cheerfully when it
+measured no routes at all, which is how a gate stops gating.
+
 Runs against a completed ``next build``. Requires no running stack, no
 network, and no third-party packages. Exit code 0 means every route is
 under budget; 1 means at least one route is over, each named with its
@@ -24,6 +31,9 @@ import sys
 from pathlib import Path
 
 DEFAULT_BUDGET_KB = 180
+# The app has fourteen page routes today; a build that yields almost none
+# has failed in a way the per-route budget cannot see.
+MIN_ROUTES = 5
 
 
 def gzipped_size(path: Path) -> int:
@@ -31,20 +41,44 @@ def gzipped_size(path: Path) -> int:
     return len(gzip.compress(path.read_bytes(), compresslevel=6))
 
 
+def wrapping_layouts(route: str, keys: set[str]) -> list[str]:
+    """Every layout key that wraps ``route``, outermost first.
+
+    A route at ``/a/b/page`` is wrapped by ``/layout``, ``/a/layout`` and
+    ``/a/b/layout`` — whichever the manifest actually holds. Next lists a
+    layout's chunks only under its own key, never inside the routes it
+    wraps, so a route measured without these is measured without the code
+    that ships on every page under it.
+    """
+    segments = route.split("/")[1:-1]  # drop the leading "" and the trailing "page"
+    prefixes = ["/layout"]
+    for depth in range(len(segments)):
+        prefixes.append("/" + "/".join(segments[: depth + 1]) + "/layout")
+    return [p for p in prefixes if p in keys]
+
+
 def route_sizes(next_dir: Path) -> dict[str, int]:
     """Map each app route to the gzipped bytes of its first-load JS.
 
-    ``app-build-manifest.json`` lists, per route, every asset the route
-    needs on first load — shared framework chunks included, which is the
-    point: a shared chunk that bloats bloats every route.
+    Each route's own assets plus the assets of every layout that wraps it —
+    shared framework chunks included, which is the point: a shared chunk
+    that bloats bloats every route. Layout keys are not reported as routes
+    of their own; nobody navigates to a layout.
     """
     manifest_path = next_dir / "app-build-manifest.json"
     manifest = json.loads(manifest_path.read_text())
+    pages = manifest["pages"]
+    keys = set(pages)
     sizes: dict[str, int] = {}
     cache: dict[str, int] = {}
-    for route, assets in manifest["pages"].items():
+    for route, assets in pages.items():
+        if not route.endswith("/page"):
+            continue
+        wanted: list[str] = list(assets)
+        for layout in wrapping_layouts(route, keys):
+            wanted += pages[layout]
         total = 0
-        for asset in assets:
+        for asset in dict.fromkeys(wanted):  # de-duplicated, order preserved
             if not asset.endswith(".js"):
                 continue
             if asset not in cache:
@@ -57,6 +91,12 @@ def route_sizes(next_dir: Path) -> dict[str, int]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--app", default="apps/web", help="app directory holding .next")
+    parser.add_argument(
+        "--min-routes",
+        type=int,
+        default=MIN_ROUTES,
+        help="fail if fewer than this many routes were measured",
+    )
     parser.add_argument(
         "--budget-kb",
         type=int,
@@ -71,8 +111,19 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     budget = args.budget_kb * 1024
+    sizes = route_sizes(next_dir)
+    # A gate that passes when it measured nothing is not a gate. An empty
+    # manifest, or one whose shape a Next upgrade changed under us, must be
+    # a failure rather than a cheerful zero-route success.
+    if len(sizes) < args.min_routes:
+        print(
+            f"measured {len(sizes)} route(s), expected at least {args.min_routes} — "
+            "the manifest is empty or its shape changed; refusing to pass"
+        )
+        return 1
+
     over: list[str] = []
-    for route, size in sorted(route_sizes(next_dir).items()):
+    for route, size in sorted(sizes.items()):
         verdict = "over budget" if size > budget else "ok"
         print(f"{route:42s} {size / 1024:8.1f} KB gz  {verdict}")
         if size > budget:

--- a/scripts/tests/test_bundle_budget.py
+++ b/scripts/tests/test_bundle_budget.py
@@ -75,7 +75,8 @@ class GateTest(unittest.TestCase):
 
     def test_under_budget_passes(self) -> None:
         app = make_build({"/page": [("static/chunks/tiny.js", b"1;")]})
-        code, out = self.run_main(["--app", str(app), "--budget-kb", "180"])
+        # --min-routes 1: this case exercises the budget, not the floor.
+        code, out = self.run_main(["--app", str(app), "--budget-kb", "180", "--min-routes", "1"])
         self.assertEqual(code, 0)
         self.assertIn("every route under", out)
 
@@ -91,7 +92,7 @@ class GateTest(unittest.TestCase):
             chunks.append(block)
         heavy = b"".join(chunks)
         app = make_build({"/reports/page": [("static/chunks/heavy.js", heavy)]})
-        code, out = self.run_main(["--app", str(app), "--budget-kb", "1"])
+        code, out = self.run_main(["--app", str(app), "--budget-kb", "1", "--min-routes", "1"])
         self.assertEqual(code, 1)
         self.assertIn("/reports/page", out)
         self.assertIn("over the 1 KB", out)
@@ -101,6 +102,76 @@ class GateTest(unittest.TestCase):
         code, out = self.run_main(["--app", str(empty)])
         self.assertEqual(code, 1)
         self.assertIn("no build manifest", out)
+
+    def test_a_manifest_that_measures_nothing_is_a_failure(self) -> None:
+        # The hole this gate had: only routes OVER budget failed it, so an
+        # empty or shape-shifted manifest passed having measured nothing.
+        app = make_build({})
+        code, out = self.run_main(["--app", str(app)])
+        self.assertEqual(code, 1)
+        self.assertIn("measured 0 route(s)", out)
+
+    def test_a_thin_manifest_trips_the_floor(self) -> None:
+        app = make_build({"/page": [("static/chunks/a.js", b"1;")]})
+        code, out = self.run_main(["--app", str(app), "--min-routes", "5"])
+        self.assertEqual(code, 1)
+        self.assertIn("refusing to pass", out)
+
+
+class LayoutTest(unittest.TestCase):
+    """A route is measured with the layouts that wrap it, or it is not measured."""
+
+    def test_route_size_includes_the_root_layout_chunk(self) -> None:
+        page = b"const page = 1;" * 50
+        layout = b"const palette = 2;" * 200
+        app = make_build(
+            {
+                "/layout": [("static/chunks/app/layout.js", layout)],
+                "/page": [("static/chunks/app/page.js", page)],
+            }
+        )
+        sizes = check_bundle_budget.route_sizes(app / ".next")
+        expected = len(gzip.compress(page, compresslevel=6)) + len(
+            gzip.compress(layout, compresslevel=6)
+        )
+        self.assertEqual(sizes["/page"], expected)
+
+    def test_a_layout_is_not_reported_as_a_route(self) -> None:
+        app = make_build(
+            {
+                "/layout": [("static/chunks/app/layout.js", b"x;")],
+                "/page": [("static/chunks/app/page.js", b"y;")],
+            }
+        )
+        self.assertEqual(list(check_bundle_budget.route_sizes(app / ".next")), ["/page"])
+
+    def test_a_nested_layout_wraps_only_its_own_subtree(self) -> None:
+        # Pure key arithmetic: no build needed, only the manifest's key set.
+        make_build(
+            {
+                "/layout": [("static/chunks/root.js", b"r;")],
+                "/property/layout": [("static/chunks/prop.js", b"p;")],
+                "/property/[id]/page": [("static/chunks/dossier.js", b"d;")],
+                "/vendors/page": [("static/chunks/vendors.js", b"v;")],
+            }
+        )
+        keys = {"/layout", "/property/layout", "/property/[id]/page", "/vendors/page"}
+        self.assertEqual(
+            check_bundle_budget.wrapping_layouts("/property/[id]/page", keys),
+            ["/layout", "/property/layout"],
+        )
+        self.assertEqual(check_bundle_budget.wrapping_layouts("/vendors/page", keys), ["/layout"])
+
+    def test_a_chunk_shared_by_route_and_layout_is_counted_once(self) -> None:
+        shared = b"const framework = 1;" * 40
+        app = make_build(
+            {
+                "/layout": [("static/chunks/shared.js", shared)],
+                "/page": [("static/chunks/shared.js", shared)],
+            }
+        )
+        sizes = check_bundle_budget.route_sizes(app / ".next")
+        self.assertEqual(sizes["/page"], len(gzip.compress(shared, compresslevel=6)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #99.

The engine's split was fetched for **today's** period and applied to money dated in some other period. Backdating a June payment in August recorded June's payment with August's row — **$1.93 moved off Schedule E's deductible interest line into equity** on the fixture note, growing with the gap, with `balance_after` inheriting it. `?as_of=` has always existed on the API; three call sites never passed it.

## The correctness fix is smaller than the plumbing

An untouched field now travels as `null`. The pre-fill is a *suggestion*, and the server recomputes the same figure from `paid_on` — which is exactly what the doctrine comment in 66bd552 always claimed, and which was only true while the two dates shared a period. A figure the operator **typed** still travels verbatim, because that is them stating what the lender actually applied.

## Then the plumbing, so the screen matches the record

- `DebtPanel` fetches as of `paid_on` and refetches when the date changes.
- `MortgagePaymentOffer` fetches as of the date being recorded, and follows it.
- The import page caches per **(property, posted_on)**, not per property. A statement imported in August carries rows from May, June and July, and because the level payment is identical across periods the exact-amount match still succeeded — so wrong-period figures posted under the engine's citation *with no visible symptom*. That was the retrospective-import workflow the feature was built for.

## Two silences, told apart

The offer used to render a disabled button with "pick the date above first". With no date there is no period and therefore no split, so it now names the path without promising figures — and asks the engine nothing. With a date and no split (a spent schedule, a fetch that failed) it says nothing at all and leaves the plain form to record honestly. The dateless `disabled` branch became unreachable and was removed rather than covered, per the house rule about redundant state.

## And the offer that could never be accepted

`acceptSplits` always emitted both legs, but the ledger refuses a zero amount — so a 0%-rate note (seller financing, a tested engine path) rendered "Accept as engine split" and **422'd on every click**. The zero leg is now omitted, mirroring `record_payment`'s own convention, and the surviving leg still sums to the row exactly.

## Ladder

271 unit tests, **100% statements / branches / functions / lines**; 25/25 e2e against the live stack; `pnpm run verify` green — and this is the first change verified by the honest gate from #111, which would previously have replayed a cached pass for test-only edits like several of these.

New tests that fail against `main`: the panel asks as of the recorded date and re-prefills from it; untouched figures travel null while typed ones travel verbatim; the offer follows the date; the zero leg is omitted.

**Not fixed here, deliberately**: the e2e walk still dates its world in literals, so it cannot yet catch this class itself — that is #118, and it is what would have caught this on the day it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)