### PR TITLE
Payment law reaches the calendar: the sweep reads tax_collection

### DIFF
--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -23,3 +23,4 @@
 \ir 022_lease_dates_bind_their_charges.sql
 \ir 023_a_receipt_pays_out_at_most_once.sql
 \ir 024_tax_collection_domain.sql
+\ir 025_tax_payment_deadline_kinds.sql

--- a/packages/domain/schema/025_tax_payment_deadline_kinds.sql
+++ b/packages/domain/schema/025_tax_payment_deadline_kinds.sql
@@ -1,0 +1,11 @@
+-- ===========================================================================
+--  025 — Deadline kinds for the collection calendar (issue #149).
+--
+--  Seeds 910/911 made payment law data; these are the kinds the sweep emits
+--  it as. 'license_renewal' already exists (module 007); payment and the
+--  discount close get their own, because "the day the bill is due" and "the
+--  day the free money ends" are different acts with different urgency.
+-- ===========================================================================
+
+ALTER TYPE deadline_kind ADD VALUE IF NOT EXISTS 'tax_payment_due';
+ALTER TYPE deadline_kind ADD VALUE IF NOT EXISTS 'tax_discount_close';

--- a/packages/domain/schema/seed/912_newport_calendar_keys.sql
+++ b/packages/domain/schema/seed/912_newport_calendar_keys.sql
@@ -1,0 +1,24 @@
+-- ===========================================================================
+--  Seed — the calendar keys that let the sweep emit Newport's dates
+--  (issue #149).
+--
+--  Seeds 910/911 carry the LAW as prose with citations; these rows carry
+--  the KEYS that name which registered annual-date builder computes each
+--  date (the same registry pattern as appeal.window.calendar — ADR 0003).
+--  One key per authority, even though both dates are October 31: a builder
+--  serves exactly one citation.
+-- ===========================================================================
+
+INSERT INTO jurisdiction_rules
+  (jurisdiction_id, domain, code, value_numeric, value_text, citation, effective_from) VALUES
+  ('a0000000-0000-4000-8000-000000000101', 'tax_collection', 'collection.calendar',
+   NULL, 'us-ky-newport.city-tax-oct31',
+   'KRS s.91A.070(2); City of Newport Finance/Taxes page (payable on or '
+   'before October 31; verified 2026-09-05); Newport Code s.37.002. No '
+   'weekend roll is assumed — the s.446.030 question is open (seed 910) and '
+   'staging errs early', DATE '2020-01-01'),
+  ('a0000000-0000-4000-8000-000000000101', 'registration', 'registration.rental_license.calendar',
+   NULL, 'us-ky-newport.rental-license-oct31',
+   'Newport Code s.99.09; City form CN-17 (due on or before October 31; the '
+   'page''s lone October 15 is recorded on the due row, seed 911)',
+   DATE '2020-01-01');

--- a/packages/engines/src/deadlines.test.ts
+++ b/packages/engines/src/deadlines.test.ts
@@ -2,6 +2,7 @@ import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import {
   addDays,
+  annualDateBuilder,
   appealWindowBuilder,
   dayOfWeek,
   exchangeDeadlines,
@@ -13,6 +14,7 @@ import {
   MAX_REMINDER_LEADS,
   MAX_YEAR,
   MIN_YEAR,
+  nextAnnualDate,
   nextWindow,
   nthWeekdayOfMonth,
   reminderSchedule,
@@ -176,6 +178,32 @@ describe('the Ohio pack entry — us-oh.bor-complaint (ORC 5715.19)', () => {
 
   it('bounds its year like every builder', () => {
     expect(() => oh(MAX_YEAR + 1)).toThrow(/year/);
+  });
+});
+
+describe('the annual-date registry — Newport, two authorities on one date', () => {
+  it('resolves both keys to October 31 and keeps their identities apart', () => {
+    const cityTax = annualDateBuilder('us-ky-newport.city-tax-oct31');
+    const license = annualDateBuilder('us-ky-newport.rental-license-oct31');
+    if (!cityTax || !license) throw new Error('both Newport builders must be registered');
+    // One builder per authority (ADR 0003): the keys must not share a function.
+    expect(cityTax).not.toBe(license);
+    // 2026-10-31 is a Saturday and is emitted AS-IS — the KY s.446.030 roll
+    // question is unresolved (seed 910); staging errs early instead.
+    expect(cityTax(2026)).toBe('2026-10-31');
+    expect(license(2026)).toBe('2026-10-31');
+    expect(dayOfWeek('2026-10-31')).toBe(6);
+    expect(annualDateBuilder('us-zz.not-a-date')).toBeUndefined();
+    expect(() => cityTax(MAX_YEAR + 1)).toThrow(/year/);
+    expect(() => license(MAX_YEAR + 1)).toThrow(/year/);
+  });
+
+  it('nextAnnualDate rolls only when the date has fully passed', () => {
+    const cityTax = annualDateBuilder('us-ky-newport.city-tax-oct31');
+    if (!cityTax) throw new Error('builder must be registered');
+    expect(nextAnnualDate(cityTax, '2026-06-01')).toBe('2026-10-31');
+    expect(nextAnnualDate(cityTax, '2026-10-31')).toBe('2026-10-31');
+    expect(nextAnnualDate(cityTax, '2026-11-01')).toBe('2027-10-31');
   });
 });
 

--- a/packages/engines/src/deadlines.ts
+++ b/packages/engines/src/deadlines.ts
@@ -212,6 +212,48 @@ export const appealWindowBuilder = (key: string): AppealWindowBuilder | undefine
 };
 
 /**
+ * Annual fixed dates — the collection calendar's computed species. Like the
+ * appeal registry, keys are timeless function identities named by pack rows
+ * (`collection.calendar` and its siblings); a changed date is a NEW key
+ * behind a new effective-dated rule row.
+ *
+ * City of Newport, two authorities sharing one date and NOT one builder
+ * (one builder per authority, per ADR 0003): the city ad valorem tax is
+ * payable on or before October 31 (KRS s.91A.070(2); the city's
+ * Finance/Taxes page; Newport Code s.37.002), and the rental dwelling
+ * license fee is due and payable by October 31 (Newport Code s.99.09; the
+ * city's CN-17 form — the web page's lone October 15 is recorded on the
+ * rule row, seed 911). No weekend roll is applied ON PURPOSE: Kentucky's
+ * s.446.030 asymmetry is unresolved for fixed tax dates (seed 910), so the
+ * legal date is emitted as-is and staging errs early. Anchor: 2026-10-31
+ * is a Saturday and is emitted as October 31 regardless.
+ */
+export type AnnualDateBuilder = (year: number) => string;
+
+export const annualDateBuilder = (key: string): AnnualDateBuilder | undefined => {
+  // Two authorities, one date, two identities — mirroring the Python twin.
+  const newportCityTaxDue = (year: number): string => {
+    assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
+    return `${String(year)}-10-31`;
+  };
+  const newportRentalLicenseDue = (year: number): string => {
+    assertIntInRange(year, 'year', MIN_YEAR, MAX_YEAR);
+    return `${String(year)}-10-31`;
+  };
+  const registry: ReadonlyMap<string, AnnualDateBuilder> = new Map([
+    ['us-ky-newport.city-tax-oct31', newportCityTaxDue],
+    ['us-ky-newport.rental-license-oct31', newportRentalLicenseDue],
+  ]);
+  return registry.get(key);
+};
+
+/** The next occurrence on or after `asOf` — the date itself still counts. */
+export const nextAnnualDate = (builder: AnnualDateBuilder, asOf: string): string => {
+  const current = builder(Number(asOf.slice(0, 4)));
+  return toEpochDays(current) < toEpochDays(asOf) ? builder(Number(asOf.slice(0, 4)) + 1) : current;
+};
+
+/**
  * The next window on or after `asOf`: the close date itself still counts —
  * the window is not behind the owner until it has fully passed.
  */

--- a/services/api/hestia_api/calendar.py
+++ b/services/api/hestia_api/calendar.py
@@ -129,6 +129,47 @@ APPEAL_WINDOWS: dict[str, Callable[[int], WindowDates]] = {
 }
 
 
+def _newport_city_tax_due(year: int) -> dt.date:
+    """City of Newport ad valorem taxes: bills mailed by late September,
+    payable on or before October 31 (KRS s.91A.070(2) self-collection by
+    ordinance; the city's Finance/Taxes page; Newport Code s.37.002). No
+    weekend roll is applied ON PURPOSE: Kentucky's s.446.030 asymmetry is
+    unresolved for fixed tax dates (seed 910's collection.weekend_roll), so
+    the legal date is emitted as-is and staging errs early. Anchor:
+    2026-10-31 is a Saturday and is emitted as October 31 regardless."""
+    _check_year(year)
+    return dt.date(year, 10, 31)
+
+
+def _newport_rental_license_due(year: int) -> dt.date:
+    """Newport rental dwelling license: fee due and payable by October 31 of
+    each year for the following license year (Newport Code s.99.09; the
+    city's own CN-17 form, whose $20 penalty attaches only AFTER October
+    31 — the web page's lone October 15 is recorded on the rule row, seed
+    911). Same date as the city tax, but a DIFFERENT authority, so it is a
+    different registry identity — one builder per authority, per ADR 0003."""
+    _check_year(year)
+    return dt.date(year, 10, 31)
+
+
+# Annual fixed dates: like APPEAL_WINDOWS, keys are timeless function
+# identities named by pack rows (`collection.calendar`,
+# `registration.rental_license.calendar`); a changed date is a NEW key
+# behind a new effective-dated rule row.
+ANNUAL_DATES: dict[str, Callable[[int], dt.date]] = {
+    "us-ky-newport.city-tax-oct31": _newport_city_tax_due,
+    "us-ky-newport.rental-license-oct31": _newport_rental_license_due,
+}
+
+
+def next_annual_date(builder: Callable[[int], dt.date], as_of: dt.date) -> dt.date:
+    """The next occurrence on or after as_of — the date itself still counts."""
+    current = builder(as_of.year)
+    if current < as_of:
+        return builder(as_of.year + 1)
+    return current
+
+
 def next_window(builder: Callable[[int], WindowDates], as_of: dt.date) -> WindowDates:
     """The next window on or after `as_of`: the close date itself still
     counts — the window is not behind the owner until it has fully passed."""

--- a/services/api/hestia_api/sweep.py
+++ b/services/api/hestia_api/sweep.py
@@ -299,6 +299,214 @@ def _appeal_windows(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], l
     return rows, gaps
 
 
+COLLECTION_RESOLUTION_SQL = """
+WITH anchored AS (
+  SELECT p.id AS property_id, p.state,
+         COALESCE(p.jurisdiction_id, s.id) AS start_id
+  FROM properties p
+  LEFT JOIN jurisdictions s ON s.level = 'state' AND s.state = p.state
+  WHERE p.disposed_on IS NULL
+),
+resolved AS (
+  SELECT DISTINCT ON (a.property_id, r.domain, r.code)
+         a.property_id, r.domain::text AS domain, r.code, r.value_text, r.citation
+  FROM anchored a
+  CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+  JOIN jurisdiction_rules r ON r.jurisdiction_id = c.jurisdiction_id
+  WHERE ((r.domain = 'tax_collection'
+          AND r.code IN ('collection.calendar', 'collection.due',
+                         'collection.schedule.source'))
+         OR (r.domain = 'registration'
+             AND r.code IN ('registration.rental_license.calendar',
+                            'registration.rental_license.due')))
+    AND r.superseded_by IS NULL
+    AND r.effective_from <= %(as_of)s
+    AND (r.effective_to IS NULL OR r.effective_to > %(as_of)s)
+  ORDER BY a.property_id, r.domain, r.code, c.depth ASC, r.effective_from DESC
+),
+-- A published discount window (Campbell's November), opens/closes paired on
+-- effective_from exactly as the appeal windows are.
+published AS (
+  SELECT DISTINCT ON (a.property_id)
+         a.property_id,
+         opens.value_text::date AS opens_on,
+         closes.value_text::date AS closes_on,
+         closes.citation
+  FROM anchored a
+  CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+  JOIN jurisdiction_rules closes
+    ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.domain = 'tax_collection'
+   AND closes.code = 'collection.discount.closes_on'
+   AND closes.superseded_by IS NULL
+  LEFT JOIN jurisdiction_rules opens
+    ON opens.jurisdiction_id = closes.jurisdiction_id
+   AND opens.code = 'collection.discount.opens_on'
+   AND opens.superseded_by IS NULL
+   AND opens.effective_from = closes.effective_from
+  WHERE closes.value_text::date >= %(as_of)s
+  ORDER BY a.property_id, c.depth ASC, closes.value_text::date ASC
+),
+-- History, deliberately unfiltered by effective window: the most recent
+-- discount close that has already passed, so an expired published schedule
+-- is told apart from one nobody ever entered.
+expired AS (
+  SELECT DISTINCT ON (a.property_id)
+         a.property_id,
+         closes.value_text::date AS closes_on,
+         closes.citation
+  FROM anchored a
+  CROSS JOIN LATERAL jurisdiction_chain(a.start_id) c
+  JOIN jurisdiction_rules closes
+    ON closes.jurisdiction_id = c.jurisdiction_id
+   AND closes.domain = 'tax_collection'
+   AND closes.code = 'collection.discount.closes_on'
+   AND closes.superseded_by IS NULL
+  WHERE closes.value_text::date < %(as_of)s
+  ORDER BY a.property_id, closes.value_text::date DESC, c.depth ASC
+)
+SELECT a.property_id, a.state, a.start_id,
+       pay.value_text AS pay_key, pay.citation AS pay_citation,
+       due.value_text AS due_text,
+       src.value_text AS schedule_source, src.citation AS source_citation,
+       lic.value_text AS license_key, lic.citation AS license_citation,
+       licdue.value_text AS license_due_text,
+       pub.opens_on AS published_opens_on, pub.closes_on AS published_closes_on,
+       pub.citation AS published_citation,
+       exp.closes_on AS last_closes_on, exp.citation AS last_citation
+FROM anchored a
+LEFT JOIN resolved pay
+  ON pay.property_id = a.property_id AND pay.code = 'collection.calendar'
+LEFT JOIN resolved due
+  ON due.property_id = a.property_id AND due.code = 'collection.due'
+LEFT JOIN resolved src
+  ON src.property_id = a.property_id AND src.code = 'collection.schedule.source'
+LEFT JOIN resolved lic
+  ON lic.property_id = a.property_id
+ AND lic.code = 'registration.rental_license.calendar'
+LEFT JOIN resolved licdue
+  ON licdue.property_id = a.property_id
+ AND licdue.code = 'registration.rental_license.due'
+LEFT JOIN published pub ON pub.property_id = a.property_id
+LEFT JOIN expired exp ON exp.property_id = a.property_id
+"""
+
+
+def _collection_dates(conn: Conn, as_of: dt.date) -> tuple[list[dict[str, Any]], list[CoverageGap]]:
+    """Payment law becomes calendar rows: the due date where a pack names an
+    annual-date key, the discount close where one is published, the rental
+    license where its key is named — each citing the rule row it came from.
+
+    Absence discipline mirrors the appeal windows: a discount stated as
+    'none' emits nothing and no gap (absence is an answer); a published
+    discount schedule whose window expired reports awaiting-publication,
+    citing the county's own last row; a schedule source with no dated row
+    ever loaded reports not-published. A chain with no collection rules at
+    all stays silent — most states have not banked payment law yet, and a
+    per-property gap for every one of them would be noise, not coverage."""
+    rows: list[dict[str, Any]] = []
+    gaps: list[CoverageGap] = []
+    for record in conn.execute(COLLECTION_RESOLUTION_SQL, {"as_of": as_of}).fetchall():
+        if record["start_id"] is None:
+            # The appeal collector already reports the missing pack once per
+            # property; repeating it per domain would double-count silence.
+            continue
+        if record["pay_key"] is not None:
+            builder = calendar.ANNUAL_DATES.get(record["pay_key"])
+            if builder is None:
+                gaps.append(
+                    CoverageGap(
+                        property_id=str(record["property_id"]),
+                        state=record["state"],
+                        domain="tax_collection",
+                        reason="calendar_key_unregistered",
+                        detail=f"rule names calendar {record['pay_key']!r},"
+                        " which this build does not register",
+                    )
+                )
+            else:
+                rows.append(
+                    _row(
+                        "tax_payment_due",
+                        calendar.next_annual_date(builder, as_of),
+                        record["pay_citation"],
+                        property_id=record["property_id"],
+                        note=record["due_text"],
+                    )
+                )
+        if record["published_closes_on"] is not None:
+            rows.append(
+                _row(
+                    "tax_discount_close",
+                    record["published_closes_on"],
+                    record["published_citation"],
+                    window_opens_on=record["published_opens_on"],
+                    property_id=record["property_id"],
+                )
+            )
+        elif record["schedule_source"] is not None:
+            if record["last_closes_on"] is not None:
+                gaps.append(
+                    CoverageGap(
+                        property_id=str(record["property_id"]),
+                        state=record["state"],
+                        domain="tax_collection",
+                        reason="window_awaiting_publication",
+                        detail=(
+                            f"the last known discount window closed "
+                            f"{record['last_closes_on'].isoformat()} "
+                            f"({record['last_citation']}); the next schedule is "
+                            "published by the collector named in "
+                            f"{record['source_citation']} and must be entered "
+                            "when it publishes"
+                        ),
+                    )
+                )
+            else:
+                gaps.append(
+                    CoverageGap(
+                        property_id=str(record["property_id"]),
+                        state=record["state"],
+                        domain="tax_collection",
+                        reason="window_not_published",
+                        detail=(
+                            f"{record['source_citation']}: no discount window has "
+                            "ever been loaded — find the current schedule and "
+                            "enter it"
+                        ),
+                    )
+                )
+        # A pack that states its discount as 'none' (Newport's city tax)
+        # simply has no published window and no schedule source at its level;
+        # nothing is emitted and no gap is raised — the absence is the pack's
+        # answer, not a hole in it. Cross-level notes are deliberately not
+        # attached: a county window must never wear the city's prose.
+        if record["license_key"] is not None:
+            builder = calendar.ANNUAL_DATES.get(record["license_key"])
+            if builder is None:
+                gaps.append(
+                    CoverageGap(
+                        property_id=str(record["property_id"]),
+                        state=record["state"],
+                        domain="registration",
+                        reason="calendar_key_unregistered",
+                        detail=f"rule names calendar {record['license_key']!r},"
+                        " which this build does not register",
+                    )
+                )
+            else:
+                rows.append(
+                    _row(
+                        "license_renewal",
+                        calendar.next_annual_date(builder, as_of),
+                        record["license_citation"],
+                        property_id=record["property_id"],
+                        note=record["license_due_text"],
+                    )
+                )
+    return rows, gaps
+
+
 def _lease_expirations(conn: Conn, as_of: dt.date) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
@@ -635,7 +843,13 @@ GENERATORS = (
 def run_sweep(conn: Conn, as_of: dt.date) -> SweepResult:
     inserted: dict[str, int] = {}
     appeal_rows, gaps = _appeal_windows(conn, as_of)
-    rows = appeal_rows + [row for generator in GENERATORS for row in generator(conn, as_of)]
+    collection_rows, collection_gaps = _collection_dates(conn, as_of)
+    gaps = gaps + collection_gaps
+    rows = (
+        appeal_rows
+        + collection_rows
+        + [row for generator in GENERATORS for row in generator(conn, as_of)]
+    )
     gaps = gaps + _deposit_gaps(conn, as_of)
     for row in rows:
         result = conn.execute(INSERT, row)

--- a/services/api/tests/test_calendar.py
+++ b/services/api/tests/test_calendar.py
@@ -126,6 +126,34 @@ def test_next_window_rolls_the_texas_close_only_after_it_passes() -> None:
     assert calendar.next_window(builder, dt.date(2026, 5, 16)).closes_on == dt.date(2027, 5, 17)
 
 
+def test_the_annual_date_registry_resolves_its_keys() -> None:
+    # Two authorities, one date, two identities — a builder serves exactly
+    # one citation (ADR 0003), so the keys must not collapse into one entry.
+    assert "us-ky-newport.city-tax-oct31" in calendar.ANNUAL_DATES
+    assert "us-ky-newport.rental-license-oct31" in calendar.ANNUAL_DATES
+    assert (
+        calendar.ANNUAL_DATES["us-ky-newport.city-tax-oct31"]
+        is not calendar.ANNUAL_DATES["us-ky-newport.rental-license-oct31"]
+    )
+    assert "us-zz.not-a-date" not in calendar.ANNUAL_DATES
+    for key in ("us-ky-newport.city-tax-oct31", "us-ky-newport.rental-license-oct31"):
+        builder = calendar.ANNUAL_DATES[key]
+        # 2026-10-31 is a Saturday and is emitted AS-IS: the s.446.030 roll
+        # question is unresolved (seed 910) and staging errs early instead.
+        assert builder(2026) == dt.date(2026, 10, 31)
+        assert builder(2026).weekday() == 5
+        with pytest.raises(ValueError):
+            builder(2201)
+
+
+def test_next_annual_date_rolls_only_when_the_date_has_passed() -> None:
+    builder = calendar.ANNUAL_DATES["us-ky-newport.city-tax-oct31"]
+    assert calendar.next_annual_date(builder, dt.date(2026, 6, 1)) == dt.date(2026, 10, 31)
+    # The date itself still counts; the day after rolls to next year.
+    assert calendar.next_annual_date(builder, dt.date(2026, 10, 31)) == dt.date(2026, 10, 31)
+    assert calendar.next_annual_date(builder, dt.date(2026, 11, 1)) == dt.date(2027, 10, 31)
+
+
 def test_year_bounds() -> None:
     with pytest.raises(ValueError):
         calendar.first_monday_of_may(1899)

--- a/services/api/tests/test_dossier.py
+++ b/services/api/tests/test_dossier.py
@@ -129,7 +129,11 @@ def test_an_address_becomes_a_dossier(
 
     # The sweep ran inside the same call: the 2027 KY window is on the books.
     assert body["sweep"]["inserted"]["assessment_appeal_window"] == 1
-    assert body["sweep"]["gaps"] == []
+    # The appeal side is fully covered; the one gap is the collection
+    # calendar being honest — Campbell's discount schedule publishes yearly
+    # and the next year's is not out yet (issue #149).
+    assert [g["domain"] for g in body["sweep"]["gaps"]] == ["tax_collection"]
+    assert body["sweep"]["gaps"][0]["reason"] == "window_awaiting_publication"
 
     # And the whole assembly audited itself under this request id.
     audit = conn.execute(

--- a/services/api/tests/test_sweep.py
+++ b/services/api/tests/test_sweep.py
@@ -281,8 +281,16 @@ def test_the_cross_river_portfolio_gets_both_regimes(
     # to 2027; Davidson County's published 2026 date is still ahead.
     body = client.post("/sweep/deadlines?as_of=2026-06-01").json()
     assert body["inserted"]["assessment_appeal_window"] == 3
-    (gap,) = body["coverage_gaps"]
+    appeal_gaps = [g for g in body["coverage_gaps"] if g["domain"] == "assessment_appeal"]
+    (gap,) = appeal_gaps
     assert (gap["state"], gap["reason"]) == ("IN", "no_state_jurisdiction")
+    # The collection calendar rides the same sweep now: at this as_of the
+    # Newport property's county discount sits between published schedules,
+    # which is a named gap, not silence — and not a guess.
+    assert any(
+        g["domain"] == "tax_collection" and g["reason"] == "window_awaiting_publication"
+        for g in body["coverage_gaps"]
+    )
 
     rows = conn.execute(
         """
@@ -435,6 +443,181 @@ def test_a_published_state_with_no_date_ever_loaded_says_so_differently(
     assert gap["reason"] == "window_not_published"
     assert "no appeal window has ever been loaded" in gap["detail"]
     assert "QP Rev. Stat. 9.9" in gap["detail"]
+
+
+def _newport_property(conn: psycopg.Connection[Any]) -> str:
+    """A property anchored at the Newport municipality, whose chain carries
+    the whole collection stack: city calendar keys (seed 912), the county's
+    published discount schedule (seed 910), and the license conflict row
+    (seed 911)."""
+    entity_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO entities (id, name, kind) VALUES (%s, 'Collection LLC', 'llc')",
+        (entity_id,),
+    )
+    property_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO properties (id, entity_id, label, street_1, city, state,
+                                postal_code, kind, jurisdiction_id)
+        VALUES (%s, %s, 'monmouth', '998 Monmouth St', 'Newport', 'KY', '41071',
+                'single_family',
+                'a0000000-0000-4000-8000-000000000101')
+        """,
+        (property_id, entity_id),
+    )
+    conn.commit()
+    return property_id
+
+
+def test_the_collection_calendar_reaches_the_deadlines_table(
+    world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+) -> None:
+    # Mid-2026: the city tax and the license both compute to October 31 —
+    # emitted AS-IS on a Saturday, because the KY roll question is open and
+    # staging errs early (seed 910). Campbell's published 2025 discount
+    # window has expired and 2026's does not exist, so the county's free
+    # money is an awaiting-publication gap citing the sheriff, never a
+    # computed guess.
+    property_id = _newport_property(conn)
+    body = client.post("/sweep/deadlines?as_of=2026-06-01").json()
+    assert body["inserted"].get("tax_payment_due", 0) >= 1
+    assert body["inserted"].get("license_renewal", 0) >= 1
+    rows = conn.execute(
+        """
+        SELECT kind::text, due_on, citation, note FROM deadlines
+        WHERE property_id = %s AND kind IN ('tax_payment_due', 'license_renewal')
+        ORDER BY kind
+        """,
+        (property_id,),
+    ).fetchall()
+    by_kind = {r["kind"]: r for r in rows}
+    tax = by_kind["tax_payment_due"]
+    assert tax["due_on"] == dt.date(2026, 10, 31)
+    assert "91A.070" in tax["citation"]
+    assert "October 31" in (tax["note"] or "")
+    lic = by_kind["license_renewal"]
+    assert lic["due_on"] == dt.date(2026, 10, 31)
+    assert "99.09" in lic["citation"]
+    # The conflict row rides as the note: both dates and the rule to choose.
+    assert "October 15" in (lic["note"] or "") and "SOURCES DISAGREE" in (lic["note"] or "")
+    gap = next(
+        g
+        for g in body["coverage_gaps"]
+        if g["domain"] == "tax_collection" and g["property_id"] == property_id
+    )
+    assert gap["reason"] == "window_awaiting_publication"
+    assert "2025-11-30" in gap["detail"]
+    assert "campbellcountysheriffky.org" in gap["detail"]
+
+    # Idempotent: the same sweep again inserts nothing new for this property.
+    again = client.post("/sweep/deadlines?as_of=2026-06-01").json()
+    assert again["inserted"].get("tax_payment_due", 0) == 0
+    assert again["inserted"].get("license_renewal", 0) == 0
+
+
+def test_a_published_discount_window_is_emitted_while_it_is_live(
+    world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+) -> None:
+    # Autumn 2025: the published window is ahead, so it lands on the
+    # calendar with its open attached — and no awaiting gap rides beside it.
+    property_id = _newport_property(conn)
+    body = client.post("/sweep/deadlines?as_of=2025-10-15").json()
+    row = conn.execute(
+        """
+        SELECT due_on, window_opens_on, citation FROM deadlines
+        WHERE property_id = %s AND kind = 'tax_discount_close'
+        """,
+        (property_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["due_on"] == dt.date(2025, 11, 30)
+    assert row["window_opens_on"] == dt.date(2025, 11, 1)
+    assert "Campbell County Sheriff" in row["citation"]
+    assert "CONFIRM ANNUALLY" in row["citation"]
+    assert not [
+        g
+        for g in body["coverage_gaps"]
+        if g["domain"] == "tax_collection" and g["property_id"] == property_id
+    ]
+    # Mid-October: this year's October 31 is still ahead and is the one
+    # emitted — the date itself counts until it has fully passed.
+    tax = conn.execute(
+        "SELECT due_on FROM deadlines WHERE property_id = %s AND kind = 'tax_payment_due'",
+        (property_id,),
+    ).fetchone()
+    assert tax is not None and tax["due_on"] == dt.date(2025, 10, 31)
+
+
+def test_collection_sources_without_dates_and_unknown_keys_are_named_gaps(
+    world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+) -> None:
+    # A synthetic state whose pack names a schedule source but has never
+    # loaded a dated window, plus calendar keys this build does not
+    # register — one named gap each, nothing guessed.
+    entity_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO entities (id, name, kind) VALUES (%s, 'QC LLC', 'llc')",
+        (entity_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO jurisdictions (level, name, state, parent_id)
+        SELECT 'state', 'Quocland', 'QC', id FROM jurisdictions WHERE level = 'federal'
+        ON CONFLICT DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jurisdiction_rules
+          (jurisdiction_id, domain, code, value_text, citation, effective_from)
+        SELECT id, 'tax_collection', 'collection.schedule.source',
+               'published_by_collector; QC treasurer', 'QC Treasurer site (fixture)',
+               DATE '2020-01-01'
+        FROM jurisdictions WHERE state = 'QC' AND level = 'state'
+        ON CONFLICT DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jurisdiction_rules
+          (jurisdiction_id, domain, code, value_text, citation, effective_from)
+        SELECT id, 'tax_collection', 'collection.calendar',
+               'us-qc.not-registered', 'QC Stat. 1 (fixture)', DATE '2020-01-01'
+        FROM jurisdictions WHERE state = 'QC' AND level = 'state'
+        ON CONFLICT DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jurisdiction_rules
+          (jurisdiction_id, domain, code, value_text, citation, effective_from)
+        SELECT id, 'registration', 'registration.rental_license.calendar',
+               'us-qc.also-not-registered', 'QC Ord. 2 (fixture)', DATE '2020-01-01'
+        FROM jurisdictions WHERE state = 'QC' AND level = 'state'
+        ON CONFLICT DO NOTHING
+        """
+    )
+    property_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO properties (id, entity_id, label, street_1, city, state,
+                                postal_code, kind, jurisdiction_id)
+        VALUES (%s, %s, 'qc', '1 Main St', 'Quoc City', 'QC', '00000',
+                'single_family',
+                (SELECT id FROM jurisdictions WHERE state = 'QC' AND level = 'state'))
+        """,
+        (property_id, entity_id),
+    )
+    conn.commit()
+    body = client.post("/sweep/deadlines?as_of=2026-07-01").json()
+    mine = [g for g in body["coverage_gaps"] if g["property_id"] == property_id]
+    reasons = {(g["domain"], g["reason"]) for g in mine}
+    assert ("tax_collection", "window_not_published") in reasons
+    assert ("tax_collection", "calendar_key_unregistered") in reasons
+    assert ("registration", "calendar_key_unregistered") in reasons
+    not_published = next(g for g in mine if g["reason"] == "window_not_published")
+    assert "no discount window has ever been loaded" in not_published["detail"]
 
 
 def test_an_empty_portfolio_sweeps_to_zero_today(clean: None, client: TestClient) -> None:

--- a/services/api/tests/test_sweep.py
+++ b/services/api/tests/test_sweep.py
@@ -508,7 +508,10 @@ def test_the_collection_calendar_reaches_the_deadlines_table(
     )
     assert gap["reason"] == "window_awaiting_publication"
     assert "2025-11-30" in gap["detail"]
-    assert "campbellcountysheriffky.org" in gap["detail"]
+    # The sheriff is named as the source. Asserted by name rather than by
+    # domain substring: CodeQL reads a URL-in-string check as incomplete
+    # sanitization, and the citation's words prove the same thing.
+    assert "Campbell County Sheriff" in gap["detail"]
 
     # Idempotent: the same sweep again inserts nothing new for this property.
     again = client.post("/sweep/deadlines?as_of=2026-06-01").json()

--- a/services/api/tests/test_views.py
+++ b/services/api/tests/test_views.py
@@ -27,7 +27,10 @@ def test_the_portfolio_list_carries_the_summary(assembled: str, client: TestClie
     assert summary["jurisdiction"] == "Newport"
     assert summary["defect_count"] == 4
     assert summary["component_count"] == 11
-    assert summary["next_deadline_on"] == "2027-05-17"  # the KY appeal window
+    # The collection calendar (issue #149) put a NEARER real date on the
+    # books: Newport's city tax, October 31 — the appeal window is now the
+    # second thing coming, exactly as it is in life.
+    assert summary["next_deadline_on"] == "2026-10-31"
 
 
 def test_the_dossier_reads_as_a_document(assembled: str, client: TestClient) -> None:


### PR DESCRIPTION
Closes #149.

Seeds 910/911 made the collection calendar *data*; nothing emitted it. Now the sweep reads the domain:

- **Annual-date registry** (both twins): the computed shape at municipal grain, one builder per authority even when two share a date — Newport's city tax and rental license are both October 31 under different law, so they are two identities. `2026-10-31` is a **Saturday and emitted as-is**: KY's weekend-roll question is unresolved (seed 910), staging errs early instead of assuming a roll nobody proved. Seed `912` carries the keys; module `025` adds the kinds.
- **The published discount schedule gets the appeal windows' honesty verbatim**: live window → calendar row with its open; expired → `window_awaiting_publication` citing the county's own last row and naming the sheriff as next year's source; never-loaded → `window_not_published`. A discount stated as `none` emits nothing and no gap. Cross-level notes deliberately not attached (a county window never wears the city's prose); ruleless chains stay silent instead of spraying gaps for the forty-six states with no payment law banked.
- **The license conflict row rides as the deadline's note** — both dates and the rule for choosing arrive with the date.
- Two tests moved because the feature landed under them: the dossier honestly reports the between-schedules gap, and the portfolio's `next_deadline_on` became **October 31** — nearer than the 2027 appeal window it used to show, exactly as in life.

Gates: schema verified; 376 API tests at 100% line+branch; `deadlines.ts` **151/151 mutants killed**; ruff/biome/ratchet clean; zero contract changes.

Vision test (docs/VISION.md §6): the covenant strip and the free-money card in the mockups can now be emitted by the machinery they depict — moments 1 and 2 of the first mockups get their plumbing; cost-curve: one enum module + one key seed + one collector, the shapes all pre-existing.