### PR TITLE
Lease dates bind their charges, so a future amendment cannot bill wrongly

### DIFF
--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -20,3 +20,4 @@
 \ir 019_assessment_records.sql
 \ir 020_income_tax_rates_leave_the_profile.sql
 \ir 021_escalation_value_gets_a_unit.sql
+\ir 022_lease_dates_bind_their_charges.sql

--- a/packages/domain/schema/022_lease_dates_bind_their_charges.sql
+++ b/packages/domain/schema/022_lease_dates_bind_their_charges.sql
@@ -1,0 +1,72 @@
+-- ===========================================================================
+--  022 — Lease dates bind their charges (issue #140).
+--
+--  The rent sweep freezes each month's charge at first billing: the amount
+--  is computed from starts_on/ends_on as they stood, and the idempotency
+--  key (lease, kind, period_start) discards recomputation by design. That
+--  is correct for a world where lease dates never move — which is the only
+--  world the API offers today (nothing updates starts_on or ends_on).
+--
+--  This module makes that fact a CONSTRAINT instead of a coincidence, so
+--  the first future lease-amendment endpoint meets a named trigger at
+--  development time rather than a wrong bill at billing time:
+--
+--    * starts_on is immutable once any rent charge exists — moving it
+--      earlier MOVES the stub month's idempotency key, and a re-sweep
+--      would insert a second charge beside the first (a double bill, each
+--      drawing its own late fee).
+--    * ends_on may only move while every billed month lies strictly before
+--      both the old and the new boundary. Cutting it into a billed month
+--      leaves a full-month charge on a part-month occupancy (frozen
+--      overbill); extending it past a prorated final charge leaves a
+--      part-month charge on a full-month occupancy (frozen underbill).
+--
+--  Whoever builds amendments either supersedes the affected charges in the
+--  same transaction and RELAXES this trigger with that reconciliation, or
+--  keeps the refusal. Either way it is a decision, never an accident.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION lease_dates_bind_their_charges()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  last_billed DATE;
+BEGIN
+  IF NEW.starts_on IS DISTINCT FROM OLD.starts_on THEN
+    IF EXISTS (SELECT 1 FROM rent_charges c
+               WHERE c.lease_id = OLD.id AND c.kind = 'rent') THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'check_violation',
+        CONSTRAINT = 'lease_dates_bind_their_charges',
+        MESSAGE = 'starts_on cannot move once rent has been billed: the '
+          'first month''s charge is keyed and priced by it. Amending the '
+          'start requires superseding the affected charges in the same '
+          'transaction (issue #140).';
+    END IF;
+  END IF;
+  IF NEW.ends_on IS DISTINCT FROM OLD.ends_on THEN
+    -- period_end is nullable on old rows: fall back to the month's own
+    -- end, because a period_start-only August charge still bills August.
+    SELECT max(coalesce(c.period_end,
+                        (date_trunc('month', c.period_start)
+                         + INTERVAL '1 month' - INTERVAL '1 day')::date))
+      INTO last_billed
+    FROM rent_charges c
+    WHERE c.lease_id = OLD.id AND c.kind = 'rent';
+    IF last_billed IS NOT NULL
+       AND ((OLD.ends_on IS NOT NULL AND OLD.ends_on <= last_billed)
+            OR (NEW.ends_on IS NOT NULL AND NEW.ends_on <= last_billed)) THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'check_violation',
+        CONSTRAINT = 'lease_dates_bind_their_charges',
+        MESSAGE = 'ends_on cannot cross a billed month: the charge for that '
+          'month is frozen at the old occupancy and would overbill or '
+          'underbill. Supersede the affected charges in the same '
+          'transaction (issue #140).';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER lease_dates_bind_their_charges
+  BEFORE UPDATE OF starts_on, ends_on ON leases
+  FOR EACH ROW EXECUTE FUNCTION lease_dates_bind_their_charges();

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -681,7 +681,33 @@ SELECT assert_rejected(
     FROM rent_charges c
     WHERE c.lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND c.kind = 'rent'$$,
   '<trigger>', 'an allocation exceeding its charge');
+-- Module 022: lease dates bind their charges. The August charge above is
+-- still on the books here, so the lease's dates are load-bearing.
+SELECT assert_rejected(
+  $$UPDATE leases SET starts_on = '2025-12-15'
+    WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222'$$,
+  'lease_dates_bind_their_charges',
+  'moving starts_on under a billed month');
+SELECT assert_rejected(
+  $$UPDATE leases SET ends_on = '2026-08-15'
+    WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222'$$,
+  'lease_dates_bind_their_charges',
+  'cutting ends_on into a billed month');
+SELECT assert_accepted(
+  $$UPDATE leases SET ends_on = '2027-03-31'
+    WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222'$$,
+  'an end date beyond every billed month may still move');
+SELECT assert_accepted(
+  $$UPDATE leases SET ends_on = NULL
+    WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222'$$,
+  'going month-to-month while the boundary is unbilled');
 DELETE FROM rent_charges WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222';
+-- With no charges left, the dates are free again — the trigger binds
+-- charges, not leases.
+SELECT assert_accepted(
+  $$UPDATE leases SET starts_on = '2026-02-01'
+    WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222'$$,
+  'a chargeless lease may move its start');
 DELETE FROM leases WHERE id = 'bbbbbbbb-2222-2222-2222-222222222222';
 DELETE FROM units WHERE id = 'bbbbbbbb-1111-1111-1111-111111111111';
 


### PR DESCRIPTION
Closes #140 (adversarial-panel landmine ticket from #102).

The sweep freezes each month's charge at first billing — correct only while lease dates never move, which today is a *coincidence* (nothing updates them). Module `022` makes it a **constraint**: `starts_on` immutable while any rent charge exists; `ends_on` may move only while every billed month lies strictly before both the old and new boundary (with `period_end` falling back to the month's own end for legacy rows). The trigger's message names the reconciliation duty, so the first amendment endpoint meets a named refusal at development time, not a wrong bill at billing time.

Five new schema assertions: both refusals (start under a billed month; end cut into one) and the three legitimate moves (an unbilled boundary, going month-to-month, a chargeless lease).

Gates: schema verified; 366 API tests at 100% line+branch; ratchet clean.

Vision test (docs/VISION.md §6): refusal 12's engineering face — "never" spoken only about what the type system enforces; this makes one more "never" true by construction.