### PR TITLE
The two silences behind a dark appeal window are told apart

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -3371,7 +3371,7 @@ export interface components {
              * Reason
              * @enum {string}
              */
-            reason: "no_state_jurisdiction" | "no_rule_for_domain" | "calendar_key_unregistered" | "window_not_published";
+            reason: "no_state_jurisdiction" | "no_rule_for_domain" | "calendar_key_unregistered" | "window_not_published" | "window_awaiting_publication";
             /** State */
             state: string;
         };

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -6940,7 +6940,8 @@
               "no_state_jurisdiction",
               "no_rule_for_domain",
               "calendar_key_unregistered",
-              "window_not_published"
+              "window_not_published",
+              "window_awaiting_publication"
             ],
             "title": "Reason",
             "type": "string"

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -1237,8 +1237,11 @@ class SweepGapOut(BaseModel):
         "no_rule_for_domain",
         "calendar_key_unregistered",
         # The pack says this state publishes its window rather than
-        # computing it, and no upcoming date is loaded.
+        # computing it, and no date has ever been loaded.
         "window_not_published",
+        # A published window did its job and expired on schedule; the county's
+        # next date must be entered when it publishes.
+        "window_awaiting_publication",
     ]
     detail: str
 

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -49,7 +49,8 @@ class CoverageGap:
     state: str
     domain: str
     reason: str  # no_state_jurisdiction | no_rule_for_domain |
-    #              calendar_key_unregistered | window_not_published
+    #              calendar_key_unregistered | window_not_published |
+    #              window_awaiting_publication
     detail: str
 
 
@@ -139,12 +140,36 @@ published AS (
   WHERE closes.value_text::date >= %(as_of)s
   ORDER BY a.property_id, c.depth ASC, closes.value_text::date ASC
 )
+,
+-- The most recent window that has already closed — history, not law, which is
+-- why the effective window filter is absent on purpose: an expired row is
+-- exactly what this looks for. A published-shape state goes dark every year
+-- by design the day its window closes, and stays dark until the county
+-- publishes the next date; the difference between that and a state nobody
+-- ever entered is the difference between "act when the county speaks" and
+-- "this state has no data", and only this row can tell them apart.
+expired AS (
+  SELECT DISTINCT ON (a.property_id)
+         a.property_id,
+         closes.value_text::date AS closes_on,
+         closes.citation
+  FROM anchored a
+  CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+  JOIN jurisdiction_rules closes
+    ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.domain = 'assessment_appeal'
+   AND closes.code = 'appeal.window.closes_on'
+   AND closes.superseded_by IS NULL
+  WHERE closes.value_text::date < %(as_of)s
+  ORDER BY a.property_id, closes.value_text::date DESC, c.depth ASC
+)
 SELECT a.property_id, a.state, a.start_id,
        cal.value_text AS calendar_key, cal.citation AS citation,
        ins.value_text AS instructions,
        src.value_text AS window_source, src.citation AS source_citation,
        pub.opens_on AS published_opens_on, pub.closes_on AS published_closes_on,
-       pub.citation AS published_citation
+       pub.citation AS published_citation,
+       exp.closes_on AS last_closes_on, exp.citation AS last_citation
 FROM anchored a
 LEFT JOIN resolved cal
   ON cal.property_id = a.property_id AND cal.code = 'appeal.window.calendar'
@@ -153,6 +178,7 @@ LEFT JOIN resolved ins
 LEFT JOIN resolved src
   ON src.property_id = a.property_id AND src.code = 'appeal.window.source'
 LEFT JOIN published pub ON pub.property_id = a.property_id
+LEFT JOIN expired exp ON exp.property_id = a.property_id
 """
 
 
@@ -195,9 +221,31 @@ def _appeal_windows(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], l
             continue
         if record["window_source"] is not None:
             # The pack says this state's window is published rather than
-            # computed, and no upcoming date is loaded. That is a different
-            # answer from "this state has no appeal rules at all", and the
-            # difference is what tells someone where to go looking.
+            # computed, and no upcoming date is loaded. Two different silences
+            # hide behind that, and they demand different acts. A state whose
+            # LAST window is on record went dark on schedule — every
+            # published-shape state does, yearly, the day its window closes —
+            # and the act is to enter the county's next date when it speaks.
+            # A state with no dated row at all was never entered, and the act
+            # is to go find this year's date now. One reason for each, so
+            # neither can hide inside the other.
+            if record["last_closes_on"] is not None:
+                gaps.append(
+                    CoverageGap(
+                        property_id=str(record["property_id"]),
+                        state=record["state"],
+                        domain="assessment_appeal",
+                        reason="window_awaiting_publication",
+                        detail=(
+                            f"the last known appeal window closed "
+                            f"{record['last_closes_on'].isoformat()} "
+                            f"({record['last_citation']}); the next date is set by "
+                            "the county and must be entered when it publishes — "
+                            "until then the window is honestly unknown"
+                        ),
+                    )
+                )
+                continue
             gaps.append(
                 CoverageGap(
                     property_id=str(record["property_id"]),
@@ -205,9 +253,10 @@ def _appeal_windows(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], l
                     domain="assessment_appeal",
                     reason="window_not_published",
                     detail=(
-                        f"{record['source_citation']}: no upcoming appeal window is "
-                        "loaded for this jurisdiction, and the date is not one this "
-                        "build may compute"
+                        f"{record['source_citation']}: no appeal window has ever "
+                        "been loaded for this jurisdiction, and the date is not one "
+                        "this build may compute — find this year's published date "
+                        "and enter it"
                     ),
                 )
             )

--- a/services/api/tests/test_sweep.py
+++ b/services/api/tests/test_sweep.py
@@ -349,13 +349,21 @@ def test_a_published_window_that_has_passed_is_a_named_gap_not_a_guess(
     assert early["inserted"]["assessment_appeal_window"] == 1
     assert not [g for g in early["coverage_gaps"] if g["domain"] == "assessment_appeal"]
 
-    # After it: a gap that names why, and NO invented deadline.
+    # After it: a gap that names why, and NO invented deadline. This is the
+    # state every published-shape jurisdiction enters yearly, ON SCHEDULE, the
+    # day its window closes — so the gap must read as "the county has not
+    # spoken yet", never as "nobody ever entered this state" (issue #127: the
+    # two silences demand different acts, and the darkness was silent).
     late = client.post("/sweep/deadlines?as_of=2026-07-01").json()
     assert "assessment_appeal_window" not in late["inserted"]
     gap = next(g for g in late["coverage_gaps"] if g["domain"] == "assessment_appeal")
-    assert gap["reason"] == "window_not_published"
+    assert gap["reason"] == "window_awaiting_publication"
     assert gap["property_id"] == property_id
-    assert "67-1-404" in gap["detail"]
+    # The detail names the last known window and its authority, so a reader
+    # knows the data was alive and what to watch for.
+    assert "2026-06-26" in gap["detail"]
+    assert "Metropolitan Board of Equalization" in gap["detail"]
+    assert "entered when it publishes" in gap["detail"]
     assert (
         conn.execute(
             "SELECT count(*) AS n FROM deadlines WHERE kind = 'assessment_appeal_window'"
@@ -364,6 +372,69 @@ def test_a_published_window_that_has_passed_is_a_named_gap_not_a_guess(
         ).fetchone()["n"]
         == 0
     )
+
+
+def test_a_published_state_with_no_date_ever_loaded_says_so_differently(
+    clean: None, client: TestClient, conn: psycopg.Connection[Any]
+) -> None:
+    """The other silence. A pack may declare its windows are published by the
+    county before anyone has entered a single date — a brand-new state, mid
+    onboarding. That is not "awaiting publication", it is "go find this
+    year's date", and the two must not share a reason. Sandboxed synthetic
+    state, since jurisdiction_rules is append-only."""
+    if (
+        conn.execute(
+            "SELECT 1 AS x FROM jurisdictions WHERE state = 'QP' AND level = 'state'"
+        ).fetchone()
+        is None
+    ):
+        conn.execute(
+            """
+            WITH state_row AS (
+              INSERT INTO jurisdictions (level, name, state, parent_id)
+              SELECT 'state', 'Quopland', 'QP', id FROM jurisdictions
+              WHERE level = 'federal' RETURNING id
+            )
+            INSERT INTO jurisdictions (level, name, state, parent_id)
+            SELECT 'municipality', 'Quopville', 'QP', id FROM state_row
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO jurisdiction_rules
+              (jurisdiction_id, domain, code, value_text, citation, effective_from)
+            SELECT id, 'assessment_appeal', 'appeal.window.source',
+                   'published_by_county; the county sets the date annually',
+                   'QP Rev. Stat. 9.9 (test fixture)', DATE '2000-01-01'
+            FROM jurisdictions WHERE state = 'QP' AND level = 'state'
+            """
+        )
+        conn.commit()
+    entity_id = str(uuid.uuid4())
+    conn.execute("INSERT INTO entities (id, name, kind) VALUES (%s, 'QP LLC', 'llc')", (entity_id,))
+    property_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO properties (id, entity_id, label, street_1, city, state,
+                                postal_code, kind, jurisdiction_id)
+        VALUES (%s, %s, 'qp', '1 Main St', 'Quopville', 'QP', '00000',
+                'single_family',
+                (SELECT id FROM jurisdictions
+                  WHERE name = 'Quopville' AND level = 'municipality'))
+        """,
+        (property_id, entity_id),
+    )
+    conn.commit()
+
+    body = client.post("/sweep/deadlines?as_of=2026-07-01").json()
+    gap = next(
+        g
+        for g in body["coverage_gaps"]
+        if g["domain"] == "assessment_appeal" and g["property_id"] == property_id
+    )
+    assert gap["reason"] == "window_not_published"
+    assert "no appeal window has ever been loaded" in gap["detail"]
+    assert "QP Rev. Stat. 9.9" in gap["detail"]
 
 
 def test_an_empty_portfolio_sweeps_to_zero_today(clean: None, client: TestClient) -> None:


### PR DESCRIPTION
Closes #127 — the January landmine from the strategic-reset note, defused at its mechanism.

A published-shape state goes dark **every year, by design**: the day Davidson County's window closes there is no upcoming date to resolve, and none will exist until the county publishes next year's — typically months later. The sweep reported that darkness with the same gap it uses for a state nobody ever entered, and since sweep gaps render nowhere on the web yet (#108), the degradation was silent end to end.

## The fix

Two reasons, because the two silences demand different acts:

| reason | means | the act |
|---|---|---|
| `window_awaiting_publication` | the last known window is on record — the gap names its close date and its citation, from the pack's own expired row | enter the county's next date when it publishes |
| `window_not_published` | no dated row has ever existed | go find this year's published date now |

The expired-row lookup deliberately drops the effective-window filter: it is citing *history*, not resolving law, and an expired row is exactly what it is looking for.

Sweeping the Nashville property after 2026-06-26 now yields: *"the last known appeal window closed 2026-06-26 (Metropolitan Board of Equalization…); the next date is set by the county and must be entered when it publishes — until then the window is honestly unknown."*

## Gates

schema verified · api **355** at 100% line and branch · sim/ingest 100% · `pnpm run verify` green · ruff, state-literal ratchet, config audit, regenerated contract clean

Also in this housekeeping pass: #44's uncommitted fixtures parked cleanly (banked off-repo, state recorded on the issue, board card → Backlog per the reset directive).
