### PR TITLE
The waiver convention is stated where callers see it, and pinned

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -837,7 +837,18 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Waive Charge */
+        /**
+         * Waive Charge
+         * @description Waive forgives the UNPAID remainder; paid allocations stay.
+         *
+         *     The convention, stated where callers can find it (issue #137): money
+         *     already allocated to the charge remains payment for it — a tenant who
+         *     paid 500 of 1450 and is then waived was forgiven 950, not refunded
+         *     500. Nothing is released back to open credit, the balance arithmetic
+         *     excludes both the waived amount and its allocations (net zero: the
+         *     charge is settled), and the audit record carries the forgiven figure.
+         *     A fully paid charge has nothing to forgive and is not waivable.
+         */
         post: operations["waive_charge_rent_charges__charge_id__waive_post"];
         delete?: never;
         options?: never;

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -10820,6 +10820,7 @@
     },
     "/rent-charges/{charge_id}/waive": {
       "post": {
+        "description": "Waive forgives the UNPAID remainder; paid allocations stay.\n\nThe convention, stated where callers can find it (issue #137): money\nalready allocated to the charge remains payment for it \u2014 a tenant who\npaid 500 of 1450 and is then waived was forgiven 950, not refunded\n500. Nothing is released back to open credit, the balance arithmetic\nexcludes both the waived amount and its allocations (net zero: the\ncharge is settled), and the audit record carries the forgiven figure.\nA fully paid charge has nothing to forgive and is not waivable.",
         "operationId": "waive_charge_rent_charges__charge_id__waive_post",
         "parameters": [
           {

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -732,15 +732,33 @@ def waive_charge(
     request: Request,
     actor: Actor = "system",
 ) -> None:
-    updated = conn.execute(
+    """Waive forgives the UNPAID remainder; paid allocations stay.
+
+    The convention, stated where callers can find it (issue #137): money
+    already allocated to the charge remains payment for it — a tenant who
+    paid 500 of 1450 and is then waived was forgiven 950, not refunded
+    500. Nothing is released back to open credit, the balance arithmetic
+    excludes both the waived amount and its allocations (net zero: the
+    charge is settled), and the audit record carries the forgiven figure.
+    A fully paid charge has nothing to forgive and is not waivable.
+    """
+    charge = conn.execute(
         """
-        UPDATE rent_charges SET status = 'waived', waived_reason = %s
-        WHERE id = %s AND status IN ('scheduled', 'due', 'partially_paid')
+        SELECT c.amount - coalesce((SELECT sum(a.amount)
+                                    FROM rent_receipt_allocations a
+                                    WHERE a.charge_id = c.id), 0) AS forgiven
+        FROM rent_charges c
+        WHERE c.id = %s AND c.status IN ('scheduled', 'due', 'partially_paid')
+        FOR UPDATE OF c
         """,
+        (str(charge_id),),
+    ).fetchone()
+    if charge is None:
+        raise HTTPException(status_code=404, detail="no waivable charge found")
+    conn.execute(
+        "UPDATE rent_charges SET status = 'waived', waived_reason = %s WHERE id = %s",
         (body.reason, str(charge_id)),
     )
-    if updated.rowcount == 0:
-        raise HTTPException(status_code=404, detail="no waivable charge found")
     _audit(
         conn,
         request,
@@ -748,7 +766,7 @@ def waive_charge(
         "rent.waive",
         "rent_charges",
         str(charge_id),
-        {"reason": body.reason},
+        {"reason": body.reason, "forgiven": str(charge["forgiven"])},
     )
 
 

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -755,6 +755,52 @@ class TestPaidMoneyDrawsNoFee:
         assert Decimal(detail["open_credit"]) == Decimal("0.00")
 
 
+class TestWaiverConvention:
+    def test_waive_forgives_the_unpaid_remainder_and_paid_money_stays(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # The convention this test PINS (issue #137): waiving a partially
+        # paid charge forgives only the unpaid remainder; the paid portion
+        # remains payment for the waived charge and is NOT released back to
+        # open credit. An adversarial reviewer hand-running the queries once
+        # concluded the paid money had vanished — these exact figures are
+        # the proof it did not, and changing this convention must break
+        # this test on purpose.
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post(
+            f"/leases/{world['lease']}/receipts",
+            json={"occurred_on": "2026-08-02", "amount": "500.00"},
+        )
+        detail = client.get(f"/leases/{world['lease']}").json()
+        charge_a = next(c for c in detail["charges"] if c["period_start"] == "2026-08-01")
+        assert charge_a["status"] == "partially_paid"
+        waived = client.post(f"/rent-charges/{charge_a['id']}/waive", json={"reason": "goodwill"})
+        assert waived.status_code == 204
+        client.post("/sweep/rent-charges?as_of=2026-09-01")
+        detail = client.get(f"/leases/{world['lease']}").json()
+        # 500 paid (stays), 950 forgiven, September's 1450 owed — no money
+        # vanished and none came back.
+        assert Decimal(detail["balance_due"]) == Decimal("1450.00")
+        assert Decimal(detail["open_credit"]) == Decimal("0.00")
+        waived_charge = next(c for c in detail["charges"] if c["period_start"] == "2026-08-01")
+        assert waived_charge["status"] == "waived"
+        assert Decimal(waived_charge["allocated"]) == Decimal("500.00")
+
+    def test_a_fully_paid_charge_has_nothing_to_forgive(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post(
+            f"/leases/{world['lease']}/receipts",
+            json={"occurred_on": "2026-08-02", "amount": "1450.00"},
+        )
+        detail = client.get(f"/leases/{world['lease']}").json()
+        (charge,) = detail["charges"]
+        assert charge["status"] == "paid"
+        refused = client.post(f"/rent-charges/{charge['id']}/waive", json={"reason": "goodwill"})
+        assert refused.status_code == 404
+
+
 class TestRenewals:
     def test_context_carries_labeled_defaults_then_measured_history(
         self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]


### PR DESCRIPTION
Closes #137 (rewritten after the premise check — the arithmetic was consistent; the convention was undocumented).

**Waive forgives the unpaid remainder; paid allocations stay.** Now stated in the endpoint docstring (hence the OpenAPI description), carried in the audit payload (`forgiven`, computed under lock at waive time), and pinned by two tests walking the adversarial reviewer's exact scenario: 500 paid of 1450 stays payment, 950 forgiven, next month owes 1450, open credit 0, allocation surviving on the waived charge — plus the refusal of a fully paid charge. Changing the convention now requires breaking a named test on purpose.

Gates: 371 API tests at 100% line+branch; contract regenerated; ruff + ratchet clean.

Vision test (docs/VISION.md §6): P5's religion applied to a convention — nothing issues from the system without its meaning recorded.