### PR TITLE
The stack bills the month with no human: the sweep scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,10 @@ HESTIA_RENTCAST_ENABLED=false
 HESTIA_CENSUS_GEOCODER_URL=https://geocoding.geo.census.gov
 HESTIA_FEMA_NFHL_URL=https://hazards.fema.gov
 HESTIA_FRED_API_KEY=
+
+# The sweep scheduler (issue #39). HESTIA_SWEEP_AT enables the in-process
+# daily scheduler at the given UTC time; absent or empty disables it (tests
+# and ad-hoc stacks stay deterministic). The weekly dossier refresh runs on
+# HESTIA_DOSSIER_REFRESH_WEEKDAY (0=Monday .. 6=Sunday, default Sunday).
+HESTIA_SWEEP_AT=06:00
+HESTIA_DOSSIER_REFRESH_WEEKDAY=6

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -52,6 +52,8 @@ python3 "$ROOT/scripts/migrate.py" --include-seeds \
   --psql "$ENGINE exec -i $CONTAINER psql -U postgres -d hestia"
 
 export HESTIA_DATABASE_URL="postgresql://postgres:hestia-dev@127.0.0.1:$PORT/hestia"
+# The dev stack bills its month by itself (issue #39).
+export HESTIA_SWEEP_AT="${HESTIA_SWEEP_AT:-06:00}"
 say "starting the API on :$API_PORT"
 (cd "$ROOT/services/api" && exec uv run uvicorn hestia_api.app:app \
   --port "$API_PORT" --reload) &

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -10,8 +10,11 @@ contract the web client will be generated from.
 from __future__ import annotations
 
 import datetime as dt
+import os
+import threading
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import asynccontextmanager
 from decimal import Decimal
 from typing import Annotated, Any, Literal
 
@@ -49,15 +52,46 @@ from hestia_api import (
     payments,
     rent,
     reports,
+    scheduler,
     screening,
     sweep,
     views,
 )
 
+
+@asynccontextmanager
+async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
+    """Start the sweep scheduler iff configured (issue #39). Absent config
+    means no thread — tests and ad-hoc stacks stay deterministic."""
+    schedule = scheduler.schedule_from_env(os.environ.get)  # type: ignore[arg-type]
+    if schedule is None:
+        yield
+        return
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=scheduler.run_loop,
+        args=(
+            stop,
+            schedule,
+            scheduler.connection_factory(config.database_url()),
+            dossier.live_fetch,
+        ),
+        name="hestia-sweep-scheduler",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+
 app = FastAPI(
     title="Hestia API",
     version="0.1.0",
     description="The owner's operating platform for real property.",
+    lifespan=_lifespan,
 )
 app.add_middleware(
     CORSMiddleware,

--- a/services/api/hestia_api/scheduler.py
+++ b/services/api/hestia_api/scheduler.py
@@ -156,6 +156,12 @@ def tick(
         conn.commit()
 
 
+def _utc_now() -> dt.datetime:
+    """The production clock — a named function so its coverage never
+    depends on a daemon thread winning a scheduling race in CI."""
+    return dt.datetime.now(dt.UTC)
+
+
 def run_loop(
     stop: threading.Event,
     schedule: Schedule,
@@ -169,7 +175,7 @@ def run_loop(
     ``waiter`` and ``clock`` are injectable so the loop itself is testable;
     in production they are the stop event's wait and the UTC clock."""
     wait = waiter if waiter is not None else stop.wait
-    read_clock = clock if clock is not None else lambda: dt.datetime.now(dt.UTC)
+    read_clock = clock if clock is not None else _utc_now
     while not stop.is_set():
         now = read_clock()
         target = next_run(now, schedule.at)

--- a/services/api/hestia_api/scheduler.py
+++ b/services/api/hestia_api/scheduler.py
@@ -1,0 +1,206 @@
+"""The sweep scheduler — the stack bills the month with no human (issue #39).
+
+Every sweep is an idempotent function behind an audited POST endpoint; this
+module makes them RUN unattended while staying honest about the parked
+hosting decision (#33): no cron, no systemd, no platform assumption — a
+single daemon thread inside the API process, gated by configuration
+(``HESTIA_SWEEP_AT``, absent means disabled, so tests and ad-hoc stacks
+stay deterministic), serialized across replicas by a Postgres advisory
+lock. Idempotency already makes a double-run harmless; the lock makes it
+clean.
+
+Each tick runs the rent sweep, the late-fee sweep, and the deadline sweep,
+plus the dossier refresh on its configured weekday, and writes one audit
+row per sweep under the ``scheduler`` actor with a shared correlation id —
+an unattended month leaves the same trail a hand-run one would. One broken
+sweep never silences the rest: it is rolled back, audited as failed, and
+the tick continues, which is the gap philosophy applied to time.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+
+from hestia_api import db, dossier, rent, sweep
+from hestia_api.config import ConfigurationError
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+# 'HESTIA39' as eight ASCII bytes — a stable, greppable advisory-lock key.
+SWEEP_LOCK_KEY = 0x4845535449413339
+
+
+@dataclass(frozen=True)
+class Schedule:
+    at: dt.time  # UTC, daily
+    dossier_weekday: int  # 0 = Monday … 6 = Sunday
+
+
+def schedule_from_env(env: Callable[[str, str], str]) -> Schedule | None:
+    """``HESTIA_SWEEP_AT`` as ``HH:MM`` (UTC) enables the scheduler; absent
+    or empty disables it. ``HESTIA_DOSSIER_REFRESH_WEEKDAY`` picks the
+    weekly refresh day (0=Monday … 6=Sunday, default Sunday)."""
+    raw = env("HESTIA_SWEEP_AT", "").strip()
+    if not raw:
+        return None
+    try:
+        at = dt.time.fromisoformat(raw)
+    except ValueError as error:
+        raise ConfigurationError(
+            f"HESTIA_SWEEP_AT must be HH:MM (UTC), received {raw!r}"
+        ) from error
+    raw_day = env("HESTIA_DOSSIER_REFRESH_WEEKDAY", "6").strip()
+    try:
+        weekday = int(raw_day)
+    except ValueError as error:
+        raise ConfigurationError(
+            f"HESTIA_DOSSIER_REFRESH_WEEKDAY must be 0..6, received {raw_day!r}"
+        ) from error
+    if not 0 <= weekday <= 6:
+        raise ConfigurationError(
+            f"HESTIA_DOSSIER_REFRESH_WEEKDAY must be 0..6, received {raw_day!r}"
+        )
+    return Schedule(at=at, dossier_weekday=weekday)
+
+
+def next_run(now: dt.datetime, at: dt.time) -> dt.datetime:
+    """Today's configured moment if it is still ahead, else tomorrow's."""
+    candidate = dt.datetime.combine(now.date(), at, tzinfo=dt.UTC)
+    if candidate <= now:
+        candidate += dt.timedelta(days=1)
+    return candidate
+
+
+def _audit_run(conn: Conn, request_id: str, action: str, payload: dict[str, Any]) -> None:
+    db.record_audit(
+        conn,
+        actor="scheduler",
+        action=action,
+        request_id=request_id,
+        table_name=None,
+        record_id=None,
+        after_value=payload,
+    )
+
+
+def tick(
+    conn: Conn,
+    *,
+    now: dt.datetime,
+    dossier_weekday: int,
+    fetch: dossier.Fetcher,
+) -> dict[str, Any]:
+    """One scheduled pass. The advisory lock is session-scoped to this
+    connection: a second runner skips honestly instead of racing, and the
+    lock dies with the connection if a runner does."""
+    got = conn.execute("SELECT pg_try_advisory_lock(%s) AS got", (SWEEP_LOCK_KEY,)).fetchone()
+    if got is None or not got["got"]:
+        return {"skipped": "another runner holds the sweep lock"}
+    try:
+        request_id = f"sweep-{uuid.uuid4()}"
+        as_of = now.date()
+        results: dict[str, Any] = {"request_id": request_id}
+        sweeps: list[tuple[str, Callable[[], dict[str, Any]]]] = [
+            ("rent.sweep", lambda: rent.sweep_rent_charges(conn, as_of).model_dump()),
+            ("latefee.sweep", lambda: rent.sweep_late_fees(conn, as_of).model_dump()),
+            (
+                "sweep.deadlines",
+                lambda: (lambda r: {"inserted": r.inserted, "gaps": len(r.gaps)})(
+                    sweep.run_sweep(conn, as_of)
+                ),
+            ),
+        ]
+        for action, run in sweeps:
+            try:
+                outcome = run()
+                _audit_run(conn, request_id, action, outcome)
+                conn.commit()
+                results[action] = "ok"
+            except Exception as error:  # one broken sweep never silences the rest
+                conn.rollback()
+                _audit_run(conn, request_id, f"{action}.failed", {"error": str(error)})
+                conn.commit()
+                results[action] = f"failed: {error}"
+        if now.weekday() == dossier_weekday:
+            refreshed = 0
+            for row in conn.execute(
+                "SELECT id::text FROM properties WHERE disposed_on IS NULL"
+            ).fetchall():
+                try:
+                    dossier.assemble(conn, row["id"], fetch=fetch, as_of=as_of)
+                    conn.commit()
+                    refreshed += 1
+                except Exception as error:  # a dead network must not unbill the month
+                    conn.rollback()
+                    _audit_run(
+                        conn,
+                        request_id,
+                        "dossier.refresh.failed",
+                        {"property_id": row["id"], "error": str(error)},
+                    )
+                    conn.commit()
+            _audit_run(conn, request_id, "dossier.refresh", {"refreshed": refreshed})
+            conn.commit()
+            results["dossier.refresh"] = refreshed
+        return results
+    finally:
+        conn.execute("SELECT pg_advisory_unlock(%s)", (SWEEP_LOCK_KEY,))
+        conn.commit()
+
+
+def run_loop(
+    stop: threading.Event,
+    schedule: Schedule,
+    connect: Callable[[], AbstractContextManager[Conn]],
+    fetch: dossier.Fetcher,
+    *,
+    waiter: Callable[[float], bool] | None = None,
+    clock: Callable[[], dt.datetime] | None = None,
+) -> None:
+    """Sleep until the next configured moment, tick, repeat — until stopped.
+    ``waiter`` and ``clock`` are injectable so the loop itself is testable;
+    in production they are the stop event's wait and the UTC clock."""
+    wait = waiter if waiter is not None else stop.wait
+    read_clock = clock if clock is not None else lambda: dt.datetime.now(dt.UTC)
+    while not stop.is_set():
+        now = read_clock()
+        target = next_run(now, schedule.at)
+        if wait(max((target - now).total_seconds(), 0.0)):
+            break
+        with connect() as conn:
+            tick(
+                conn,
+                now=read_clock(),
+                dossier_weekday=schedule.dossier_weekday,
+                fetch=fetch,
+            )
+
+
+def connection_factory(url: str) -> Callable[[], AbstractContextManager[Conn]]:
+    """A fresh connection per tick: the advisory lock is session-scoped, and
+    a long-lived idle connection would hold nothing but risk."""
+
+    @contextmanager
+    def open_conn() -> Iterator[Conn]:
+        yield from db.connection_for(url)
+
+    return open_conn
+
+
+__all__ = [
+    "SWEEP_LOCK_KEY",
+    "Schedule",
+    "connection_factory",
+    "next_run",
+    "run_loop",
+    "schedule_from_env",
+    "tick",
+]

--- a/services/api/tests/test_scheduler.py
+++ b/services/api/tests/test_scheduler.py
@@ -1,0 +1,258 @@
+"""The sweep scheduler (issue #39): the stack bills the month with no human,
+every run leaves its audit trail, and one broken sweep never silences the
+rest."""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from hestia_api import rent, scheduler
+from hestia_api.config import ConfigurationError
+
+UTC = dt.UTC
+
+
+@pytest.fixture
+def world(clean: None, client: TestClient) -> dict[str, str]:
+    entity_id = client.post("/entities", json={"name": "S39", "kind": "llc"}).json()["id"]
+    property_id = client.post(
+        "/properties",
+        json={
+            "entity_id": entity_id,
+            "label": "sched",
+            "street_1": "1 Tick St",
+            "city": "Newport",
+            "state": "KY",
+            "postal_code": "41071",
+            "kind": "single_family",
+        },
+    ).json()["id"]
+    unit_id = client.post("/units", json={"property_id": property_id, "label": "A"}).json()["id"]
+    lease_id = client.post(
+        "/leases",
+        json={"unit_id": unit_id, "starts_on": "2026-04-01", "rent": "1450.00"},
+    ).json()["id"]
+    return {"entity": entity_id, "property": property_id, "lease": lease_id}
+
+
+def env_of(**values: str):
+    def env(key: str, default: str = "") -> str:
+        return values.get(key, default)
+
+    return env
+
+
+class TestSchedule:
+    def test_absent_or_empty_means_disabled(self) -> None:
+        assert scheduler.schedule_from_env(env_of()) is None
+        assert scheduler.schedule_from_env(env_of(HESTIA_SWEEP_AT="  ")) is None
+
+    def test_a_time_enables_and_the_weekday_defaults_to_sunday(self) -> None:
+        schedule = scheduler.schedule_from_env(env_of(HESTIA_SWEEP_AT="06:00"))
+        assert schedule == scheduler.Schedule(at=dt.time(6, 0), dossier_weekday=6)
+        monday = scheduler.schedule_from_env(
+            env_of(HESTIA_SWEEP_AT="23:30", HESTIA_DOSSIER_REFRESH_WEEKDAY="0")
+        )
+        assert monday is not None and monday.dossier_weekday == 0
+
+    def test_junk_is_refused_loudly(self) -> None:
+        with pytest.raises(ConfigurationError, match="HH:MM"):
+            scheduler.schedule_from_env(env_of(HESTIA_SWEEP_AT="six am"))
+        with pytest.raises(ConfigurationError, match=r"0\.\.6"):
+            scheduler.schedule_from_env(
+                env_of(HESTIA_SWEEP_AT="06:00", HESTIA_DOSSIER_REFRESH_WEEKDAY="mon")
+            )
+        with pytest.raises(ConfigurationError, match=r"0\.\.6"):
+            scheduler.schedule_from_env(
+                env_of(HESTIA_SWEEP_AT="06:00", HESTIA_DOSSIER_REFRESH_WEEKDAY="7")
+            )
+
+    def test_next_run_is_today_ahead_and_tomorrow_behind(self) -> None:
+        at = dt.time(6, 0)
+        before = dt.datetime(2026, 9, 5, 5, 59, tzinfo=UTC)
+        after = dt.datetime(2026, 9, 5, 6, 0, tzinfo=UTC)
+        assert scheduler.next_run(before, at) == dt.datetime(2026, 9, 5, 6, 0, tzinfo=UTC)
+        # The moment itself has passed the instant it arrives: tomorrow.
+        assert scheduler.next_run(after, at) == dt.datetime(2026, 9, 6, 6, 0, tzinfo=UTC)
+
+
+def _refusing_fetch(request: Any) -> Any:
+    raise AssertionError("no network call belongs in this test")
+
+
+class TestTick:
+    def test_a_tick_bills_the_month_and_leaves_the_trail(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # A Tuesday, so the weekly dossier refresh (Sunday) stays out of the
+        # way and no network is touched.
+        now = dt.datetime(2026, 9, 1, 6, 0, tzinfo=UTC)
+        result = scheduler.tick(conn, now=now, dossier_weekday=6, fetch=_refusing_fetch)
+        assert result["rent.sweep"] == "ok"
+        assert result["latefee.sweep"] == "ok"
+        assert result["sweep.deadlines"] == "ok"
+        assert "dossier.refresh" not in result
+        charges = conn.execute(
+            "SELECT count(*) AS n FROM rent_charges WHERE lease_id = %s",
+            (world["lease"],),
+        ).fetchone()
+        assert charges is not None and charges["n"] == 1
+        trail = conn.execute(
+            """
+            SELECT action FROM audit_log
+            WHERE actor = 'scheduler' AND request_id = %s ORDER BY id
+            """,
+            (result["request_id"],),
+        ).fetchall()
+        assert [t["action"] for t in trail] == [
+            "rent.sweep",
+            "latefee.sweep",
+            "sweep.deadlines",
+        ]
+
+    def test_a_broken_sweep_is_audited_and_the_rest_still_run(
+        self,
+        world: dict[str, str],
+        client: TestClient,
+        conn: psycopg.Connection[Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def explode(*_: Any, **__: Any) -> Any:
+            raise RuntimeError("late-fee resolution fell over")
+
+        monkeypatch.setattr(rent, "sweep_late_fees", explode)
+        now = dt.datetime(2026, 9, 1, 6, 0, tzinfo=UTC)
+        result = scheduler.tick(conn, now=now, dossier_weekday=6, fetch=_refusing_fetch)
+        assert result["rent.sweep"] == "ok"
+        assert result["latefee.sweep"].startswith("failed:")
+        assert result["sweep.deadlines"] == "ok"
+        failed = conn.execute(
+            """
+            SELECT after_value FROM audit_log
+            WHERE actor = 'scheduler' AND action = 'latefee.sweep.failed'
+              AND request_id = %s
+            """,
+            (result["request_id"],),
+        ).fetchone()
+        assert failed is not None and "fell over" in str(failed["after_value"])
+
+    def test_the_dossier_refresh_runs_on_its_weekday_and_degrades_per_property(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # 2026-09-06 is a Sunday. The refusing fetch makes every property's
+        # refresh fail — each failure is audited, the tick survives, and the
+        # summary row still lands.
+        now = dt.datetime(2026, 9, 6, 6, 0, tzinfo=UTC)
+        result = scheduler.tick(conn, now=now, dossier_weekday=6, fetch=_refusing_fetch)
+        assert result["dossier.refresh"] == 0
+        rows = conn.execute(
+            """
+            SELECT action FROM audit_log
+            WHERE actor = 'scheduler' AND request_id = %s
+              AND action LIKE 'dossier.refresh%%'
+            """,
+            (result["request_id"],),
+        ).fetchall()
+        actions = [r["action"] for r in rows]
+        assert "dossier.refresh" in actions
+        assert "dossier.refresh.failed" in actions
+
+    def test_a_second_runner_skips_instead_of_racing(
+        self,
+        world: dict[str, str],
+        client: TestClient,
+        conn: psycopg.Connection[Any],
+        database_url: str,
+    ) -> None:
+        with psycopg.connect(database_url, row_factory=psycopg.rows.dict_row) as rival:
+            held = rival.execute(
+                "SELECT pg_try_advisory_lock(%s) AS got", (scheduler.SWEEP_LOCK_KEY,)
+            ).fetchone()
+            assert held is not None and held["got"]
+            result = scheduler.tick(
+                conn,
+                now=dt.datetime(2026, 9, 1, 6, 0, tzinfo=UTC),
+                dossier_weekday=6,
+                fetch=_refusing_fetch,
+            )
+            assert result == {"skipped": "another runner holds the sweep lock"}
+
+
+class TestLoop:
+    def test_the_loop_ticks_once_then_stops_on_the_waiter(self) -> None:
+        stop = threading.Event()
+        waits: list[float] = []
+        answers = iter([False, True])
+
+        def waiter(timeout: float) -> bool:
+            waits.append(timeout)
+            return next(answers)
+
+        ticks: list[dt.datetime] = []
+
+        class FakeConn:
+            def __enter__(self) -> FakeConn:
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                return None
+
+        real_tick = scheduler.tick
+        try:
+
+            def fake_tick(conn: Any, *, now: dt.datetime, **_: Any) -> dict[str, Any]:
+                ticks.append(now)
+                return {}
+
+            scheduler.tick = fake_tick  # type: ignore[assignment]
+            scheduler.run_loop(
+                stop,
+                scheduler.Schedule(at=dt.time(6, 0), dossier_weekday=6),
+                lambda: FakeConn(),  # type: ignore[arg-type,return-value]
+                _refusing_fetch,
+                waiter=waiter,
+                clock=lambda: dt.datetime(2026, 9, 5, 5, 0, tzinfo=UTC),
+            )
+        finally:
+            scheduler.tick = real_tick  # type: ignore[assignment]
+        assert len(ticks) == 1
+        # The first wait targeted 06:00 from 05:00 — an hour.
+        assert waits[0] == pytest.approx(3600.0)
+
+    def test_a_pre_set_stop_never_ticks(self) -> None:
+        stop = threading.Event()
+        stop.set()
+        scheduler.run_loop(
+            stop,
+            scheduler.Schedule(at=dt.time(6, 0), dossier_weekday=6),
+            lambda: (_ for _ in ()).throw(AssertionError("must not connect")),  # type: ignore[arg-type,return-value]
+            _refusing_fetch,
+            waiter=lambda _: True,
+        )
+
+    def test_the_connection_factory_opens_real_sessions(self, database_url: str) -> None:
+        factory = scheduler.connection_factory(database_url)
+        with factory() as conn:
+            row = conn.execute("SELECT 1 AS one").fetchone()
+            assert row is not None and row["one"] == 1
+
+
+class TestLifespan:
+    def test_the_scheduler_thread_starts_and_stops_with_the_app(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Enabled via env: the lifespan starts the thread (it will sleep
+        # toward the next 23:59) and joins it cleanly on shutdown.
+        from hestia_api import app as app_module
+
+        monkeypatch.setenv("HESTIA_SWEEP_AT", "23:59")
+        with TestClient(app_module.app) as running:
+            names = [t.name for t in threading.enumerate()]
+            assert "hestia-sweep-scheduler" in names
+            assert running.get("/deadlines").status_code == 200
+        assert "hestia-sweep-scheduler" not in [t.name for t in threading.enumerate()]

--- a/services/api/tests/test_scheduler.py
+++ b/services/api/tests/test_scheduler.py
@@ -162,6 +162,38 @@ class TestTick:
         assert "dossier.refresh" in actions
         assert "dossier.refresh.failed" in actions
 
+    def test_a_successful_refresh_counts_and_commits(
+        self,
+        world: dict[str, str],
+        client: TestClient,
+        conn: psycopg.Connection[Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The success path of the weekly refresh: assemble stubbed to
+        # succeed, the counter advances, the summary row carries it, and no
+        # failure rows appear.
+        from hestia_api import dossier
+
+        seen: list[str] = []
+
+        def ok_assemble(_conn: Any, property_id: str, **_: Any) -> dict[str, Any]:
+            seen.append(property_id)
+            return {"steps": []}
+
+        monkeypatch.setattr(dossier, "assemble", ok_assemble)
+        now = dt.datetime(2026, 9, 6, 6, 0, tzinfo=UTC)  # a Sunday
+        result = scheduler.tick(conn, now=now, dossier_weekday=6, fetch=_refusing_fetch)
+        assert result["dossier.refresh"] == 1
+        assert seen == [world["property"]]
+        failed = conn.execute(
+            """
+            SELECT count(*) AS n FROM audit_log
+            WHERE request_id = %s AND action = 'dossier.refresh.failed'
+            """,
+            (result["request_id"],),
+        ).fetchone()
+        assert failed is not None and failed["n"] == 0
+
     def test_a_second_runner_skips_instead_of_racing(
         self,
         world: dict[str, str],

--- a/services/api/tests/test_scheduler.py
+++ b/services/api/tests/test_scheduler.py
@@ -224,6 +224,9 @@ class TestLoop:
         # The first wait targeted 06:00 from 05:00 — an hour.
         assert waits[0] == pytest.approx(3600.0)
 
+    def test_the_production_clock_reads_utc(self) -> None:
+        assert scheduler._utc_now().tzinfo == dt.UTC
+
     def test_a_pre_set_stop_never_ticks(self) -> None:
         stop = threading.Event()
         stop.set()
@@ -232,7 +235,6 @@ class TestLoop:
             scheduler.Schedule(at=dt.time(6, 0), dossier_weekday=6),
             lambda: (_ for _ in ()).throw(AssertionError("must not connect")),  # type: ignore[arg-type,return-value]
             _refusing_fetch,
-            waiter=lambda _: True,
         )
 
     def test_the_connection_factory_opens_real_sessions(self, database_url: str) -> None:


### PR DESCRIPTION
Closes #39 (Act I: P3's proof-that-nothing-needs-you requires the system to act unattended; the covenant ledger cannot count from day one if a human runs the sweeps).

- **A daemon thread in the API process**, honest about the parked hosting decision (#33): no cron, no platform assumption — `HESTIA_SWEEP_AT` (UTC, daily) enables it; absent disables, so tests stay deterministic. `dev.sh` exports it: the dev stack bills itself.
- **A Postgres advisory lock** serializes replicas (skip, never race; dies with the connection).
- **Each tick**: rent sweep → late fees → deadlines, plus the weekly dossier refresh on its weekday. One audit row per sweep, `scheduler` actor, shared correlation id — an unattended month leaves the same trail a hand-run one would.
- **One broken sweep never silences the rest** (rolled back, audited as failed, tick continues); a dead network cannot unbill the month.
- The loop's waiter and clock are injectable — every branch of the loop itself is under test, including the rival-runner skip against a second live connection and the lifespan thread observed starting and joining.

Gates: 393 API tests at 100% line+branch (12 new); ruff/ratchet/config-audit clean; no contract changes.

Vision test (docs/VISION.md §6): silence test — the home state can only be *proof* that nothing needs you if nothing needed you to produce it.