### PR TITLE
A receipt pays out at most once, and the docstring stops lying about it

### DIFF
--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -21,3 +21,4 @@
 \ir 020_income_tax_rates_leave_the_profile.sql
 \ir 021_escalation_value_gets_a_unit.sql
 \ir 022_lease_dates_bind_their_charges.sql
+\ir 023_a_receipt_pays_out_at_most_once.sql

--- a/packages/domain/schema/023_a_receipt_pays_out_at_most_once.sql
+++ b/packages/domain/schema/023_a_receipt_pays_out_at_most_once.sql
@@ -1,0 +1,41 @@
+-- ===========================================================================
+--  023 — A receipt pays out at most once (issue #139).
+--
+--  Module 014 capped allocations per CHARGE: no charge can collect more
+--  than its amount. Nothing capped the other side — allocations per LEDGER
+--  EVENT — so two concurrent sweeps that both read a receipt's remaining
+--  credit before either committed could spend the same money against two
+--  different charges: per-charge cap satisfied, primary key satisfied, one
+--  hundred dollars paying two hundred of rent, open_credit negative, and a
+--  collection silently missed. apply_open_credit's docstring even claimed
+--  the database backed this arithmetic; until this module, it did not.
+--
+--  Same shape as 014's trigger, pointed the other way: the event row is
+--  locked, the event's existing allocations are summed, and an allocation
+--  that would spend past the receipt's amount is refused loudly. Under a
+--  concurrent race the loser now gets a rollback instead of the tenant's
+--  money being double-counted — loud beats silently wrong, and the caller
+--  simply retries against the settled books.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION refuse_over_crediting() RETURNS TRIGGER AS $$
+DECLARE
+  event_amount NUMERIC;
+  spent NUMERIC;
+BEGIN
+  SELECT amount INTO event_amount FROM ledger_events
+  WHERE id = NEW.ledger_event_id FOR UPDATE;
+  SELECT coalesce(sum(amount), 0) INTO spent
+  FROM rent_receipt_allocations WHERE ledger_event_id = NEW.ledger_event_id;
+  IF spent + NEW.amount > event_amount THEN
+    RAISE EXCEPTION 'allocation would spend the receipt twice: % + % > %',
+      spent, NEW.amount, event_amount
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER rent_receipt_allocations_spend_once
+  BEFORE INSERT ON rent_receipt_allocations
+  FOR EACH ROW EXECUTE FUNCTION refuse_over_crediting();

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -681,6 +681,34 @@ SELECT assert_rejected(
     FROM rent_charges c
     WHERE c.lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND c.kind = 'rent'$$,
   '<trigger>', 'an allocation exceeding its charge');
+-- Module 023: the other side of the same coin — a receipt may pay out at
+-- most its own amount, across ALL charges. Two 60s from a 100 receipt: the
+-- first lands, the second is refused, whatever charge it aims at.
+INSERT INTO ledger_events (occurred_on, category, amount, entity_id, memo)
+  VALUES ('2026-08-15', 'rent', 100.00,
+          '11111111-1111-1111-1111-111111111111', 'module-023 fixture receipt');
+INSERT INTO rent_charges (id, lease_id, kind, period_start, due_on, amount)
+  VALUES ('bbbbbbbb-4444-4444-4444-444444444444',
+          'bbbbbbbb-2222-2222-2222-222222222222', 'late_fee', '2026-08-01',
+          '2026-08-20', 75.00);
+SELECT assert_accepted(
+  $$INSERT INTO rent_receipt_allocations (charge_id, ledger_event_id, amount)
+    SELECT c.id,
+           (SELECT id FROM ledger_events WHERE memo = 'module-023 fixture receipt'),
+           60.00
+    FROM rent_charges c
+    WHERE c.lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND c.kind = 'rent'$$,
+  'sixty of a hundred-dollar receipt pays the rent charge');
+SELECT assert_rejected(
+  $$INSERT INTO rent_receipt_allocations (charge_id, ledger_event_id, amount)
+    VALUES ('bbbbbbbb-4444-4444-4444-444444444444',
+            (SELECT id FROM ledger_events WHERE memo = 'module-023 fixture receipt'),
+            60.00)$$,
+  '<trigger>', 'the same receipt spending past its amount on a second charge');
+DELETE FROM rent_receipt_allocations
+  WHERE charge_id IN (SELECT id FROM rent_charges
+                      WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222');
+DELETE FROM rent_charges WHERE id = 'bbbbbbbb-4444-4444-4444-444444444444';
 -- Module 022: lease dates bind their charges. The August charge above is
 -- still on the books here, so the lease's dates are load-bearing.
 SELECT assert_rejected(

--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -584,10 +584,30 @@ def apply_open_credit(conn: Conn, lease_id: str) -> list[dict[str, str]]:
     both sides — the single allocation engine behind receipts, sweeps, and
     webhook settlements. A prepayment therefore pays the next charge the
     moment the sweep creates it, instead of vanishing while a late fee
-    accrues (the adversarial review's scenario). Charge rows are locked so
-    concurrent applications serialize; the schema's allocation-cap trigger
-    backs the arithmetic at the database.
+    accrues (the adversarial review's scenario).
+
+    Concurrency, honestly (issue #139): the charge rows are locked FIRST,
+    so a concurrent application on the same lease waits here and then sees
+    the survivor set; the credits are read AFTER, in a fresh statement, so
+    the remaining figures reflect whatever the earlier transaction spent.
+    Behind both stands the database: module 014 caps allocations per
+    charge, module 023 caps them per receipt, so a race that slips the
+    ordering is refused loudly and rolled back rather than spending the
+    same money twice.
     """
+    open_charges = conn.execute(
+        """
+        SELECT c.id::text,
+               c.amount - coalesce((SELECT sum(a.amount)
+                                    FROM rent_receipt_allocations a
+                                    WHERE a.charge_id = c.id), 0) AS outstanding
+        FROM rent_charges c
+        WHERE c.lease_id = %s AND c.status IN ('due', 'partially_paid')
+        ORDER BY c.due_on, c.created_at
+        FOR UPDATE OF c
+        """,
+        (lease_id,),
+    ).fetchall()
     credits = conn.execute(
         """
         SELECT e.id, e.event_uuid::text,
@@ -602,19 +622,6 @@ def apply_open_credit(conn: Conn, lease_id: str) -> list[dict[str, str]]:
           AND NOT EXISTS (SELECT 1 FROM ledger_events r
                           WHERE r.reverses_event_id = e.id)
         ORDER BY e.occurred_on, e.id
-        """,
-        (lease_id,),
-    ).fetchall()
-    open_charges = conn.execute(
-        """
-        SELECT c.id::text,
-               c.amount - coalesce((SELECT sum(a.amount)
-                                    FROM rent_receipt_allocations a
-                                    WHERE a.charge_id = c.id), 0) AS outstanding
-        FROM rent_charges c
-        WHERE c.lease_id = %s AND c.status IN ('due', 'partially_paid')
-        ORDER BY c.due_on, c.created_at
-        FOR UPDATE OF c
         """,
         (lease_id,),
     ).fetchall()


### PR DESCRIPTION
Closes #139 (adversarial-panel finding).

`apply_open_credit` claimed a database backstop that half-existed: module 014 caps allocations per **charge**, nothing capped them per **ledger event**, and the credits were read before the charge locks — two concurrent sweeps could spend the same receipt against two different charges (per-charge cap satisfied, PK satisfied, `open_credit` negative, a collection silently missed).

- **Module 023**: 014's trigger pointed the other way — the event locks, its allocations sum, spending past the receipt's amount is refused loudly. The racing loser rolls back and retries against settled books.
- **Ordering**: charges lock first; credits are read after in a fresh statement, so remaining figures reflect whatever an earlier transaction spent.
- **The docstring now names the real mechanisms.**

Schema proof: sixty-then-sixty from a hundred-dollar receipt — first lands, second refused, whatever charge it aims at.

Gates: schema verified; 369 API tests at 100% line+branch; ruff + ratchet clean.

Vision test (docs/VISION.md §6): refusal 12 — "never" spoken only about what the type system enforces; this promise was being spoken without enforcement, and now it isn't.