### PR TITLE
The property knows what 02:00 means where it stands

### DIFF
--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -2226,6 +2226,8 @@ export interface components {
             state: string;
             /** Street 1 */
             street_1: string;
+            /** Time Zone */
+            time_zone: string | null;
             /** Year Built */
             year_built: number | null;
         };
@@ -2844,6 +2846,8 @@ export interface components {
             state: string;
             /** Street 1 */
             street_1: string;
+            /** Time Zone */
+            time_zone?: string | null;
             /** Year Built */
             year_built?: number | null;
         };
@@ -2878,6 +2882,8 @@ export interface components {
             state: string;
             /** Street 1 */
             street_1: string;
+            /** Time Zone */
+            time_zone?: string | null;
             /** Year Built */
             year_built?: number | null;
         };

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -3296,6 +3296,17 @@
             "title": "Street 1",
             "type": "string"
           },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
+          },
           "year_built": {
             "anyOf": [
               {
@@ -3319,6 +3330,7 @@
           "county",
           "kind",
           "year_built",
+          "time_zone",
           "latitude",
           "longitude",
           "jurisdiction_chain",
@@ -5212,6 +5224,17 @@
             "title": "Street 1",
             "type": "string"
           },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
+          },
           "year_built": {
             "anyOf": [
               {
@@ -5316,6 +5339,17 @@
             "minLength": 1,
             "title": "Street 1",
             "type": "string"
+          },
+          "time_zone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Zone"
           },
           "year_built": {
             "anyOf": [

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -26,3 +26,4 @@
 \ir 025_tax_payment_deadline_kinds.sql
 \ir 026_charge_supersession_status.sql
 \ir 027_charges_correct_by_supersession.sql
+\ir 028_property_time_zone.sql

--- a/packages/domain/schema/028_property_time_zone.sql
+++ b/packages/domain/schema/028_property_time_zone.sql
@@ -1,0 +1,18 @@
+-- ===========================================================================
+--  028 — The property knows what 02:00 means where it stands (issue #58).
+--
+--  Time is local or it is wrong, and Kentucky and Tennessee both straddle a
+--  zone line, so the state cannot decide — and per ADR 0003 it would not
+--  get to. The zone is a PROPERTY fact: an IANA name, validated at the API
+--  against the zoneinfo database (PostgreSQL cannot CHECK a set that ships
+--  with the OS and moves), NULL an honest typed gap its consumers name —
+--  the dispatch ranker, the notification digests, every deadline surface —
+--  never a guess from the state.
+-- ===========================================================================
+
+ALTER TABLE properties ADD COLUMN time_zone TEXT;
+
+COMMENT ON COLUMN properties.time_zone IS
+  'IANA zone name (America/Chicago). Validated app-side against zoneinfo; '
+  'NULL means the owner has not answered yet — consumers name the gap, '
+  'nothing guesses from the state, because two of ours straddle zone lines.';

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -13,6 +13,7 @@ import datetime as dt
 import os
 import threading
 import uuid
+import zoneinfo
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import asynccontextmanager
 from decimal import Decimal
@@ -32,7 +33,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from hestia_api import (
     appeal,
@@ -202,6 +203,22 @@ class PropertyIn(BaseModel):
     # Disambiguates municipalities whose names collide within a state
     # (Ohio's twenty Washington Townships); optional everywhere else.
     county: str | None = Field(default=None, min_length=1)
+    # IANA zone — the property's own answer to what 02:00 means where it
+    # stands (issue #58). None is an honest gap consumers name; nothing
+    # guesses from the state, because KY and TN both straddle zone lines.
+    time_zone: str | None = None
+
+    @field_validator("time_zone")
+    @classmethod
+    def time_zone_is_a_real_iana_zone(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value not in zoneinfo.available_timezones():
+            raise ValueError(
+                f"{value!r} is not an IANA time zone; use a name like "
+                "America/Chicago or America/New_York"
+            )
+        return value
 
 
 class PropertyOut(PropertyIn):
@@ -253,8 +270,8 @@ def create_property(
             """
             INSERT INTO properties
               (entity_id, label, street_1, city, state, postal_code, county,
-               kind, year_built, jurisdiction_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
+               kind, year_built, time_zone, jurisdiction_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
             """,
             (
                 str(body.entity_id),
@@ -266,6 +283,7 @@ def create_property(
                 body.county,
                 body.kind,
                 body.year_built,
+                body.time_zone,
                 resolved.jurisdiction_id,
             ),
         ).fetchone()
@@ -300,7 +318,7 @@ def get_property(property_id: uuid.UUID, conn: Conn) -> PropertyOut:
     row = conn.execute(
         """
         SELECT id, entity_id, label, street_1, city, state, postal_code, county,
-               kind, year_built, jurisdiction_id
+               kind, year_built, time_zone, jurisdiction_id
         FROM properties WHERE id = %s
         """,
         (str(property_id),),

--- a/services/api/hestia_api/views.py
+++ b/services/api/hestia_api/views.py
@@ -96,6 +96,7 @@ class DossierView(BaseModel):
     county: str | None
     kind: str
     year_built: int | None
+    time_zone: str | None
     latitude: float | None
     longitude: float | None
     jurisdiction_chain: list[ChainLink]
@@ -134,7 +135,7 @@ def dossier_view(conn: Conn, property_id: str) -> DossierView | None:
     prop = conn.execute(
         """
         SELECT p.id::text, p.entity_id::text, p.label, p.street_1, p.city, p.state,
-               p.postal_code, p.county, p.kind::text, p.year_built,
+               p.postal_code, p.county, p.kind::text, p.year_built, p.time_zone,
                p.latitude::float, p.longitude::float, p.jurisdiction_id
         FROM properties p WHERE p.id = %s
         """,

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -122,8 +122,31 @@ class TestEntitiesAndProperties:
         prop = created.json()
         fetched = client.get(f"/properties/{prop['id']}").json()
         assert fetched == prop
+        # The zone was not answered: an honest NULL, never a guess from KY —
+        # which straddles a zone line and could not answer anyway (#58).
+        assert fetched["time_zone"] is None
         missing = client.get(f"/properties/{uuid.uuid4()}")
         assert missing.status_code == 404
+
+    def test_the_time_zone_is_a_validated_iana_fact(self, client: TestClient) -> None:
+        entity_id = client.post("/entities", json={"name": "TZ", "kind": "llc"}).json()["id"]
+        base = {
+            "entity_id": entity_id,
+            "label": "zoned",
+            "street_1": "1 Zone St",
+            "city": "Newport",
+            "state": "KY",
+            "postal_code": "41071",
+            "kind": "single_family",
+        }
+        refused = client.post("/properties", json={**base, "time_zone": "Central Time"})
+        assert refused.status_code == 422
+        assert "IANA" in refused.text and "America/Chicago" in refused.text
+        created = client.post("/properties", json={**base, "time_zone": "America/New_York"})
+        assert created.status_code == 201
+        prop = created.json()
+        assert prop["time_zone"] == "America/New_York"
+        assert client.get(f"/properties/{prop['id']}").json()["time_zone"] == "America/New_York"
 
     def test_jurisdiction_resolves_from_the_loaded_packs(
         self, client: TestClient, conn: psycopg.Connection[Any]


### PR DESCRIPTION
Closes #58 (Act I by dependency: #38's digest day is a local day, and the dispatch ranker's whole question is who answers at the property's 02:00).

- `properties.time_zone` — an IANA name, validated at the API against `zoneinfo` (PostgreSQL can't CHECK a set that ships with the OS and moves); the 422 teaches the shape (*use a name like America/Chicago*).
- **NULL is an honest gap its consumers name** — nothing ever guesses a zone from the state, because Kentucky and Tennessee both straddle zone lines and per ADR 0003 the state wouldn't get to decide anyway.
- Surfaced on `PropertyOut` and the dossier view; contract regenerated. The property form's zone select is the terminal agent's half.

Gates: schema verified; 396 API tests at 100% line+branch under CI's own coverage flags; ruff/ratchet clean.

Vision test (docs/VISION.md §6): P1 — the zone is the owner's answer, recorded as entered; refusal 1 — the unanswered zone is a typed gap, never a defaulted guess.