### PR TITLE
due_on becomes a day of the month, which is what a lease means by it

### DIFF
--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -3995,7 +3995,7 @@
           },
           "rent_due_day": {
             "default": 1,
-            "maximum": 28.0,
+            "maximum": 31.0,
             "minimum": 1.0,
             "title": "Rent Due Day",
             "type": "integer"

--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -10,6 +10,7 @@ a coverage gap, the deadline sweep's discipline.
 
 from __future__ import annotations
 
+import calendar as calendar_module
 import datetime as dt
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
@@ -54,7 +55,7 @@ class LeaseIn(BaseModel):
     starts_on: dt.date
     ends_on: dt.date | None = None
     rent: Decimal = Field(gt=0, decimal_places=2, max_digits=18)
-    rent_due_day: int = Field(default=1, ge=1, le=28)
+    rent_due_day: int = Field(default=1, ge=1, le=31)
     security_deposit: Decimal = Field(default=Decimal(0), ge=0, decimal_places=2, max_digits=18)
     escalation: Literal["none", "fixed_amount", "fixed_percent"] = "none"
     escalation_value: Decimal | None = None
@@ -307,6 +308,18 @@ def _escalated_rent(
     return grown.quantize(CENT, rounding=ROUND_HALF_EVEN)
 
 
+def _due_on_in(period_start: dt.date, rent_due_day: int) -> dt.date:
+    """The lease's due day AS A DAY OF THE MONTH, clamped to the month's last
+    day — "due on the 31st" means the 31st where one exists and the last day
+    where none does, which is what a lease means by it. The previous
+    implementation was day ARITHMETIC (period_start + due_day - 1): identical
+    for days 1-28, but day 31 in February landed on March 3 — a due date
+    outside its own period, feeding wrong late fees and a wrong ageing
+    bucket (issue #103)."""
+    last_day = calendar_module.monthrange(period_start.year, period_start.month)[1]
+    return period_start.replace(day=min(rent_due_day, last_day))
+
+
 def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
     """One rent charge per active lease for as_of's month. Idempotent via the
     one-charge-per-period key; CPI escalations are reported, not guessed."""
@@ -342,7 +355,7 @@ def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
         amount = _escalated_rent(
             lease["rent"], lease["escalation"], lease["escalation_value"], years
         )
-        due_on = period_start + dt.timedelta(days=lease["rent_due_day"] - 1)
+        due_on = _due_on_in(period_start, lease["rent_due_day"])
         result = conn.execute(
             """
             INSERT INTO rent_charges

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -152,6 +152,40 @@ class TestRentSweep:
         )
         assert ok.status_code == 201
 
+    def test_due_on_is_a_day_of_the_month_not_day_arithmetic(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # Issue #103: with rent_due_day = 31 the old arithmetic put
+        # February's due date on March 3 — outside its own period, feeding
+        # wrong late fees and a wrong ageing bucket. "The 31st" means the
+        # month's last day where no 31st exists.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U103"}
+        ).json()["id"]
+        lease = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-01",
+                "rent": "1200.00",
+                "rent_due_day": 31,
+            },
+        )
+        assert lease.status_code == 201, lease.text
+        lease_id = lease.json()["id"]
+        for as_of in ["2026-01-01", "2026-02-01", "2026-09-01", "2028-02-01"]:
+            client.post(f"/sweep/rent-charges?as_of={as_of}")
+        charges = client.get(f"/leases/{lease_id}").json()["charges"]
+        by_period = {c["period_start"]: c["due_on"] for c in charges}
+        assert by_period["2026-01-01"] == "2026-01-31"
+        assert by_period["2026-02-01"] == "2026-02-28"
+        assert by_period["2026-09-01"] == "2026-09-30"
+        assert by_period["2028-02-01"] == "2028-02-29"
+        # Every due date sits inside its own period — the defect's signature
+        # was a due date in the following month.
+        for period, due in by_period.items():
+            assert due[:7] == period[:7]
+
     def test_escalations_and_cpi_gap(self, world: dict[str, str], client: TestClient) -> None:
         # A second unit with each escalation shape.
         unit2 = client.post("/units", json={"property_id": world["property"], "label": "B"}).json()[


### PR DESCRIPTION
Closes #103.

`period_start + timedelta(rent_due_day - 1)` was day *arithmetic* — safe only because `LeaseIn` capped the day at 28 while the schema permits 31. With day 31, February billed a due date of **March 3**: outside its own period, feeding wrong late fees and a wrong ageing bucket.

`_due_on_in` clamps to the month's last day (the ticket's preferred fix: "the 31st" means the last day where none exists), and `LeaseIn` now accepts 1–31, ending the two layers' disagreement about what is representable. Tests pin the real 31st, February's clamp, September's 30th, leap February's 29th, and the defect's signature (every due date inside its own period).

Gates: 359 API tests at 100% line+branch; ruff clean; ratchet clean.

Vision test (docs/VISION.md §6): entry-fee line — the greatest app also never bills a tenant wrong.