### PR TITLE
Money on account is applied before any fee decision reads the books

### DIFF
--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -434,10 +434,13 @@ def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
             (lease["id"], period_start, period_end, due_on, amount),
         )
         created += result.rowcount
-        if result.rowcount:
-            # A prepaid tenant's open credit pays the new charge immediately —
-            # before anything can call it overdue.
-            apply_open_credit(conn, lease["id"])
+        # Unconditionally, not only when a charge was just created: credit
+        # that lands AFTER a month's charge exists (a check recorded through
+        # the ledger door) used to strand as open_credit until a receipt or
+        # late-fee sweep touched the lease — and the late-fee sweep fined
+        # first (issue #138). Idempotent, so a re-swept month costs one
+        # no-op query.
+        apply_open_credit(conn, lease["id"])
     return RentSweepResult(charges_created=created, gaps=[vars(gap) for gap in gaps])
 
 
@@ -477,26 +480,37 @@ LEFT JOIN resolved fee_percent
 """
 
 
+_OVERDUE_SNAPSHOT_SQL = """
+SELECT c.id::text AS charge_id, c.lease_id::text, c.period_start, c.due_on,
+       c.amount, coalesce(sum(a.amount), 0) AS allocated
+FROM rent_charges c
+LEFT JOIN rent_receipt_allocations a ON a.charge_id = c.id
+WHERE c.kind = 'rent' AND c.status IN ('due', 'partially_paid')
+  AND c.due_on < %(as_of)s
+  AND NOT EXISTS (SELECT 1 FROM rent_charges lf
+                  WHERE lf.lease_id = c.lease_id AND lf.kind = 'late_fee'
+                    AND lf.period_start = c.period_start)
+GROUP BY c.id
+HAVING coalesce(sum(a.amount), 0) < c.amount
+"""
+
+
 def sweep_late_fees(conn: Conn, as_of: dt.date) -> RentSweepResult:
     """Assess late fees ONLY where the jurisdiction chain provides a cited
     rule (grace days + a fee amount or percent). No rule, no fee — the gap
     says so, and the owner can still assess manually from the lease terms."""
-    overdue = conn.execute(
-        """
-        SELECT c.id::text AS charge_id, c.lease_id::text, c.period_start, c.due_on,
-               c.amount, coalesce(sum(a.amount), 0) AS allocated
-        FROM rent_charges c
-        LEFT JOIN rent_receipt_allocations a ON a.charge_id = c.id
-        WHERE c.kind = 'rent' AND c.status IN ('due', 'partially_paid')
-          AND c.due_on < %(as_of)s
-          AND NOT EXISTS (SELECT 1 FROM rent_charges lf
-                          WHERE lf.lease_id = c.lease_id AND lf.kind = 'late_fee'
-                            AND lf.period_start = c.period_start)
-        GROUP BY c.id
-        HAVING coalesce(sum(a.amount), 0) < c.amount
-        """,
-        {"as_of": as_of},
-    ).fetchall()
+    # First read = candidates only. A tenant whose money is already on
+    # account — a check through the ledger door, a webhook settlement that
+    # landed between sweeps — must never draw a fee, so open credit is
+    # applied for every candidate BEFORE the snapshot that decides fees
+    # (issue #138: the fee INSERT used to run first and the credit second,
+    # fining money the tenant had since the due date).
+    candidates = conn.execute(_OVERDUE_SNAPSHOT_SQL, {"as_of": as_of}).fetchall()
+    if not candidates:
+        return RentSweepResult(charges_created=0, gaps=[])
+    for lease_id in {row["lease_id"] for row in candidates}:
+        apply_open_credit(conn, lease_id)
+    overdue = conn.execute(_OVERDUE_SNAPSHOT_SQL, {"as_of": as_of}).fetchall()
     if not overdue:
         return RentSweepResult(charges_created=0, gaps=[])
     rules = {

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -686,7 +686,20 @@ class TestPaidMoneyDrawsNoFee:
             },
         )
         assert posted.status_code == 201, posted.text
-        client.post("/sweep/late-fees?as_of=2026-08-20")
+        # The world fixture's lease is overdue too — pay it the same way, so
+        # the sweep's second snapshot is EMPTY and the everyone-is-cured
+        # early return is the path actually exercised.
+        client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-08-01",
+                "category": "rent",
+                "amount": "1450.00",
+                "lease_id": world["lease"],
+            },
+        )
+        swept = client.post("/sweep/late-fees?as_of=2026-08-20").json()
+        assert swept == {"charges_created": 0, "gaps": []}
         detail = client.get(f"/leases/{lease_id}").json()
         assert [c["kind"] for c in detail["charges"]] == ["rent"]
         (rent_charge,) = detail["charges"]

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -610,6 +610,138 @@ class TestLateFees:
         assert "flat $35" in fee["rule_citation"]
 
 
+class TestPaidMoneyDrawsNoFee:
+    def _qy_world(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> str:
+        """A synthetic QY state with grace 3 + flat $20, its own property and
+        lease at 1000/mo — self-contained so test order cannot matter."""
+        exists = conn.execute("SELECT 1 AS x FROM jurisdictions WHERE state = 'QY'").fetchone()
+        if exists is None:
+            conn.execute(
+                """
+                INSERT INTO jurisdictions (level, name, state, parent_id)
+                SELECT 'state', 'Quyland', 'QY', id FROM jurisdictions
+                WHERE level = 'federal'
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO jurisdiction_rules
+                  (jurisdiction_id, domain, code, value_numeric, value_money, citation,
+                   effective_from)
+                SELECT id, 'late_fee', 'latefee.grace_days', 3, NULL,
+                       'QY Stat. 1.1 (fixture)', DATE '2000-01-01'
+                FROM jurisdictions WHERE state = 'QY' AND level = 'state'
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO jurisdiction_rules
+                  (jurisdiction_id, domain, code, value_numeric, value_money, citation,
+                   effective_from)
+                SELECT id, 'late_fee', 'latefee.amount', NULL, 20.00,
+                       'QY Stat. 1.2 (fixture): flat $20', DATE '2000-01-01'
+                FROM jurisdictions WHERE state = 'QY' AND level = 'state'
+                """
+            )
+            conn.commit()
+        property_id = client.post(
+            "/properties",
+            json={
+                "entity_id": world["entity"],
+                "label": "qy-house",
+                "street_1": "1 Paid Up Pl",
+                "city": "Quyton",
+                "state": "QY",
+                "postal_code": "00000",
+                "kind": "single_family",
+            },
+        ).json()["id"]
+        unit_id = client.post("/units", json={"property_id": property_id, "label": "A"}).json()[
+            "id"
+        ]
+        return client.post(
+            "/leases",
+            json={"unit_id": unit_id, "starts_on": "2026-01-01", "rent": "1000.00"},
+        ).json()["id"]
+
+    def test_a_check_through_the_ledger_door_draws_no_fee(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # Issue #138: the owner records the tenant's on-time check via
+        # POST /ledger (which allocates nothing); the late-fee sweep used to
+        # take its overdue snapshot BEFORE applying that credit and fined a
+        # tenant whose money had been on account since the due date.
+        lease_id = self._qy_world(world, client, conn)
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        posted = client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-08-01",
+                "category": "rent",
+                "amount": "1000.00",
+                "lease_id": lease_id,
+                "memo": "tenant check, recorded by hand",
+            },
+        )
+        assert posted.status_code == 201, posted.text
+        client.post("/sweep/late-fees?as_of=2026-08-20")
+        detail = client.get(f"/leases/{lease_id}").json()
+        assert [c["kind"] for c in detail["charges"]] == ["rent"]
+        (rent_charge,) = detail["charges"]
+        assert rent_charge["status"] == "paid"
+        assert Decimal(detail["balance_due"]) == Decimal("0.00")
+
+    def test_credit_covering_one_of_two_months_fines_only_the_unpaid_one(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        lease_id = self._qy_world(world, client, conn)
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post("/sweep/rent-charges?as_of=2026-09-01")
+        client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-08-01",
+                "category": "rent",
+                "amount": "1000.00",
+                "lease_id": lease_id,
+            },
+        )
+        client.post("/sweep/late-fees?as_of=2026-09-20")
+        charges = client.get(f"/leases/{lease_id}").json()["charges"]
+        fees = [c for c in charges if c["kind"] == "late_fee"]
+        # August was covered by the credit (oldest first); only September's
+        # genuinely unpaid month draws its flat fee.
+        assert len(fees) == 1
+        assert Decimal(fees[0]["amount"]) == Decimal("20.00")
+        paid_aug = next(c for c in charges if c["period_start"] == "2026-08-01")
+        assert paid_aug["status"] == "paid"
+
+    def test_credit_landing_after_the_charge_is_applied_by_the_next_rent_sweep(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # The rowcount gate: a re-swept month created no charge, so credit
+        # that arrived in between was never applied until something else
+        # touched the lease. The apply is now unconditional per sweep.
+        lease_id = self._qy_world(world, client, conn)
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post(
+            "/ledger",
+            json={
+                "occurred_on": "2026-08-02",
+                "category": "rent",
+                "amount": "1000.00",
+                "lease_id": lease_id,
+            },
+        )
+        client.post("/sweep/rent-charges?as_of=2026-08-01")  # same month, 0 created
+        detail = client.get(f"/leases/{lease_id}").json()
+        (rent_charge,) = detail["charges"]
+        assert rent_charge["status"] == "paid"
+        assert Decimal(detail["open_credit"]) == Decimal("0.00")
+
+
 class TestRenewals:
     def test_context_carries_labeled_defaults_then_measured_history(
         self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]


### PR DESCRIPTION
Closes #138 (adversarial-panel finding on #102's seam; pre-existing).

Two composing halves, both of which fined a tenant who had paid:

1. **The late-fee sweep fined first and applied credit second.** A check recorded through the ledger door on the due date (which allocates nothing, by design) drew a fee nineteen days later while the money sat on account. The first overdue read is now a *candidate list only*; open credit is applied for every candidate lease, and the snapshot that decides fees is taken after. With two overdue months and credit covering one, only the genuinely unpaid month draws its fee (oldest paid first) — test-pinned.
2. **The rent sweep's `rowcount > 0` gate stranded late-arriving credit** until a receipt or fee sweep touched the lease. The apply is now unconditional per swept lease (idempotent; a re-swept month costs one no-op query).

The stated rule, now true across all three doors (receipt endpoint, ledger door, webhook): **every fee decision applies credit before it reads the allocation table.**

Gates: 369 API tests at 100% line+branch; ruff clean; ratchet clean.

Vision test (docs/VISION.md §6): refusal 13's sibling in money — a false fee is the billing version of crying wolf, and the first one would have landed on Bri's own hand-recorded check.