### PR TITLE
escalation_value gets a unit, and the fixture that blessed 350% is corrected

### DIFF
--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -19,3 +19,4 @@
 \ir 018_screening.sql
 \ir 019_assessment_records.sql
 \ir 020_income_tax_rates_leave_the_profile.sql
+\ir 021_escalation_value_gets_a_unit.sql

--- a/packages/domain/schema/021_escalation_value_gets_a_unit.sql
+++ b/packages/domain/schema/021_escalation_value_gets_a_unit.sql
@@ -1,0 +1,50 @@
+-- ===========================================================================
+--  021 — escalation_value gets a unit, because the repo already proved it
+--  needed one (issue #104).
+--
+--  leases.escalation_value is polymorphic by convention: dollars when
+--  escalation = 'fixed_amount', a decimal fraction when 'fixed_percent'.
+--  That convention was written down nowhere the database could enforce it,
+--  and the repository's own two layers already disagreed about it:
+--  tests/constraints.sql certified ('fixed_percent', 3.5) as "a well-formed
+--  twelve-month lease" while services/api/tests/test_rent.py wrote 0.03 for
+--  three percent. Through _escalated_rent's base * (1 + value) ** years,
+--  the certified fixture is a 350 PERCENT annual increase.
+--
+--  Module 001 documents this exact hazard as the reason the annual_rate
+--  domain is bounded: a rate typed in percent form once produced a payment
+--  a hundredfold too large, with no error to hint at it. leases was the
+--  table that did not use the fix. Now it does, by kind:
+--
+--    fixed_percent  — bounded like annual_rate: a decimal fraction,
+--                     abs(value) < 1. No residential escalation clause
+--                     reaches 100 percent a year; 3.5 can only be a typo
+--                     for 0.035, and it now fails loudly at insert.
+--    fixed_amount   — non-negative dollars. (A step-down lease, should one
+--                     ever arrive, is an amendment to this constraint with
+--                     its own justification — not a silent allowance today.)
+--    cpi            — the value's meaning is owned by the parked CPI work
+--                     (#44) and is not constrained here.
+--    none           — no value is required (escalation_has_a_value already
+--                     governs presence; this module governs units).
+--
+--  If this migration fails on an existing row, that row IS the bug being
+--  hunted: a lease whose next sweep would bill an escalation two orders of
+--  magnitude too large. Loud is the point; nothing here rewrites money.
+-- ===========================================================================
+
+ALTER TABLE leases
+  ADD CONSTRAINT escalation_value_matches_its_kind CHECK (
+    CASE escalation
+      WHEN 'fixed_percent' THEN escalation_value > -1 AND escalation_value < 1
+      WHEN 'fixed_amount'  THEN escalation_value >= 0
+      ELSE TRUE
+    END
+  );
+
+COMMENT ON COLUMN leases.escalation_value IS
+  'Unit depends on escalation kind: a DECIMAL FRACTION for fixed_percent '
+  '(0.035 means 3.5% — percent-form entry like 3.5 is rejected by '
+  'escalation_value_matches_its_kind, the same hazard annual_rate exists '
+  'for), non-negative DOLLARS for fixed_amount, and reserved for the CPI '
+  'engine when escalation = cpi.';

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -193,8 +193,24 @@ SELECT assert_rejected(
   'escalation_has_a_value', 'an escalation clause with no escalation value');
 SELECT assert_accepted(
   $$INSERT INTO leases (unit_id, starts_on, ends_on, rent, escalation, escalation_value)
+    VALUES ('55555555-5555-5555-5555-555555555555','2026-01-01','2026-12-31',1450,'fixed_percent',0.035)$$,
+  'a well-formed twelve-month lease at 3.5 percent, entered as 0.035');
+-- The fixture above once read 3.5 — through base * (1 + value) ** years that
+-- is a 350 percent annual increase, and this suite CERTIFIED it (issue #104).
+-- The same hazard annual_rate was bounded for; now the confusion is rejected
+-- at the layer that used to bless it.
+SELECT assert_rejected(
+  $$INSERT INTO leases (unit_id, starts_on, ends_on, rent, escalation, escalation_value)
     VALUES ('55555555-5555-5555-5555-555555555555','2026-01-01','2026-12-31',1450,'fixed_percent',3.5)$$,
-  'a well-formed twelve-month lease');
+  'escalation_value_matches_its_kind', 'a percent escalation entered in percent form');
+SELECT assert_rejected(
+  $$INSERT INTO leases (unit_id, starts_on, ends_on, rent, escalation, escalation_value)
+    VALUES ('55555555-5555-5555-5555-555555555555','2026-01-01','2026-12-31',1450,'fixed_amount',-25)$$,
+  'escalation_value_matches_its_kind', 'a negative fixed-amount escalation');
+SELECT assert_accepted(
+  $$INSERT INTO leases (unit_id, starts_on, ends_on, rent, escalation, escalation_value)
+    VALUES ('55555555-5555-5555-5555-555555555555','2026-01-01','2026-12-31',1450,'fixed_amount',75)$$,
+  'a seventy-five dollar annual step, in dollars');
 
 \echo ''
 \echo 'insurance'

--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -16,7 +16,7 @@ from decimal import ROUND_HALF_EVEN, Decimal
 from typing import Any, Literal
 
 import psycopg
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from hestia_api import ledger as ledger_module
 
@@ -60,6 +60,23 @@ class LeaseIn(BaseModel):
     escalation_value: Decimal | None = None
     status: Literal["active", "month_to_month", "draft"] = "active"
     resident_ids: list[str] = []
+
+    @model_validator(mode="after")
+    def escalation_value_matches_its_kind(self) -> "LeaseIn":
+        """The unit hazard module 021 rejects at the schema, rejected here
+        first as a 422 the caller can read: a percent escalation is a
+        DECIMAL FRACTION (0.035 is 3.5%), a fixed amount is non-negative
+        dollars. 3.5 for 3.5% would compound to a 350% annual increase."""
+        value = self.escalation_value
+        if self.escalation == "fixed_percent" and value is not None and not -1 < value < 1:
+            raise ValueError(
+                f"escalation_value for fixed_percent is a decimal fraction: "
+                f"{value} would escalate rent by {value:.0%} a year — "
+                f"3.5% is written 0.035"
+            )
+        if self.escalation == "fixed_amount" and value is not None and value < 0:
+            raise ValueError("escalation_value for fixed_amount is non-negative dollars")
+        return self
 
 
 class LeaseSummary(BaseModel):

--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -62,7 +62,7 @@ class LeaseIn(BaseModel):
     resident_ids: list[str] = []
 
     @model_validator(mode="after")
-    def escalation_value_matches_its_kind(self) -> "LeaseIn":
+    def escalation_value_matches_its_kind(self) -> LeaseIn:
         """The unit hazard module 021 rejects at the schema, rejected here
         first as a 422 the caller can read: a percent escalation is a
         DECIMAL FRACTION (0.035 is 3.5%), a fixed amount is non-negative

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -105,6 +105,53 @@ class TestRentSweep:
         assert Decimal(charge["amount"]) == Decimal("1450.00")
         assert Decimal(detail["balance_due"]) == Decimal("1450.00")
 
+    def test_percent_form_escalation_is_refused_with_the_unit_spelled_out(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # The issue #104 confusion: 3.5 meant as 3.5% is a 350% annual
+        # increase through (1 + value) ** years. The API answers 422 with
+        # the unit in the message, before the schema CHECK ever sees it.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U104"}
+        ).json()["id"]
+        refused = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-01",
+                "rent": "1450.00",
+                "escalation": "fixed_percent",
+                "escalation_value": "3.5",
+            },
+        )
+        assert refused.status_code == 422
+        assert "0.035" in refused.text and "350%" in refused.text
+        negative = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-01",
+                "rent": "1450.00",
+                "escalation": "fixed_amount",
+                "escalation_value": "-25.00",
+            },
+        )
+        assert negative.status_code == 422
+        assert "non-negative dollars" in negative.text
+        # The correctly-united forms both pass this validator (the fixtures
+        # in test_escalations_and_cpi_gap create them for real).
+        ok = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-01",
+                "rent": "1450.00",
+                "escalation": "fixed_percent",
+                "escalation_value": "0.035",
+            },
+        )
+        assert ok.status_code == 201
+
     def test_escalations_and_cpi_gap(self, world: dict[str, str], client: TestClient) -> None:
         # A second unit with each escalation shape.
         unit2 = client.post("/units", json={"property_id": world["property"], "label": "B"}).json()[


### PR DESCRIPTION
Closes #104.

The column was polymorphic by convention only, and the repo's own layers disagreed about the convention: `tests/constraints.sql` certified `('fixed_percent', 3.5)` as *well-formed* while `test_rent.py` wrote `0.03` for 3%. Through `base * (1 + value) ** years` the certified fixture is a **350% annual increase** — the exact hazard module 001 bounded `annual_rate` against, on the one table that didn't use the fix.

- Module `021`: named CHECK `escalation_value_matches_its_kind` (percent bounded like `annual_rate`, amount non-negative, cpi left to parked #44) + column comment stating the unit per kind.
- Constraint suite: fixture corrected to `0.035`; the old `3.5` and a negative `fixed_amount` become proven **rejections**.
- `LeaseIn`: same confusion refused as a 422 whose message says *'3.5% is written 0.035'* — the unit taught at the door, not discovered at the constraint.
- A migration failure on an existing row is a **found bug**, not a deployment problem: that lease's next sweep would bill 100× high. Nothing rewrites money.

Gates: schema verified with the new rejections; 356 API tests at 100% line+branch; ratchet clean.

Vision test (docs/VISION.md §6): refusal 1 (no invented number) applied to the write path — a number whose unit can't be trusted never enters; serves the entry-fee line of every money surface.