### PR TITLE
Rent escalates on the anniversary date, and partial months bill their days

### DIFF
--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -131,7 +131,7 @@ class LeaseDetail(BaseModel):
 @dataclass(frozen=True)
 class RentSweepGap:
     lease_id: str
-    reason: str  # cpi_index_unavailable | no_late_fee_rule
+    reason: str  # cpi_index_unavailable | no_late_fee_rule | amount_rounds_to_zero
     detail: str
 
 
@@ -308,6 +308,48 @@ def _escalated_rent(
     return grown.quantize(CENT, rounding=ROUND_HALF_EVEN)
 
 
+def _month_end(month_start: dt.date) -> dt.date:
+    last = calendar_module.monthrange(month_start.year, month_start.month)[1]
+    return month_start.replace(day=last)
+
+
+def _lease_years_elapsed(starts_on: dt.date, month_start: dt.date) -> int:
+    """Complete lease years at the period's start: the count of
+    anniversaries falling on or before it. A February 29 start clamps to
+    February 28 — under period-boundary application both candidate
+    anniversaries (Feb 28 / Mar 1) land inside the same period, so the
+    choice provably never changes a bill; the clamp mirrors _due_on_in.
+    Escalating from the anniversary DATE rather than its month errs toward
+    the tenant: the anniversary month itself stays at the old rate and the
+    first escalated charge is the first full period of the new lease year
+    (issue #102, convention posted on the ticket)."""
+    years = month_start.year - starts_on.year
+    if years <= 0:
+        return 0
+    last_day = calendar_module.monthrange(month_start.year, starts_on.month)[1]
+    anniversary = dt.date(month_start.year, starts_on.month, min(starts_on.day, last_day))
+    return years - 1 if anniversary > month_start else years
+
+
+def _prorated(
+    monthly: Decimal,
+    month_start: dt.date,
+    month_end: dt.date,
+    period_start: dt.date,
+    period_end: dt.date,
+) -> Decimal:
+    """Calendar-day proration for a partial month: monthly x occupied days /
+    days in month, half-even to the cent. A whole month is returned as
+    EXACTLY the monthly figure — the multiplication is skipped so no
+    rounding artifact can shave the normal case."""
+    if period_start == month_start and period_end == month_end:
+        return monthly
+    occupied = (period_end - period_start).days + 1
+    days_in_month = (month_end - month_start).days + 1
+    share = monthly * Decimal(occupied) / Decimal(days_in_month)
+    return share.quantize(CENT, rounding=ROUND_HALF_EVEN)
+
+
 def _due_on_in(period_start: dt.date, rent_due_day: int) -> dt.date:
     """The lease's due day AS A DAY OF THE MONTH, clamped to the month's last
     day — "due on the 31st" means the 31st where one exists and the last day
@@ -323,17 +365,18 @@ def _due_on_in(period_start: dt.date, rent_due_day: int) -> dt.date:
 def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
     """One rent charge per active lease for as_of's month. Idempotent via the
     one-charge-per-period key; CPI escalations are reported, not guessed."""
-    period_start = as_of.replace(day=1)
+    month_start = as_of.replace(day=1)
+    month_end = _month_end(month_start)
     leases = conn.execute(
         """
         SELECT id::text, starts_on, ends_on, rent, rent_due_day,
                escalation::text, escalation_value
         FROM leases
         WHERE status IN ('active', 'month_to_month')
-          AND starts_on <= %(period)s
-          AND (ends_on IS NULL OR ends_on >= %(period)s)
+          AND starts_on <= %(month_end)s
+          AND (ends_on IS NULL OR ends_on >= %(month_start)s)
         """,
-        {"period": period_start},
+        {"month_start": month_start, "month_end": month_end},
     ).fetchall()
     created = 0
     gaps: list[RentSweepGap] = []
@@ -347,25 +390,48 @@ def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
                 )
             )
             continue
-        years = (
-            period_start.year
-            - lease["starts_on"].year
-            - (1 if (period_start.month, 1) < (lease["starts_on"].month, 1) else 0)
-        )
-        amount = _escalated_rent(
+        # Escalation applies from the first period that starts on or after
+        # the lease ANNIVERSARY DATE — never from the first of the
+        # anniversary month, which billed up to 30 days early (issue #102).
+        years = _lease_years_elapsed(lease["starts_on"], month_start)
+        monthly = _escalated_rent(
             lease["rent"], lease["escalation"], lease["escalation_value"], years
         )
-        due_on = _due_on_in(period_start, lease["rent_due_day"])
+        # The charge covers only the days the lease occupies: a mid-month
+        # start prorates the stub first month (which previously never billed
+        # at all), a mid-month end prorates the final one (which previously
+        # billed in full). period_start doubles as the idempotency key and
+        # is deterministic per (lease, month).
+        period_start = max(month_start, lease["starts_on"])
+        period_end = min(month_end, lease["ends_on"]) if lease["ends_on"] else month_end
+        amount = _prorated(monthly, month_start, month_end, period_start, period_end)
+        if amount == 0:
+            # A sub-cent share (peppercorn rent over a one-day stub) rounds
+            # to 0.00, which the amount > 0 CHECK would refuse — and one
+            # refused row would roll back every lease's charge for the
+            # month. Nothing billable is a reported gap, never an abort.
+            gaps.append(
+                RentSweepGap(
+                    lease_id=lease["id"],
+                    reason="amount_rounds_to_zero",
+                    detail=(
+                        f"the prorated share of {monthly} for "
+                        f"{period_start}..{period_end} rounds to zero; "
+                        "no charge was created"
+                    ),
+                )
+            )
+            continue
+        # Rent for a mid-month start is not due before the lease exists.
+        due_on = max(_due_on_in(month_start, lease["rent_due_day"]), period_start)
         result = conn.execute(
             """
             INSERT INTO rent_charges
               (lease_id, kind, period_start, period_end, due_on, amount, generated_by)
-            VALUES (%s, 'rent', %s,
-                    (%s::date + INTERVAL '1 month' - INTERVAL '1 day')::date,
-                    %s, %s, 'sweep')
+            VALUES (%s, 'rent', %s, %s, %s, %s, 'sweep')
             ON CONFLICT (lease_id, kind, period_start) DO NOTHING
             """,
-            (lease["id"], period_start, period_start, due_on, amount),
+            (lease["id"], period_start, period_end, due_on, amount),
         )
         created += result.rowcount
         if result.rowcount:

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -186,6 +186,162 @@ class TestRentSweep:
         for period, due in by_period.items():
             assert due[:7] == period[:7]
 
+    def test_escalation_waits_for_the_anniversary_date_not_its_month(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # Issue #102's table: a 2024-03-15 lease used to bill the WHOLE of
+        # March 2025 escalated — fourteen days early. The convention (posted
+        # on the ticket): the first escalated charge is the first period
+        # starting on or after the anniversary date.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102a"}
+        ).json()["id"]
+        lease_id = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2024-03-15",
+                "rent": "1000.00",
+                "escalation": "fixed_percent",
+                "escalation_value": "0.05",
+            },
+        ).json()["id"]
+        for as_of in ["2025-03-01", "2025-04-01", "2026-03-01", "2026-04-01"]:
+            client.post(f"/sweep/rent-charges?as_of={as_of}")
+        by_period = {
+            c["period_start"]: Decimal(c["amount"])
+            for c in client.get(f"/leases/{lease_id}").json()["charges"]
+        }
+        assert by_period["2025-03-01"] == Decimal("1000.00")  # old rate to the date
+        assert by_period["2025-04-01"] == Decimal("1050.00")  # first full period after
+        assert by_period["2026-03-01"] == Decimal("1050.00")
+        assert by_period["2026-04-01"] == Decimal("1102.50")  # compounded year two
+
+    def test_a_december_31_lease_no_longer_escalates_thirty_days_early(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102b"}
+        ).json()["id"]
+        lease_id = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2024-12-31",
+                "rent": "2000.00",
+                "escalation": "fixed_amount",
+                "escalation_value": "100.00",
+            },
+        ).json()["id"]
+        for as_of in ["2025-12-01", "2026-01-01"]:
+            client.post(f"/sweep/rent-charges?as_of={as_of}")
+        by_period = {
+            c["period_start"]: Decimal(c["amount"])
+            for c in client.get(f"/leases/{lease_id}").json()["charges"]
+        }
+        # December 2025 spans the anniversary but STARTS before it: old rate.
+        assert by_period["2025-12-01"] == Decimal("2000.00")
+        assert by_period["2026-01-01"] == Decimal("2100.00")
+
+    def test_a_leap_day_lease_escalates_from_the_clamped_anniversary(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102c"}
+        ).json()["id"]
+        lease_id = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2024-02-29",
+                "rent": "1000.00",
+                "escalation": "fixed_percent",
+                "escalation_value": "0.03",
+            },
+        ).json()["id"]
+        for as_of in ["2025-02-01", "2025-03-01"]:
+            client.post(f"/sweep/rent-charges?as_of={as_of}")
+        by_period = {
+            c["period_start"]: Decimal(c["amount"])
+            for c in client.get(f"/leases/{lease_id}").json()["charges"]
+        }
+        assert by_period["2025-02-01"] == Decimal("1000.00")
+        assert by_period["2025-03-01"] == Decimal("1030.00")
+
+    def test_the_stub_first_month_bills_prorated_instead_of_never(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # Issue #102's second defect: a mid-month lease was invisible to its
+        # own first sweep and the stub month was never billed at all.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102d"}
+        ).json()["id"]
+        lease_id = client.post(
+            "/leases",
+            json={"unit_id": unit, "starts_on": "2026-03-15", "rent": "3100.00"},
+        ).json()["id"]
+        client.post("/sweep/rent-charges?as_of=2026-03-01")
+        client.post("/sweep/rent-charges?as_of=2026-03-01")
+        # Exactly one charge for THIS lease after two sweeps: the stub month
+        # billed once, idempotent under its deterministic stub key. (The
+        # sweep total also counts the world fixture's own lease.)
+        (charge,) = client.get(f"/leases/{lease_id}").json()["charges"]
+        assert charge["period_start"] == "2026-03-15"
+        # 17 of March's 31 days at 3100.00: exactly 1700.00.
+        assert Decimal(charge["amount"]) == Decimal("1700.00")
+        # Rent for a mid-month start is not due before the lease exists.
+        assert charge["due_on"] == "2026-03-15"
+
+    def test_the_final_month_bills_prorated_instead_of_in_full(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # The third defect, found in this pass: ends_on >= period_start swept
+        # a lease ending April 10 into April and billed the FULL month.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102e"}
+        ).json()["id"]
+        lease_id = client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-01",
+                "ends_on": "2026-04-10",
+                "rent": "3000.00",
+            },
+        ).json()["id"]
+        client.post("/sweep/rent-charges?as_of=2026-04-01")
+        client.post("/sweep/rent-charges?as_of=2026-05-01")
+        charges = client.get(f"/leases/{lease_id}").json()["charges"]
+        by_period = {c["period_start"]: c for c in charges}
+        april = by_period["2026-04-01"]
+        # 10 of April's 30 days at 3000.00: exactly 1000.00.
+        assert Decimal(april["amount"]) == Decimal("1000.00")
+        assert "2026-05-01" not in by_period  # May is past the lease
+
+    def test_a_sub_cent_stub_share_is_a_gap_not_a_sweep_abort(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # Adversarial-panel finding on this change: a peppercorn rent whose
+        # one-day stub share rounds to 0.00 would violate the amount > 0
+        # CHECK and roll back EVERY lease's charge for the month. It must
+        # be a reported gap instead, with the other leases still billed.
+        unit = client.post(
+            "/units", json={"property_id": world["property"], "label": "U102f"}
+        ).json()["id"]
+        client.post(
+            "/leases",
+            json={
+                "unit_id": unit,
+                "starts_on": "2026-01-31",
+                "ends_on": "2026-03-01",
+                "rent": "0.10",
+            },
+        )
+        result = client.post("/sweep/rent-charges?as_of=2026-01-15").json()
+        assert result["charges_created"] >= 1  # the world lease still billed
+        (gap,) = [g for g in result["gaps"] if g["reason"] == "amount_rounds_to_zero"]
+        assert "rounds to zero" in gap["detail"]
+
     def test_escalations_and_cpi_gap(self, world: dict[str, str], client: TestClient) -> None:
         # A second unit with each escalation shape.
         unit2 = client.post("/units", json={"property_id": world["property"], "label": "B"}).json()[


### PR DESCRIPTION
Closes #102. Conventions were posted on the ticket before the build for veto; every choice errs toward the tenant, never toward overbilling.

Three defects in one expression family:

1. **The escalation year discarded the day** (the ticket's finding): the whole anniversary MONTH billed escalated — 14 days early for a March 15 lease, 30 for a December 31 one. `_lease_years_elapsed` counts anniversaries **on or before the period start**: the anniversary month stays at the old rate; the first escalated charge is the first full period of the new lease year. Feb 29 clamps to Feb 28 — provably bill-identical under period-boundary application.
2. **The stub first month never billed**: `starts_on <= period_start` made a mid-month lease invisible to its own first sweep. The filter now asks whether the lease occupies any day of the month; the charge prorates by calendar days (half-even to the cent), keyed by `period_start = max(month start, starts_on)` — deterministic, so the sweep stays idempotent — and `due_on` never precedes the lease.
3. **The final month overbilled** (found in this pass, symmetric to 2): a lease ending April 10 billed a full April. `period_end = min(month end, ends_on)`, same proration.

A whole month returns **exactly** the monthly figure — the multiplication is skipped, so no rounding artifact touches the normal case and every previously-correct lease bills identically. Late fees follow automatically (they key off the rent charge's own period_start); a consumer sweep confirmed nothing assumes the 1st.

An adversarial two-refuter panel is attacking the arithmetic and integration seams in parallel; its findings (if any) land here before merge.

Gates: 365 API tests at 100% line+branch; ruff clean; ratchet clean.

Vision test (docs/VISION.md §6): the entry fee — money classes right before a single bill renders (Act I).