### PR TITLE
The qs floor rises to 6.16.0 ahead of two fresh advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   postcss: '>=8.5.23'
-  qs: '>=6.15.2'
+  qs: '>=6.16.0'
   sharp: '>=0.35.0'
   tmp: '>=0.2.6'
   uuid: '>=11.1.1'
@@ -2877,8 +2877,8 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -4958,7 +4958,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -5342,7 +5342,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2(supports-color@10.2.2)
@@ -6134,7 +6134,7 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -6569,7 +6569,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.3
+      qs: 6.16.0
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ minimumReleaseAge: 1440
 # the advisories; `pnpm audit` at zero findings is the proof they hold).
 overrides:
   postcss: ">=8.5.23"
-  qs: ">=6.15.2"
+  qs: ">=6.16.0" # GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g (via @lhci/cli>express>body-parser)
   sharp: ">=0.35.0"
   tmp: ">=0.2.6" # GHSA-ph9p-34f9-6g65, GHSA-52f5-9888-hmc6 (via @lhci/cli>inquirer)
   uuid: ">=11.1.1" # GHSA-w5hq-g745-h8pq (via @lhci/cli); v4() API unchanged in v11


### PR DESCRIPTION
Two advisories (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g) published against qs <6.16.0, reached via `@lhci/cli>express>body-parser`, turned the SCA gate red on main and on every open PR. The existing floor in `pnpm-workspace.yaml` rises from >=6.15.2 to >=6.16.0 with the advisories named beside it, lockfile refreshed. `pnpm audit --audit-level=low`: zero unaccepted findings. Full local verify green (6/6 incl. mutation).

Unblocks #128, which is red only on this gate.