### PR TITLE
A wrong charge gets a correction path: supersession, never mutation

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -828,6 +828,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/rent-charges/{charge_id}/correct": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Correct Charge
+         * @description Correct a wrong charge by supersession (issue #105): the old row
+         *     becomes history pointing at its successor; paid money is released to
+         *     open credit and re-applied. Superseded, waived, and written-off charges
+         *     are not correctable — correct the LIVE row to extend a chain.
+         */
+        post: operations["correct_charge_rent_charges__charge_id__correct_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/rent-charges/{charge_id}/waive": {
         parameters: {
             query?: never;
@@ -1558,6 +1581,10 @@ export interface components {
             allocated: string;
             /** Amount */
             amount: string;
+            /** Correction Reason */
+            correction_reason?: string | null;
+            /** Corrects Charge Id */
+            corrects_charge_id?: string | null;
             /**
              * Due On
              * Format: date
@@ -1578,6 +1605,8 @@ export interface components {
             rule_citation: string | null;
             /** Status */
             status: string;
+            /** Superseded By */
+            superseded_by?: string | null;
             /** Waived Reason */
             waived_reason: string | null;
         };
@@ -1652,6 +1681,26 @@ export interface components {
             provenance_kind: string;
             /** System */
             system: string;
+        };
+        /** CorrectionIn */
+        CorrectionIn: {
+            /** Amount */
+            amount: number | string;
+            /** Reason */
+            reason: string;
+        };
+        /** CorrectionOut */
+        CorrectionOut: {
+            /** New Charge Id */
+            new_charge_id: string;
+            /** Reapplied */
+            reapplied: {
+                [key: string]: string;
+            }[];
+            /** Released */
+            released: string;
+            /** Superseded Charge Id */
+            superseded_charge_id: string;
         };
         /**
          * CostIn
@@ -5468,6 +5517,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Readiness"];
+                };
+            };
+        };
+    };
+    correct_charge_rent_charges__charge_id__correct_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-actor"?: string;
+            };
+            path: {
+                charge_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CorrectionIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CorrectionOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -1132,6 +1132,28 @@
             "title": "Amount",
             "type": "string"
           },
+          "correction_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correction Reason"
+          },
+          "corrects_charge_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrects Charge Id"
+          },
           "due_on": {
             "format": "date",
             "title": "Due On",
@@ -1169,6 +1191,17 @@
           "status": {
             "title": "Status",
             "type": "string"
+          },
+          "superseded_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Superseded By"
           },
           "waived_reason": {
             "anyOf": [
@@ -1471,6 +1504,69 @@
           "derived_from"
         ],
         "title": "ComponentOut",
+        "type": "object"
+      },
+      "CorrectionIn": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*(?:\\d{0,16}|(?=[\\d.]{1,19}0*$)\\d{0,16}\\.\\d{0,2}0*$)",
+                "type": "string"
+              }
+            ],
+            "title": "Amount"
+          },
+          "reason": {
+            "minLength": 3,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "reason"
+        ],
+        "title": "CorrectionIn",
+        "type": "object"
+      },
+      "CorrectionOut": {
+        "properties": {
+          "new_charge_id": {
+            "title": "New Charge Id",
+            "type": "string"
+          },
+          "reapplied": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Reapplied",
+            "type": "array"
+          },
+          "released": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Released",
+            "type": "string"
+          },
+          "superseded_charge_id": {
+            "title": "Superseded Charge Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "superseded_charge_id",
+          "new_charge_id",
+          "released",
+          "reapplied"
+        ],
+        "title": "CorrectionOut",
         "type": "object"
       },
       "CostIn": {
@@ -10816,6 +10912,67 @@
           }
         },
         "summary": "Readyz"
+      }
+    },
+    "/rent-charges/{charge_id}/correct": {
+      "post": {
+        "description": "Correct a wrong charge by supersession (issue #105): the old row\nbecomes history pointing at its successor; paid money is released to\nopen credit and re-applied. Superseded, waived, and written-off charges\nare not correctable \u2014 correct the LIVE row to extend a chain.",
+        "operationId": "correct_charge_rent_charges__charge_id__correct_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "charge_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Charge Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CorrectionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorrectionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Correct Charge"
       }
     },
     "/rent-charges/{charge_id}/waive": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -24,3 +24,5 @@
 \ir 023_a_receipt_pays_out_at_most_once.sql
 \ir 024_tax_collection_domain.sql
 \ir 025_tax_payment_deadline_kinds.sql
+\ir 026_charge_supersession_status.sql
+\ir 027_charges_correct_by_supersession.sql

--- a/packages/domain/schema/026_charge_supersession_status.sql
+++ b/packages/domain/schema/026_charge_supersession_status.sql
@@ -1,0 +1,9 @@
+-- ===========================================================================
+--  026 — The 'superseded' charge status (issue #105, part 1 of 2).
+--
+--  Its own module because PostgreSQL refuses to USE an enum value in the
+--  transaction that added it, and module 027's coupling CHECK does exactly
+--  that. The value lands here; the machinery lands next door.
+-- ===========================================================================
+
+ALTER TYPE charge_status ADD VALUE IF NOT EXISTS 'superseded';

--- a/packages/domain/schema/027_charges_correct_by_supersession.sql
+++ b/packages/domain/schema/027_charges_correct_by_supersession.sql
@@ -1,0 +1,70 @@
+-- ===========================================================================
+--  027 — A wrong charge gets a correction path: supersession, never
+--  mutation (issue #105).
+--
+--  The premise-checker's catch during vision grooming: one_charge_per_period
+--  forbids a second ('rent', period) row, the sweep never revises, nothing
+--  updates rent_charges.amount, and waive-and-reissue is blocked by the same
+--  key — so ANY wrong rent charge (a typo, a mid-period lease amendment, a
+--  late-arriving CPI figure when #44 returns) was irrecoverable in an
+--  append-only system with no correction path.
+--
+--  The path is the house's own supersession law (module 006's append-never-
+--  mutate; jurisdiction_rules' superseded_by), applied to charges:
+--
+--    * The old charge is never edited and never deleted. It is marked
+--      superseded, pointing at its successor, and drops out of every
+--      balance the way waived rows do — history, fully readable.
+--    * The successor is a NEW row: same lease, kind, and period, the
+--      corrected amount, carrying WHO it corrects and WHY. A correction
+--      without a reason does not exist.
+--    * one_charge_per_period becomes a partial unique index over LIVE rows
+--      (same name, so every test that names it keeps matching): one live
+--      charge per period forever, any number of superseded predecessors.
+--    * The successor pointer is DEFERRABLE: the writer marks the old row
+--      first (so it leaves the live index) and inserts the new row second,
+--      inside one transaction; the FK proves the chain at commit.
+--    * One successor per charge — a second correction corrects the LIVE
+--      row, extending the chain, never forking it.
+--
+--  Money follows the correction: the writer releases the old charge's
+--  allocations back to open credit and re-applies oldest-first, so a paid
+--  charge corrected downward leaves the excess VISIBLE as credit, and one
+--  corrected upward shows the true remaining balance. Nothing in the
+--  ledger moves — receipts are history; only their allocation changes.
+-- ===========================================================================
+
+ALTER TABLE rent_charges
+  ADD COLUMN superseded_by UUID REFERENCES rent_charges (id)
+    DEFERRABLE INITIALLY DEFERRED,
+  ADD COLUMN corrects_charge_id UUID REFERENCES rent_charges (id),
+  ADD COLUMN correction_reason TEXT;
+
+ALTER TABLE rent_charges DROP CONSTRAINT one_charge_per_period;
+CREATE UNIQUE INDEX one_charge_per_period
+  ON rent_charges (lease_id, kind, period_start)
+  WHERE superseded_by IS NULL;
+
+-- A chain, never a fork: each charge has at most one successor. (UNIQUE
+-- ignores NULLs, so uncorrected charges are unconstrained.)
+ALTER TABLE rent_charges
+  ADD CONSTRAINT one_successor_per_charge UNIQUE (superseded_by);
+
+-- A correction without a reason does not exist, and a reason without a
+-- correction is noise.
+ALTER TABLE rent_charges
+  ADD CONSTRAINT correction_says_why
+  CHECK ((corrects_charge_id IS NULL) = (correction_reason IS NULL));
+
+-- The status and the pointer move together, both directions: no silently
+-- dead live-looking rows, no superseded rows still wearing 'due'.
+ALTER TABLE rent_charges
+  ADD CONSTRAINT superseded_is_coupled
+  CHECK ((status = 'superseded') = (superseded_by IS NOT NULL));
+
+COMMENT ON COLUMN rent_charges.superseded_by IS
+  'The successor charge that corrected this one. Set once, never cleared; '
+  'a superseded charge is history and drops out of every balance.';
+COMMENT ON COLUMN rent_charges.corrects_charge_id IS
+  'The charge this row corrects. Travels with correction_reason — '
+  'correction_says_why makes a why-less correction unrepresentable.';

--- a/packages/domain/schema/tests/constraints.sql
+++ b/packages/domain/schema/tests/constraints.sql
@@ -709,6 +709,75 @@ DELETE FROM rent_receipt_allocations
   WHERE charge_id IN (SELECT id FROM rent_charges
                       WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222');
 DELETE FROM rent_charges WHERE id = 'bbbbbbbb-4444-4444-4444-444444444444';
+-- Module 027: correction by supersession. The August rent charge above is
+-- still live; supersede it and prove the law holds in both directions.
+SELECT assert_rejected(
+  $$UPDATE rent_charges SET status = 'superseded'
+    WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND kind = 'rent'$$,
+  'superseded_is_coupled', 'a superseded status with no successor pointer');
+SELECT assert_rejected(
+  $$INSERT INTO rent_charges
+      (lease_id, kind, period_start, due_on, amount, corrects_charge_id)
+    SELECT lease_id, 'late_fee', '2026-09-01', '2026-09-01', 10.00, id
+    FROM rent_charges
+    WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND kind = 'rent'$$,
+  'correction_says_why', 'a correction with no reason');
+-- The real flow, in one transaction: mark the old row first (it leaves the
+-- live index; the deferred FK proves the chain at commit), insert the
+-- successor second — same period, corrected amount, reason carried.
+DO $$
+DECLARE
+  old_id UUID;
+  new_id UUID := 'bbbbbbbb-5555-5555-5555-555555555555';
+BEGIN
+  SELECT id INTO old_id FROM rent_charges
+  WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222' AND kind = 'rent'
+    AND superseded_by IS NULL;
+  UPDATE rent_charges SET status = 'superseded', superseded_by = new_id
+  WHERE id = old_id;
+  INSERT INTO rent_charges
+    (id, lease_id, kind, period_start, due_on, amount, generated_by,
+     corrects_charge_id, correction_reason)
+  VALUES (new_id, 'bbbbbbbb-2222-2222-2222-222222222222', 'rent',
+          '2026-08-01', '2026-08-01', 1400.00, 'correction',
+          old_id, 'fixture: rent was mistyped by fifty dollars');
+  RAISE NOTICE '  ok      a charge superseded and its successor live in one period';
+END $$;
+-- The live index still refuses a SECOND live row for the corrected period...
+SELECT assert_rejected(
+  $$INSERT INTO rent_charges (lease_id, kind, period_start, due_on, amount)
+    VALUES ('bbbbbbbb-2222-2222-2222-222222222222', 'rent', '2026-08-01',
+            '2026-08-05', 1450.00)$$,
+  'one_charge_per_period', 'a second LIVE charge for a corrected period');
+-- ...and the chain cannot fork: a September throwaway, properly coupled,
+-- tries to claim the same successor and loses to one_successor_per_charge
+-- (status set alongside the pointer, so the coupling CHECK stays out of
+-- the way and the UNIQUE is what answers).
+INSERT INTO rent_charges (lease_id, kind, period_start, due_on, amount)
+  VALUES ('bbbbbbbb-2222-2222-2222-222222222222', 'rent', '2026-09-01',
+          '2026-09-01', 1450.00);
+SELECT assert_rejected(
+  $$UPDATE rent_charges
+    SET status = 'superseded',
+        superseded_by = 'bbbbbbbb-5555-5555-5555-555555555555'
+    WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222'
+      AND period_start = '2026-09-01'$$,
+  'one_successor_per_charge', 'two charges claiming one successor');
+-- Cleanup in ONE transaction, RESTORING the pre-correction state (the
+-- module-022 tests below still need the live August charge): the successor
+-- goes first (its corrects FK points at the old row), the old row is
+-- un-superseded — legal only in this sandbox — and the September throwaway
+-- goes with them; the deferred pointer resolves at commit.
+DO $$
+BEGIN
+  DELETE FROM rent_charges WHERE id = 'bbbbbbbb-5555-5555-5555-555555555555';
+  UPDATE rent_charges SET superseded_by = NULL, status = 'due'
+    WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222'
+      AND period_start = '2026-08-01';
+  DELETE FROM rent_charges
+    WHERE lease_id = 'bbbbbbbb-2222-2222-2222-222222222222'
+      AND period_start = '2026-09-01';
+END $$;
 -- Module 022: lease dates bind their charges. The August charge above is
 -- still on the books here, so the lease's dates are load-bearing.
 SELECT assert_rejected(

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -770,6 +770,39 @@ def waive_charge(
     )
 
 
+@app.post("/rent-charges/{charge_id}/correct", response_model=rent.CorrectionOut)
+def correct_charge(
+    charge_id: uuid.UUID,
+    body: rent.CorrectionIn,
+    conn: Conn,
+    request: Request,
+    actor: Actor = "system",
+) -> rent.CorrectionOut:
+    """Correct a wrong charge by supersession (issue #105): the old row
+    becomes history pointing at its successor; paid money is released to
+    open credit and re-applied. Superseded, waived, and written-off charges
+    are not correctable — correct the LIVE row to extend a chain."""
+    try:
+        result = rent.correct_charge(conn, str(charge_id), body)
+    except rent.UncorrectableCharge as error:
+        raise HTTPException(status_code=404, detail="no correctable charge found") from error
+    _audit(
+        conn,
+        request,
+        actor,
+        "rent.correct",
+        "rent_charges",
+        str(charge_id),
+        {
+            "reason": body.reason,
+            "new_amount": str(body.amount),
+            "new_charge_id": result.new_charge_id,
+            "released": str(result.released),
+        },
+    )
+    return result
+
+
 @app.get("/leases/{lease_id}/renewal-context", response_model=rent.RenewalContextOut)
 def renewal_context(lease_id: uuid.UUID, conn: Conn) -> rent.RenewalContextOut:
     try:

--- a/services/api/hestia_api/ledger.py
+++ b/services/api/hestia_api/ledger.py
@@ -118,11 +118,12 @@ class AlreadyReversed(Exception):
 
 def refresh_charge_status(conn: Conn, charge_id: str) -> None:
     """Recompute a charge's status from its allocations — in BOTH directions
-    (a reversal can un-pay a charge), never touching waived/written_off."""
+    (a reversal can un-pay a charge), never touching waived/written_off — or
+    superseded, which is history and must never be resurrected to 'due'."""
     conn.execute(
         """
         UPDATE rent_charges c SET status = CASE
-          WHEN c.status IN ('waived', 'written_off') THEN c.status
+          WHEN c.status IN ('waived', 'written_off', 'superseded') THEN c.status
           WHEN coalesce((SELECT sum(a.amount) FROM rent_receipt_allocations a
                          WHERE a.charge_id = c.id), 0) >= c.amount THEN 'paid'
           WHEN coalesce((SELECT sum(a.amount) FROM rent_receipt_allocations a

--- a/services/api/hestia_api/rent.py
+++ b/services/api/hestia_api/rent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import calendar as calendar_module
 import datetime as dt
+import uuid
 from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
 from typing import Any, Literal
@@ -106,6 +107,11 @@ class ChargeOut(BaseModel):
     outstanding: Decimal
     rule_citation: str | None
     waived_reason: str | None
+    # The correction chain (issue #105): who this row corrects and why, and
+    # who corrected it — a superseded charge is history, fully readable.
+    corrects_charge_id: str | None = None
+    correction_reason: str | None = None
+    superseded_by: str | None = None
 
 
 class LeaseDetail(BaseModel):
@@ -203,12 +209,12 @@ SELECT l.id::text, u.property_id::text, p.label AS property_label,
        -- paid-up tenant). Waived/written_off drop out of BOTH sides.
        coalesce((SELECT sum(c.amount) FROM rent_charges c
                  WHERE c.lease_id = l.id
-                   AND c.status NOT IN ('waived', 'written_off')), 0)
+                   AND c.status NOT IN ('waived', 'written_off', 'superseded')), 0)
        - coalesce((SELECT sum(a.amount)
                    FROM rent_receipt_allocations a
                    JOIN rent_charges c ON c.id = a.charge_id
                    WHERE c.lease_id = l.id
-                     AND c.status NOT IN ('waived', 'written_off')), 0)
+                     AND c.status NOT IN ('waived', 'written_off', 'superseded')), 0)
          AS balance_due,
        -- Money received but not yet applied to any charge: a prepayment,
        -- persistent and visible, consumed by the next sweep.
@@ -268,6 +274,8 @@ def lease_detail(conn: Conn, lease_id: str) -> LeaseDetail:
         """
         SELECT c.id::text, c.kind::text, c.period_start, c.due_on, c.amount,
                c.status::text, c.rule_citation, c.waived_reason,
+               c.corrects_charge_id::text, c.correction_reason,
+               c.superseded_by::text,
                coalesce(sum(a.amount), 0) AS allocated
         FROM rent_charges c
         LEFT JOIN rent_receipt_allocations a ON a.charge_id = c.id
@@ -287,7 +295,7 @@ def lease_detail(conn: Conn, lease_id: str) -> LeaseDetail:
                 allocated=charge["allocated"],
                 outstanding=(
                     charge["amount"] - charge["allocated"]
-                    if charge["status"] not in ("waived", "written_off")
+                    if charge["status"] not in ("waived", "written_off", "superseded")
                     else Decimal(0)
                 ),
             )
@@ -362,6 +370,84 @@ def _due_on_in(period_start: dt.date, rent_due_day: int) -> dt.date:
     return period_start.replace(day=min(rent_due_day, last_day))
 
 
+class CorrectionIn(BaseModel):
+    amount: Decimal = Field(gt=0, decimal_places=2, max_digits=18)
+    reason: str = Field(min_length=3)
+
+
+class CorrectionOut(BaseModel):
+    superseded_charge_id: str
+    new_charge_id: str
+    released: Decimal
+    reapplied: list[dict[str, str]]
+
+
+class UncorrectableCharge(Exception):
+    pass
+
+
+def correct_charge(conn: Conn, charge_id: str, body: CorrectionIn) -> CorrectionOut:
+    """Correct a wrong charge by SUPERSESSION, never mutation (issue #105):
+    the old row is marked superseded pointing at its successor — a new row,
+    same lease/kind/period, the corrected amount, carrying who it corrects
+    and why. Its allocations are released back to open credit and re-applied
+    oldest-first, so a paid charge corrected downward leaves the excess
+    visible as credit and one corrected upward shows the true remainder.
+    The ledger never moves — receipts are history; only allocation changes.
+    Order matters and is the schema's law: the old row is marked first (it
+    leaves the live one_charge_per_period index), the successor lands
+    second, and the deferrable pointer proves the chain at commit."""
+    old = conn.execute(
+        """
+        SELECT id::text, lease_id::text, kind::text, period_start, period_end,
+               due_on, rule_citation
+        FROM rent_charges
+        WHERE id = %s AND status IN ('scheduled', 'due', 'partially_paid', 'paid')
+        FOR UPDATE
+        """,
+        (charge_id,),
+    ).fetchone()
+    if old is None:
+        raise UncorrectableCharge(charge_id)
+    released = conn.execute(
+        "DELETE FROM rent_receipt_allocations WHERE charge_id = %s RETURNING amount",
+        (charge_id,),
+    ).fetchall()
+    released_total = sum((r["amount"] for r in released), Decimal(0))
+    new_id = str(uuid.uuid4())
+    conn.execute(
+        "UPDATE rent_charges SET status = 'superseded', superseded_by = %s WHERE id = %s",
+        (new_id, charge_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO rent_charges
+          (id, lease_id, kind, period_start, period_end, due_on, amount,
+           generated_by, rule_citation, corrects_charge_id, correction_reason)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, 'correction', %s, %s, %s)
+        """,
+        (
+            new_id,
+            old["lease_id"],
+            old["kind"],
+            old["period_start"],
+            old["period_end"],
+            old["due_on"],
+            body.amount,
+            old["rule_citation"],
+            charge_id,
+            body.reason,
+        ),
+    )
+    reapplied = apply_open_credit(conn, old["lease_id"])
+    return CorrectionOut(
+        superseded_charge_id=charge_id,
+        new_charge_id=new_id,
+        released=released_total,
+        reapplied=reapplied,
+    )
+
+
 def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
     """One rent charge per active lease for as_of's month. Idempotent via the
     one-charge-per-period key; CPI escalations are reported, not guessed."""
@@ -429,7 +515,8 @@ def sweep_rent_charges(conn: Conn, as_of: dt.date) -> RentSweepResult:
             INSERT INTO rent_charges
               (lease_id, kind, period_start, period_end, due_on, amount, generated_by)
             VALUES (%s, 'rent', %s, %s, %s, %s, 'sweep')
-            ON CONFLICT (lease_id, kind, period_start) DO NOTHING
+            ON CONFLICT (lease_id, kind, period_start)
+              WHERE superseded_by IS NULL DO NOTHING
             """,
             (lease["id"], period_start, period_end, due_on, amount),
         )
@@ -548,7 +635,8 @@ def sweep_late_fees(conn: Conn, as_of: dt.date) -> RentSweepResult:
             INSERT INTO rent_charges
               (lease_id, kind, period_start, due_on, amount, generated_by, rule_citation)
             VALUES (%s, 'late_fee', %s, %s, %s, 'sweep', %s)
-            ON CONFLICT (lease_id, kind, period_start) DO NOTHING
+            ON CONFLICT (lease_id, kind, period_start)
+              WHERE superseded_by IS NULL DO NOTHING
             """,
             (
                 charge["lease_id"],

--- a/services/api/tests/test_rent.py
+++ b/services/api/tests/test_rent.py
@@ -801,6 +801,123 @@ class TestWaiverConvention:
         assert refused.status_code == 404
 
 
+class TestChargeCorrection:
+    def test_an_unpaid_overbilled_charge_corrects_by_supersession(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        # Issue #105: the old row becomes history pointing at its successor;
+        # the period keeps exactly one LIVE charge; the balance follows the
+        # corrected figure; a re-swept month does not duplicate.
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        detail = client.get(f"/leases/{world['lease']}").json()
+        (charge,) = detail["charges"]
+        corrected = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1400.00", "reason": "rent was mistyped by fifty dollars"},
+        )
+        assert corrected.status_code == 200, corrected.text
+        body = corrected.json()
+        assert body["superseded_charge_id"] == charge["id"]
+        assert Decimal(body["released"]) == Decimal("0.00")
+        detail = client.get(f"/leases/{world['lease']}").json()
+        by_id = {c["id"]: c for c in detail["charges"]}
+        old = by_id[charge["id"]]
+        new = by_id[body["new_charge_id"]]
+        assert old["status"] == "superseded"
+        assert old["superseded_by"] == new["id"]
+        assert Decimal(old["outstanding"]) == Decimal("0.00")
+        assert new["corrects_charge_id"] == old["id"]
+        assert "mistyped" in new["correction_reason"]
+        assert Decimal(new["amount"]) == Decimal("1400.00")
+        assert new["period_start"] == old["period_start"]
+        assert Decimal(detail["balance_due"]) == Decimal("1400.00")
+        # Idempotency holds against the LIVE index: re-sweeping the month
+        # creates nothing beside the corrected charge.
+        again = client.post("/sweep/rent-charges?as_of=2026-08-01").json()
+        assert again["charges_created"] == 0
+
+    def test_a_paid_charge_corrected_downward_releases_the_excess_as_credit(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post(
+            f"/leases/{world['lease']}/receipts",
+            json={"occurred_on": "2026-08-01", "amount": "1450.00"},
+        )
+        detail = client.get(f"/leases/{world['lease']}").json()
+        (charge,) = detail["charges"]
+        assert charge["status"] == "paid"
+        body = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1400.00", "reason": "August was billed fifty high"},
+        ).json()
+        # 1450 released; 1400 re-applies to the successor; 50 stays VISIBLE.
+        assert Decimal(body["released"]) == Decimal("1450.00")
+        detail = client.get(f"/leases/{world['lease']}").json()
+        new = next(c for c in detail["charges"] if c["id"] == body["new_charge_id"])
+        assert new["status"] == "paid"
+        assert Decimal(detail["balance_due"]) == Decimal("0.00")
+        assert Decimal(detail["open_credit"]) == Decimal("50.00")
+
+    def test_a_partially_paid_charge_corrected_upward_shows_the_true_remainder(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        client.post(
+            f"/leases/{world['lease']}/receipts",
+            json={"occurred_on": "2026-08-01", "amount": "500.00"},
+        )
+        detail = client.get(f"/leases/{world['lease']}").json()
+        (charge,) = detail["charges"]
+        body = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1500.00", "reason": "utilities rider was omitted"},
+        ).json()
+        detail = client.get(f"/leases/{world['lease']}").json()
+        new = next(c for c in detail["charges"] if c["id"] == body["new_charge_id"])
+        assert new["status"] == "partially_paid"
+        assert Decimal(new["allocated"]) == Decimal("500.00")
+        assert Decimal(detail["balance_due"]) == Decimal("1000.00")
+        assert Decimal(detail["open_credit"]) == Decimal("0.00")
+
+    def test_the_chain_extends_from_the_live_row_and_history_is_refused(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        (charge,) = client.get(f"/leases/{world['lease']}").json()["charges"]
+        first = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1400.00", "reason": "first correction"},
+        ).json()
+        # Correcting the SUPERSEDED row again: 404 — correct the live one.
+        refused = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1300.00", "reason": "should not land"},
+        )
+        assert refused.status_code == 404
+        second = client.post(
+            f"/rent-charges/{first['new_charge_id']}/correct",
+            json={"amount": "1300.00", "reason": "second correction, live row"},
+        )
+        assert second.status_code == 200
+        detail = client.get(f"/leases/{world['lease']}").json()
+        assert Decimal(detail["balance_due"]) == Decimal("1300.00")
+        live = [c for c in detail["charges"] if c["status"] not in ("superseded",)]
+        assert len(live) == 1
+
+    def test_a_waived_charge_is_history_and_not_correctable(
+        self, world: dict[str, str], client: TestClient
+    ) -> None:
+        client.post("/sweep/rent-charges?as_of=2026-08-01")
+        (charge,) = client.get(f"/leases/{world['lease']}").json()["charges"]
+        client.post(f"/rent-charges/{charge['id']}/waive", json={"reason": "goodwill"})
+        refused = client.post(
+            f"/rent-charges/{charge['id']}/correct",
+            json={"amount": "1.00", "reason": "should not land"},
+        )
+        assert refused.status_code == 404
+
+
 class TestRenewals:
     def test_context_carries_labeled_defaults_then_measured_history(
         self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]


### PR DESCRIPTION
Closes #105 (rescued from a fabricated park by the vision grooming's premise-checker — any wrong rent charge was irrecoverable).

The house's supersession law, applied to charges:

- **The old row is never edited**: marked superseded pointing at its successor, dropping out of every balance like waived rows — history, fully readable, chain rendered on `ChargeOut`.
- **The successor is a new row** — same lease/kind/period, corrected amount, carrying *who* it corrects and *why* (`correction_says_why` makes a why-less correction unrepresentable).
- `one_charge_per_period` becomes a **partial unique index over live rows, keeping its name** so every test naming it still matches; the successor pointer is **deferrable** (mark first, insert second, one transaction); `one_successor_per_charge` means chains extend from the live row and never fork; `superseded_is_coupled` moves status and pointer together, both directions.
- **Money follows**: allocations release to open credit and re-apply oldest-first — a paid charge corrected down leaves the excess *visible* as credit; corrected up shows the true remainder. The ledger never moves. `refresh_charge_status` refuses to resurrect history.
- `POST /rent-charges/{id}/correct`, audited with old/new amounts, reason, and released sum.

Gates: schema verified (five new assertions incl. the fork refusal and the live-index collision); 381 API tests at 100% line+branch; contract regenerated; ruff/ratchet clean.

Vision test (docs/VISION.md §6): P1's second click — a corrected bill's history *is* the drill (old row, reason, successor, released money, all cited to itself); refusal 1 — the correction path replaces the silent edit an incumbent would ship.