### PR TITLE
The November free-money moment gets its law, and the 21 percent lie dies

### DIFF
--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -22,3 +22,4 @@
 \ir 021_escalation_value_gets_a_unit.sql
 \ir 022_lease_dates_bind_their_charges.sql
 \ir 023_a_receipt_pays_out_at_most_once.sql
+\ir 024_tax_collection_domain.sql

--- a/packages/domain/schema/024_tax_collection_domain.sql
+++ b/packages/domain/schema/024_tax_collection_domain.sql
@@ -1,0 +1,11 @@
+-- ===========================================================================
+--  024 — The collection calendar becomes a rule domain (issue #145).
+--
+--  The packs carry when a value may be APPEALED but nothing about when the
+--  bill is PAID: no discount window, no penalty phase, no delinquency
+--  boundary. The November free-money moment (Kentucky's 2% discount) had no
+--  law under it. Collection mechanics are jurisdiction facts — cited,
+--  effective-dated, chain-resolved — so they get a domain, not a column.
+-- ===========================================================================
+
+ALTER TYPE rule_domain ADD VALUE IF NOT EXISTS 'tax_collection';

--- a/packages/domain/schema/seed/910_kentucky_collection_calendar.sql
+++ b/packages/domain/schema/seed/910_kentucky_collection_calendar.sql
@@ -1,0 +1,182 @@
+-- ===========================================================================
+--  Seed — the Kentucky collection calendar (issue #145).
+--
+--  Born from the mockup refutation: the widely cited KRS 134.020 was
+--  REPEALED effective January 1, 2010 (2009 Ky. Acts ch. 10, s.71 — the
+--  whole pre-2009 collection chapter fell in one sweep), and the calendar
+--  now lives in KRS 134.015. Two schedules exist:
+--
+--    * The REGULAR schedule (s.134.015(2)) is COMPUTED: statutory dates,
+--      a pure function of the year — 2% through November 1 (inclusive:
+--      the face period begins November 2 by the statute's own words),
+--      face through December 31, 5% in January, 10% after.
+--    * The ALTERNATIVE schedule (s.134.015(3)) is established by THE
+--      DEPARTMENT of Revenue when the regular schedule is delayed — not
+--      by the county, not by the taxpayer — and every phase derives one
+--      full month at a time from the MAILING DATE, which is a per-year
+--      published fact. Campbell County has run this schedule in 2023,
+--      2024, and 2025 (bills mail end of October; discount is the full
+--      month of November), so the county rows below carry the published
+--      2025 window and a source row that names where 2026's will come
+--      from when it publishes (~mid-October, per the sheriff's pattern).
+--
+--  THE 21% TRAP, disarmed as data: sheriffs print "21% penalty" after
+--  January 31 (Campbell and Warren both do), but no statute says 21. The
+--  second statutory penalty is TEN percent (s.134.015(2)(d)); the sheriff
+--  then adds "ten percent (10%) of the total taxes due plus ten percent
+--  (10%) of the ten percent (10%) penalty" (s.134.119(7)) — 10 + 10 + 1.
+--  A pack row carrying 0.21 as "the penalty" would be confidently wrong
+--  twice over, and the pack test refuses one.
+--
+--  Prediction scored (stated on the log before research): HYBRID,
+--  confirmed — regular schedule computed, alternative schedule anchored
+--  to a published mailing date. Sharpened by the sources: the DEPARTMENT
+--  elects, and all four phases shift together.
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- The statutory calendar — state row, regular schedule.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.due',
+   NULL, 'all property taxes are due and payable on or before December 31 of '
+   'the assessment year; unpaid bills are delinquent thereafter (the '
+   'Department''s collection-process page states they become delinquent '
+   'January 1)',
+   'KRS s.134.015(1) (created 2009 Ky. Acts ch. 10, s.2). BEWARE the '
+   'predecessor: KRS s.134.020 was REPEALED effective January 1, 2010 by '
+   '2009 Ky. Acts ch. 10, s.71 — do not "correct" this pack back to it',
+   DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.discount',
+   0.02, 'paid in full by November 1 of the assessment year — November 1 '
+   'INCLUSIVE: the statute''s face period begins November 2, so a payment on '
+   'the first still earns the discount',
+   'KRS s.134.015(2)(a) (discount "by November 1"); s.134.015(2)(b) (face '
+   'runs "between November 2 and December 31")', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.phase.face',
+   NULL, 'November 2 through December 31: the amount reflected on the tax '
+   'bill, without discount or penalty',
+   'KRS s.134.015(2)(b)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.phase.penalty_first',
+   0.05, 'January 1 through January 31 of the year following the assessment '
+   'year: five percent of the taxes due and unpaid',
+   'KRS s.134.015(2)(c)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.phase.penalty_second',
+   0.10, 'after January 31: TEN percent of the taxes due and unpaid — the '
+   '"21%" sheriffs print is this penalty PLUS the sheriff''s add-on, never a '
+   'statutory 21',
+   'KRS s.134.015(2)(d)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.sheriff_addon',
+   NULL, 'on delinquent taxes the sheriff is additionally entitled to ten '
+   'percent of the total taxes due plus ten percent of the ten percent '
+   'penalty, added to the amount due — with the s.134.015(2)(d) penalty the '
+   'practical aggregate is 21 percent, which is a COMPOSITE, not a rate',
+   'KRS s.134.119(7)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.alternative_schedule',
+   NULL, 'when the regular schedule is delayed, THE DEPARTMENT of Revenue '
+   '(s.134.010(5)) — not the county, not the taxpayer — may establish an '
+   'alternative schedule: taxes due two full months from the date bills are '
+   'mailed; 2% discount for one full month from mailing; face the next full '
+   'month; 5% the month after; 10% thereafter. Every phase shifts together, '
+   'anchored to the mailing date — a per-year published fact carried on the '
+   'county rows',
+   'KRS s.134.015(3); KRS s.134.010(5) (department defined)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.certificate_of_delinquency',
+   NULL, 'unpaid claims are filed with the county clerk on April 15 (regular '
+   'schedule) or three months and fifteen days from the due date (alternative '
+   'schedule) and become certificates of delinquency carrying the face '
+   'amount, the 10 percent penalty, and the sheriff''s commission and add-on. '
+   'The two sections word the alternative period differently ("three (3) '
+   'months and fifteen (15) days" vs "three (3) full months and fifteen (15) '
+   'days") — recorded as found',
+   'KRS s.134.122(1)(a), (2); KRS s.134.010(1)', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.omitted_property',
+   NULL, 'a bill for omitted property (or an increased valuation finally '
+   'determined on appeal) is due the day it is prepared and delinquent the '
+   'same day; if unpaid within one full month, an additional ten percent '
+   'penalty attaches — computed on the tax, fees, penalties, AND interest '
+   'due, a broader base than the tax alone',
+   'KRS s.134.015(6)', DATE '2010-01-01'),
+  -- The weekend question, answered honestly: Kentucky's general
+  -- computation-of-time statute is ASYMMETRIC, and nothing resolves whether
+  -- it reaches these fixed calendar dates. The platform therefore never
+  -- relies on a roll here — staged dates err early instead.
+  ('a0000000-0000-4000-8000-000000000010', 'tax_collection', 'collection.weekend_roll',
+   NULL, 'UNRESOLVED; KRS s.446.030(1)(a) rolls COMPUTED periods off a '
+   'Saturday, Sunday, or legal holiday, but s.446.030(2) rolls acts fixed to '
+   'a particular day off SUNDAY ONLY — and no section of chapter 134 carries '
+   'its own roll, nor does the Department''s collection-process page mention '
+   'one. Until counsel resolves which rule (if either) reaches these dates, '
+   'no emitted Kentucky collection deadline may assume a roll: stage the '
+   'prior business day',
+   'KRS s.446.030(1)(a); s.446.030(2) — CONFIRM WITH KY COUNSEL',
+   DATE '2010-01-01');
+
+-- ---------------------------------------------------------------------------
+-- Campbell County: the alternative schedule in practice, and the published
+-- 2025 window. The 2026 schedule does not exist yet — the source row names
+-- where it will come from, so its absence is a fact with an address.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0000-4000-8000-000000000021', 'tax_collection', 'collection.schedule_kind',
+   NULL, 'alternative; the county has run the s.134.015(3) schedule in 2023, '
+   '2024, and 2025 — bills mail at the very end of October and the 2% '
+   'discount runs the full month of November. Each year''s window is a '
+   'published fact from the sheriff, entered when it publishes',
+   'KRS s.134.015(3); Campbell County Sheriff''s Office tax pages, 2023-2025 '
+   '(verified 2026-09-05)', DATE '2023-01-01'),
+  ('a0000000-0000-4000-8000-000000000021', 'tax_collection', 'collection.schedule.source',
+   NULL, 'published_by_sheriff; the year''s phase dates are published by the '
+   'Campbell County Sheriff (~mid-October, per the three-year pattern). No '
+   '2026 schedule was published as of 2026-09-05 — until it is, the 2026 '
+   'window is honestly unknown and only the statutory shape is certain',
+   'Campbell County Sheriff''s Office (campbellcountysheriffky.org)',
+   DATE '2023-01-01'),
+  ('a0000000-0000-4000-8000-000000000021', 'tax_collection', 'collection.discount.note',
+   NULL, 'the 911 fee included on the county bill is not subject to the 2% '
+   'discount',
+   'Campbell County Sheriff''s Office, Tax Information page (verified '
+   '2026-09-05)', DATE '2023-01-01');
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from, effective_to) VALUES
+  ('a0000000-0000-4000-8000-000000000021', 'tax_collection', 'collection.discount.opens_on',
+   NULL, '2025-11-01',
+   'Campbell County Sheriff, 2025 collection: "The 2% discount period will '
+   'extend from November 1 through November 30, 2025"',
+   DATE '2025-01-01', DATE '2026-01-01'),
+  ('a0000000-0000-4000-8000-000000000021', 'tax_collection', 'collection.discount.closes_on',
+   NULL, '2025-11-30',
+   'Campbell County Sheriff, 2025 collection — CONFIRM ANNUALLY, the window '
+   'derives from each year''s mailing date',
+   DATE '2025-01-01', DATE '2026-01-01');
+
+-- ---------------------------------------------------------------------------
+-- Newport city tax: a different collector, a different calendar, and a
+-- stated NO on the discount — absence as an answer, not silence.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0000-4000-8000-000000000101', 'tax_collection', 'collection.due',
+   NULL, 'city bills (city plus Newport Board of Education) are mailed by '
+   'late September and payable on or before October 31; delinquent if '
+   'postmarked after that date',
+   'KRS s.91A.070(2) (a city collecting its own ad valorem taxes does so by '
+   'ordinance); City of Newport Finance/Taxes page (verified 2026-09-05); '
+   'Newport Code s.37.002 (the annual levy ordinance sets dates) — CONFIRM '
+   'the current year''s levy ordinance', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000101', 'tax_collection', 'collection.phase.penalty_first',
+   0.10, 'a 10 percent penalty is added to late bills, with interest on '
+   'delinquent bills — rates set by the annual levy ordinance',
+   'City of Newport Finance/Taxes page (verified 2026-09-05) — CONFIRM WITH '
+   'THE ANNUAL ORDINANCE', DATE '2010-01-01'),
+  ('a0000000-0000-4000-8000-000000000101', 'tax_collection', 'collection.discount',
+   NULL, 'none; no early-payment discount exists for Newport city property '
+   'tax — the county''s 2% is the county''s alone',
+   'City of Newport Finance/Taxes page (no discount provision; verified '
+   '2026-09-05) — CONFIRM WITH THE ANNUAL ORDINANCE', DATE '2010-01-01');

--- a/packages/domain/schema/tests/packs/kentucky.sql
+++ b/packages/domain/schema/tests/packs/kentucky.sql
@@ -158,3 +158,143 @@ BEGIN
   END IF;
   RAISE NOTICE '  ok      Kentucky taxes income at 3.5 percent, stored as a rate';
 END $$;
+
+-- ---------------------------------------------------------------------------
+-- The collection calendar (seed/910, issue #145): the November free-money
+-- moment gets its law, the repealed section stays dead, and the sheriffs'
+-- "21%" is pinned as the composite it is.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  discount RECORD;
+  second RECORD;
+  alt TEXT;
+  campbell_kind TEXT;
+  campbell_opens DATE;
+  campbell_closes DATE;
+  newport_due TEXT;
+  newport_discount TEXT;
+  roll TEXT;
+BEGIN
+  SELECT r.value_numeric, r.value_text, r.citation INTO discount
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND j.level = 'state'
+    AND r.code = 'collection.discount' AND r.superseded_by IS NULL;
+  IF discount.value_numeric IS DISTINCT FROM 0.02::NUMERIC
+     OR discount.value_text NOT LIKE '%November 1 INCLUSIVE%' THEN
+    RAISE EXCEPTION 'the 2%% discount row is missing its rate or its boundary: %',
+      discount.value_text;
+  END IF;
+  -- The repeal warning travels with the calendar, or someone "corrects" the
+  -- pack back to a statute that died in 2010.
+  IF NOT EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.name = 'Kentucky' AND j.level = 'state' AND r.code = 'collection.due'
+      AND r.citation LIKE '%134.020%REPEALED%'
+  ) THEN
+    RAISE EXCEPTION 'the KRS 134.020 repeal warning is missing from collection.due';
+  END IF;
+  RAISE NOTICE '  ok      two percent through November 1 inclusive, and 134.020 stays dead';
+
+  -- The second penalty is TEN percent. A 0.21 anywhere in the domain means
+  -- somebody seeded the sheriffs' composite as a statutory rate.
+  SELECT r.value_numeric, r.value_text INTO second
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND j.level = 'state'
+    AND r.code = 'collection.phase.penalty_second' AND r.superseded_by IS NULL;
+  IF second.value_numeric IS DISTINCT FROM 0.10::NUMERIC
+     OR second.value_text NOT LIKE '%COMPOSITE%' AND second.value_text NOT LIKE '%never a statutory 21%' THEN
+    RAISE EXCEPTION 'the second penalty is %, expected 0.10 with the 21-composite warning',
+      second.value_numeric;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.state = 'KY' AND r.domain = 'tax_collection'
+      AND r.value_numeric = 0.21::NUMERIC
+  ) THEN
+    RAISE EXCEPTION 'a Kentucky collection row carries 0.21 — the sheriffs'' '
+      'composite (10%% penalty + 10%% fee + 1%%) seeded as a statutory rate';
+  END IF;
+  RAISE NOTICE '  ok      the second penalty is ten percent, and no row carries the 21 composite';
+
+  -- The alternative schedule names ITS elector: the department, never the
+  -- county or the taxpayer.
+  SELECT r.value_text INTO alt
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND j.level = 'state'
+    AND r.code = 'collection.alternative_schedule' AND r.superseded_by IS NULL;
+  IF alt IS NULL OR alt NOT LIKE '%THE DEPARTMENT%' THEN
+    RAISE EXCEPTION 'the alternative schedule does not name its elector: %', alt;
+  END IF;
+  RAISE NOTICE '  ok      the alternative schedule is the department''s, phases anchored to mailing';
+
+  -- Campbell runs the alternative schedule, its 2025 window is bounded by
+  -- its year, and the 2026 absence has a named source.
+  SELECT r.value_text INTO campbell_kind
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Campbell County' AND r.code = 'collection.schedule_kind'
+    AND r.superseded_by IS NULL;
+  IF campbell_kind IS NULL OR campbell_kind NOT LIKE 'alternative;%' THEN
+    RAISE EXCEPTION 'Campbell County does not state its schedule kind: %', campbell_kind;
+  END IF;
+  SELECT opens.value_text::date, closes.value_text::date
+    INTO campbell_opens, campbell_closes
+  FROM jurisdiction_rules opens
+  JOIN jurisdictions j ON j.id = opens.jurisdiction_id
+  JOIN jurisdiction_rules closes ON closes.jurisdiction_id = opens.jurisdiction_id
+   AND closes.code = 'collection.discount.closes_on'
+   AND closes.effective_from = opens.effective_from
+  WHERE j.name = 'Campbell County' AND opens.code = 'collection.discount.opens_on'
+    AND opens.superseded_by IS NULL AND closes.superseded_by IS NULL;
+  IF campbell_opens IS DISTINCT FROM DATE '2025-11-01'
+     OR campbell_closes IS DISTINCT FROM DATE '2025-11-30' THEN
+    RAISE EXCEPTION 'the Campbell 2025 discount window is % .. %, expected Nov 1-30',
+      campbell_opens, campbell_closes;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.name = 'Campbell County'
+      AND r.code IN ('collection.discount.opens_on', 'collection.discount.closes_on')
+      AND (r.effective_to IS NULL
+           OR r.value_text::date < r.effective_from
+           OR r.value_text::date >= r.effective_to)
+  ) THEN
+    RAISE EXCEPTION 'a published Campbell discount window is unbounded or outside its year';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+    WHERE j.name = 'Campbell County' AND r.code = 'collection.schedule.source'
+      AND r.value_text LIKE 'published_by_sheriff;%'
+  ) THEN
+    RAISE EXCEPTION 'the Campbell schedule has no named source for next year''s dates';
+  END IF;
+  RAISE NOTICE '  ok      Campbell 2025: November, bounded by its year, next year''s source named';
+
+  -- Newport collects its own tax on its own calendar, and says NO discount
+  -- out loud rather than by omission.
+  SELECT r.value_text INTO newport_due
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Newport' AND r.code = 'collection.due' AND r.superseded_by IS NULL;
+  IF newport_due IS NULL OR newport_due NOT LIKE '%October 31%' THEN
+    RAISE EXCEPTION 'the Newport city due date is missing: %', newport_due;
+  END IF;
+  SELECT r.value_text INTO newport_discount
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Newport' AND r.code = 'collection.discount' AND r.superseded_by IS NULL;
+  IF newport_discount IS NULL OR newport_discount NOT LIKE 'none;%' THEN
+    RAISE EXCEPTION 'Newport does not state that it offers no discount: %', newport_discount;
+  END IF;
+  RAISE NOTICE '  ok      Newport: October 31, its own collector, and a stated no on the discount';
+
+  -- The weekend question stays visibly unresolved — a roll nobody proved
+  -- must never be relied on, and the row says so.
+  SELECT r.value_text INTO roll
+  FROM jurisdiction_rules r JOIN jurisdictions j ON j.id = r.jurisdiction_id
+  WHERE j.name = 'Kentucky' AND j.level = 'state'
+    AND r.code = 'collection.weekend_roll' AND r.superseded_by IS NULL;
+  IF roll IS NULL OR roll NOT LIKE 'UNRESOLVED;%'
+     OR roll NOT LIKE '%SUNDAY ONLY%' THEN
+    RAISE EXCEPTION 'the weekend-roll row does not state its unresolved asymmetry: %', roll;
+  END IF;
+  RAISE NOTICE '  ok      the weekend roll is recorded as unresolved, stage-early stated';
+END $$;


### PR DESCRIPTION
Closes #145 (born from the mockup refutation).

The packs carried when a value may be *appealed* but nothing about when the bill is *paid*. Module `024` adds the `tax_collection` domain; seed `910` carries the Kentucky calendar from primary sources, verbatim where boundaries matter:

- **2% through November 1, inclusive** — the statute's own face period begins November 2 (s.134.015(2)(a)-(b)).
- **The second penalty is TEN percent, never 21** — the sheriffs' printed "21%" is a composite (s.134.015(2)(d) penalty + s.134.119(7) add-on: 10% of taxes + 10% of the penalty = 10+10+1), and the pack test **refuses any row carrying 0.21 as a rate**.
- **The alternative schedule's elector is the Department of Revenue** (s.134.015(3); s.134.010(5)), not the county — every phase deriving one full month from the mailing date. Campbell has run it three years straight; the county rows carry the published 2025 window (bounded by its year) and a named source for 2026's, which doesn't exist yet and says so.
- **Newport's city tax** gets its own calendar (KRS s.91A.070; late-September bills, Oct 31, 10% penalty) and a stated **no** on the discount.
- **The weekend question seeded as the unresolved asymmetry it is** (s.446.030: computed periods roll off weekends, fixed-day acts off *Sunday only*) — no emitted KY collection deadline may assume a roll; stage the prior business day.
- The KRS 134.020 **repeal warning travels in the citation**, so nobody "corrects" the pack back to a statute that died in 2010.

Prediction scored (stated on the log before research): hybrid, **confirmed** — sharpened by who elects. Pre-push adversarial refutation: **19 of 19 rows CONFIRMED against primary sources** — the first zero-findings pass of this run.

Gates: schema verified (KY pack now 14 checks incl. the 0.21 refusal); 371 API tests at 100% line+branch; ratchet clean.

Vision test (docs/VISION.md §6): serves the November moment (mockup 1's turn card and mockup 2's free-money card now have law under them); cost-curve — one new domain module + one seed, zero service code: the collection calendar fit existing shapes.