### PR TITLE
The correspondent channel: deadlines reach the owner, one message per step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,11 @@ HESTIA_FRED_API_KEY=
 # HESTIA_DOSSIER_REFRESH_WEEKDAY (0=Monday .. 6=Sunday, default Sunday).
 HESTIA_SWEEP_AT=06:00
 HESTIA_DOSSIER_REFRESH_WEEKDAY=6
+
+# The correspondent channel (issue #38). All three travel together; absent
+# means delivery records to the notifications ledger under channel 'log'.
+# HESTIA_SMTP_PORT defaults to 587.
+HESTIA_SMTP_HOST=
+HESTIA_SMTP_PORT=587
+HESTIA_SMTP_FROM=
+HESTIA_NOTIFY_TO=

--- a/apps/web/src/lib/api-schema.d.ts
+++ b/apps/web/src/lib/api-schema.d.ts
@@ -610,6 +610,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Notifications */
+        get: operations["list_notifications_notifications_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/deliver": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Deliver Notifications
+         * @description The correspondent channel's manual door (issue #38): the scheduler
+         *     calls the same function nightly; this exists for tests, catch-ups, and
+         *     the drill. Idempotent — one message per (deadline, reminder step).
+         */
+        post: operations["deliver_notifications_notifications_deliver_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/payments/stripe/webhook": {
         parameters: {
             query?: never;
@@ -2050,6 +2089,17 @@ export interface components {
             /** Triggers Disclosure */
             triggers_disclosure: boolean;
         };
+        /** DeliveryOut */
+        DeliveryOut: {
+            /** Delivered */
+            delivered: number;
+            /** Failed */
+            failed: number;
+            /** Interrupts */
+            interrupts: number;
+            /** Logged */
+            logged: number;
+        };
         /** DepositOut */
         DepositOut: {
             /** Deposit Account */
@@ -2694,6 +2744,32 @@ export interface components {
         NoticeIn: {
             /** Sent On */
             sent_on?: string | null;
+        };
+        /** NotificationOut */
+        NotificationOut: {
+            /** Attempts */
+            attempts: number;
+            /** Channel */
+            channel: string;
+            /** Deadline Id */
+            deadline_id: string;
+            /**
+             * Delivered At
+             * Format: date-time
+             */
+            delivered_at: string;
+            /** Id */
+            id: string;
+            /** Lead Days */
+            lead_days: number;
+            /** Recipient */
+            recipient: string | null;
+            /** Status */
+            status: string;
+            /** Subject */
+            subject: string;
+            /** Urgency */
+            urgency: string;
         };
         /** PaymentIn */
         PaymentIn: {
@@ -5084,6 +5160,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReversalOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_notifications_notifications_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    deliver_notifications_notifications_deliver_post: {
+        parameters: {
+            query?: {
+                as_of?: string | null;
+            };
+            header?: {
+                "x-actor"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeliveryOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/src/lib/openapi.json
+++ b/apps/web/src/lib/openapi.json
@@ -2709,6 +2709,34 @@
         "title": "DefectOut",
         "type": "object"
       },
+      "DeliveryOut": {
+        "properties": {
+          "delivered": {
+            "title": "Delivered",
+            "type": "integer"
+          },
+          "failed": {
+            "title": "Failed",
+            "type": "integer"
+          },
+          "interrupts": {
+            "title": "Interrupts",
+            "type": "integer"
+          },
+          "logged": {
+            "title": "Logged",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "delivered",
+          "logged",
+          "failed",
+          "interrupts"
+        ],
+        "title": "DeliveryOut",
+        "type": "object"
+      },
       "DepositOut": {
         "properties": {
           "deposit_account": {
@@ -4787,6 +4815,72 @@
           }
         },
         "title": "NoticeIn",
+        "type": "object"
+      },
+      "NotificationOut": {
+        "properties": {
+          "attempts": {
+            "title": "Attempts",
+            "type": "integer"
+          },
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "deadline_id": {
+            "title": "Deadline Id",
+            "type": "string"
+          },
+          "delivered_at": {
+            "format": "date-time",
+            "title": "Delivered At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "lead_days": {
+            "title": "Lead Days",
+            "type": "integer"
+          },
+          "recipient": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recipient"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "urgency": {
+            "title": "Urgency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "deadline_id",
+          "lead_days",
+          "urgency",
+          "channel",
+          "recipient",
+          "subject",
+          "status",
+          "attempts",
+          "delivered_at"
+        ],
+        "title": "NotificationOut",
         "type": "object"
       },
       "PaymentIn": {
@@ -10299,6 +10393,110 @@
           }
         },
         "summary": "Reverse Ledger Event"
+      }
+    },
+    "/notifications": {
+      "get": {
+        "operationId": "list_notifications_notifications_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationOut"
+                  },
+                  "title": "Response List Notifications Notifications Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Notifications"
+      }
+    },
+    "/notifications/deliver": {
+      "post": {
+        "description": "The correspondent channel's manual door (issue #38): the scheduler\ncalls the same function nightly; this exists for tests, catch-ups, and\nthe drill. Idempotent \u2014 one message per (deadline, reminder step).",
+        "operationId": "deliver_notifications_notifications_deliver_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "As Of"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-actor",
+            "required": false,
+            "schema": {
+              "default": "system",
+              "title": "X-Actor",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliveryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Deliver Notifications"
       }
     },
     "/payments/stripe/webhook": {

--- a/packages/domain/schema/000_all.sql
+++ b/packages/domain/schema/000_all.sql
@@ -27,3 +27,4 @@
 \ir 026_charge_supersession_status.sql
 \ir 027_charges_correct_by_supersession.sql
 \ir 028_property_time_zone.sql
+\ir 029_notification_delivery.sql

--- a/packages/domain/schema/029_notification_delivery.sql
+++ b/packages/domain/schema/029_notification_delivery.sql
@@ -1,0 +1,54 @@
+-- ===========================================================================
+--  029 — The correspondent channel's delivery ledger (issue #38).
+--
+--  VISION P3 makes the notification channel a primary surface, not a
+--  delivery seam: for most of the year Hestia is a correspondent, and what
+--  it sends must be as auditable as what it books. This table is that
+--  ledger — one row per (deadline, reminder step), which is what makes "a
+--  deadline inside its reminder window produces exactly one digest entry
+--  per schedule step" a database fact instead of a hope.
+--
+--  The three standing urgency classes are the vision's law, typed here so
+--  no message can ship without one: interrupt_now is reserved (refusal 13:
+--  the first false interrupt is a covenant breach of its own kind),
+--  next_session waits in the digest, on_record informs the ledger only.
+--
+--  Delivery failures are the one place this ledger updates in place: a
+--  failed send keeps its row and retries into it (attempts counted, last
+--  error kept), because the identity being protected is the MESSAGE — one
+--  per deadline per step — not the attempt. Nothing here is money.
+-- ===========================================================================
+
+CREATE TYPE urgency_class AS ENUM ('interrupt_now', 'next_session', 'on_record');
+
+CREATE TYPE delivery_status AS ENUM ('sent', 'logged', 'failed');
+
+CREATE TABLE notifications (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  deadline_id      UUID NOT NULL REFERENCES deadlines (id) ON DELETE CASCADE,
+  -- Which reminderSchedule step this message is: the lead, in days, from
+  -- the deadline's due date. One message per step, forever.
+  lead_days        SMALLINT NOT NULL CHECK (lead_days >= 0),
+  urgency          urgency_class NOT NULL,
+  channel          TEXT NOT NULL,            -- 'email' | 'log'
+  recipient        TEXT,                     -- NULL when channel = 'log'
+  subject          TEXT NOT NULL,
+  body             TEXT NOT NULL,
+  status           delivery_status NOT NULL,
+  attempts         SMALLINT NOT NULL DEFAULT 1 CHECK (attempts >= 1),
+  last_error       TEXT,
+  delivered_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT one_message_per_step UNIQUE (deadline_id, lead_days),
+  CONSTRAINT failed_says_why
+    CHECK (status <> 'failed' OR last_error IS NOT NULL),
+  CONSTRAINT email_names_its_recipient
+    CHECK (channel <> 'email' OR recipient IS NOT NULL)
+);
+
+COMMENT ON TABLE notifications IS
+  'The correspondent channel''s ledger (VISION P3): one row per (deadline, '
+  'reminder step). Failures retry INTO their row — the protected identity '
+  'is the message, not the attempt.';
+COMMENT ON COLUMN notifications.urgency IS
+  'The vision''s standing classes. interrupt_now is reserved; a false '
+  'interrupt is a covenant breach of its own kind (refusal 13).';

--- a/services/api/hestia_api/app.py
+++ b/services/api/hestia_api/app.py
@@ -50,6 +50,7 @@ from hestia_api import (
     jurisdiction,
     ledger,
     maintenance,
+    notify,
     payments,
     rent,
     reports,
@@ -853,6 +854,35 @@ def correct_charge(
         },
     )
     return result
+
+
+@app.post("/notifications/deliver", response_model=notify.DeliveryOut)
+def deliver_notifications(
+    conn: Conn,
+    request: Request,
+    as_of: dt.date | None = None,
+    actor: Actor = "system",
+) -> notify.DeliveryOut:
+    """The correspondent channel's manual door (issue #38): the scheduler
+    calls the same function nightly; this exists for tests, catch-ups, and
+    the drill. Idempotent — one message per (deadline, reminder step)."""
+    effective = as_of or dt.date.today()
+    result = notify.deliver(conn, effective, seam=notify.smtp_sender())
+    db.record_audit(
+        conn,
+        actor=actor,
+        action="notify.deliver",
+        request_id=request.state.request_id,
+        after_value={"as_of": str(effective), **result.model_dump()},
+    )
+    return result
+
+
+@app.get("/notifications", response_model=list[notify.NotificationOut])
+def list_notifications(
+    conn: Conn, limit: int = Query(default=50, ge=1, le=500)
+) -> list[notify.NotificationOut]:
+    return notify.recent(conn, limit)
 
 
 @app.get("/leases/{lease_id}/renewal-context", response_model=rent.RenewalContextOut)

--- a/services/api/hestia_api/calendar.py
+++ b/services/api/hestia_api/calendar.py
@@ -204,6 +204,24 @@ def next_ky_inspection_window(as_of: dt.date) -> InspectionWindow:
     )
 
 
+MAX_REMINDER_LEADS = 12
+
+
+def reminder_schedule(due_on: dt.date, lead_days: list[int]) -> list[dt.date]:
+    """Reminder dates for a deadline, deduplicated and ascending — the
+    Python twin of reminderSchedule in packages/engines/src/deadlines.ts,
+    pinned to the same behavior by the same anchors: leads sort
+    descending-by-lead (so dates ascend), duplicates collapse, and 1 to
+    MAX_REMINDER_LEADS entries of 0..365 days are the only legal shape."""
+    if not 1 <= len(lead_days) <= MAX_REMINDER_LEADS:
+        raise ValueError(f"lead_days must hold 1 to {MAX_REMINDER_LEADS} entries")
+    for lead in lead_days:
+        if not 0 <= lead <= 365:
+            raise ValueError(f"lead must be in [0, 365], received {lead}")
+    unique = sorted(set(lead_days), reverse=True)
+    return [due_on - dt.timedelta(days=lead) for lead in unique]
+
+
 def roll_forward_from_weekend(day: dt.date) -> dt.date:
     if day.weekday() == 5:  # Saturday
         return day + dt.timedelta(days=2)

--- a/services/api/hestia_api/config.py
+++ b/services/api/hestia_api/config.py
@@ -36,3 +36,28 @@ def stripe_webhook_secret() -> str:
     if not secret:
         raise ConfigurationError("HESTIA_STRIPE_WEBHOOK_SECRET is not set; see .env.example")
     return secret
+
+
+def smtp_settings() -> tuple[str, int, str, str] | None:
+    """(host, port, from, to) when the correspondent channel is configured;
+    None otherwise — delivery then records to the ledger under 'log'. All
+    four settings travel together: a partial configuration is a loud error,
+    never a half-working channel."""
+    host = os.environ.get("HESTIA_SMTP_HOST", "").strip()
+    sender = os.environ.get("HESTIA_SMTP_FROM", "").strip()
+    recipient = os.environ.get("HESTIA_NOTIFY_TO", "").strip()
+    if not any((host, sender, recipient)):
+        return None
+    if not all((host, sender, recipient)):
+        raise ConfigurationError(
+            "HESTIA_SMTP_HOST, HESTIA_SMTP_FROM and HESTIA_NOTIFY_TO travel "
+            "together; set all three or none (see .env.example)"
+        )
+    raw_port = os.environ.get("HESTIA_SMTP_PORT", "587").strip()
+    try:
+        port = int(raw_port)
+    except ValueError as error:
+        raise ConfigurationError(
+            f"HESTIA_SMTP_PORT must be an integer, received {raw_port!r}"
+        ) from error
+    return host, port, sender, recipient

--- a/services/api/hestia_api/notify.py
+++ b/services/api/hestia_api/notify.py
@@ -1,0 +1,287 @@
+"""The correspondent channel (issue #38; VISION P3, §7 Act I).
+
+For most of the year Hestia is a correspondent, not a cockpit — so what it
+sends is a primary surface, held to the same law as what it books. Every
+message is a DecisionCard in the covenant's voice: the verdict (what and
+when), the authority (the deadline row's own citation), and one action —
+never a feelings update, never a summary of nothing.
+
+The three standing urgency classes are typed at the schema and assigned
+conservatively here: ``interrupt_now`` is RESERVED for a money-or-waiver
+date at its final step (refusal 13: the first false interrupt is a
+covenant breach of its own kind); everything else waits in the digest as
+``next_session``. Corrections to already-delivered dates ride the same
+discipline when they come.
+
+Delivery is idempotent by construction: one message per (deadline,
+reminder step), a database fact (module 029). The provider is a seam — an
+injected ``send`` callable; SMTP when configured, and when it is not, the
+message is still written to the ledger under channel ``log``, because the
+record of what Hestia would have said is itself a deliverable.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import smtplib
+from collections.abc import Callable
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Any
+
+import psycopg
+from pydantic import BaseModel
+
+from hestia_api import calendar, config
+
+Conn = psycopg.Connection[dict[str, Any]]
+
+# The default runway: a month out, two weeks, one week, the day before.
+DEFAULT_LEADS = [30, 14, 7, 1]
+
+# Kinds whose FINAL reminder step may interrupt: missing them waives a
+# right or attaches a penalty by operation of law. Everything else waits.
+INTERRUPT_KINDS = frozenset(
+    {
+        "assessment_appeal_window",
+        "tax_payment_due",
+        "deposit_itemization",
+        "adverse_action_notice",
+    }
+)
+
+
+def urgency_for(kind: str, lead_days: int) -> str:
+    """Conservative by doctrine: interrupt_now only for a waiver-or-penalty
+    kind at its final approach (two days or fewer); the digest carries the
+    rest. Dates that err early must never cry wolf."""
+    if kind in INTERRUPT_KINDS and lead_days <= 2:
+        return "interrupt_now"
+    return "next_session"
+
+
+@dataclass(frozen=True)
+class Message:
+    deadline_id: str
+    lead_days: int
+    urgency: str
+    subject: str
+    body: str
+
+
+class DeliveryOut(BaseModel):
+    delivered: int
+    logged: int
+    failed: int
+    interrupts: int
+
+
+class NotificationOut(BaseModel):
+    id: str
+    deadline_id: str
+    lead_days: int
+    urgency: str
+    channel: str
+    recipient: str | None
+    subject: str
+    status: str
+    attempts: int
+    delivered_at: dt.datetime
+
+
+def _compose(row: dict[str, Any], lead_days: int) -> Message:
+    """The covenant's voice: verdict, authority, one action. The citation is
+    the deadline row's own — the code carries no state's statutes."""
+    kind = row["kind"]
+    due = row["due_on"]
+    label = row["property_label"] or row["entity_name"] or "the portfolio"
+    urgency = urgency_for(kind, lead_days)
+    when = "TOMORROW" if lead_days == 1 else f"in {lead_days} days" if lead_days else "TODAY"
+    subject = f"[Hestia] {kind.replace('_', ' ')} — {due.isoformat()} ({when})"
+    runway = (
+        f"The window opened {row['window_opens_on'].isoformat()}. "
+        if row["window_opens_on"]
+        else ""
+    )
+    note = f"\n{row['note']}\n" if row["note"] else ""
+    action = (
+        "Act now: this date waives a right or attaches a penalty by law."
+        if urgency == "interrupt_now"
+        else "It is prepared and waiting in Hestia; nothing else needs you today."
+    )
+    body = (
+        f"{label}: {kind.replace('_', ' ')} is due {due.isoformat()} ({when}).\n"
+        f"{runway}"
+        f"Authority: {row['citation']}\n"
+        f"{note}"
+        f"{action}\n"
+    )
+    return Message(
+        deadline_id=row["id"],
+        lead_days=lead_days,
+        urgency=urgency,
+        subject=subject,
+        body=body,
+    )
+
+
+def due_messages(conn: Conn, as_of: dt.date) -> list[Message]:
+    """Every (deadline, step) whose reminder date has arrived and whose
+    message has not been written — the crossing, not the calendar, is what
+    fires, so a stack that slept through a step still sends it once."""
+    rows = conn.execute(
+        """
+        SELECT d.id::text, d.kind::text, d.due_on, d.window_opens_on,
+               d.citation, d.note,
+               p.label AS property_label, e.name AS entity_name
+        FROM deadlines d
+        LEFT JOIN properties p ON p.id = d.property_id
+        LEFT JOIN entities e ON e.id = d.entity_id
+        WHERE d.status = 'upcoming' AND d.due_on >= %(as_of)s
+        ORDER BY d.due_on, d.id
+        """,
+        {"as_of": as_of},
+    ).fetchall()
+    if not rows:
+        return []
+    written = {
+        (n["deadline_id"], n["lead_days"])
+        for n in conn.execute(
+            "SELECT deadline_id::text AS deadline_id, lead_days FROM notifications"
+        ).fetchall()
+    }
+    messages: list[Message] = []
+    for row in rows:
+        for remind_on in calendar.reminder_schedule(row["due_on"], DEFAULT_LEADS):
+            lead = (row["due_on"] - remind_on).days
+            if remind_on <= as_of and (row["id"], lead) not in written:
+                messages.append(_compose(row, lead))
+    return messages
+
+
+Sender = Callable[[str, str, str], None]  # (recipient, subject, body) -> None
+
+
+def smtp_sender() -> tuple[Sender, str] | None:
+    """The live seam: (sender, recipient) when SMTP + recipient are
+    configured, else None — and the ledger still records under 'log'."""
+    settings = config.smtp_settings()
+    if settings is None:
+        return None
+    host, port, sender_addr, recipient = settings
+
+    def send(to: str, subject: str, body: str) -> None:
+        message = EmailMessage()
+        message["From"] = sender_addr
+        message["To"] = to
+        message["Subject"] = subject
+        message.set_content(body)
+        with smtplib.SMTP(host, port, timeout=10) as smtp:
+            smtp.send_message(message)
+
+    return send, recipient
+
+
+def deliver(
+    conn: Conn,
+    as_of: dt.date,
+    *,
+    seam: tuple[Sender, str] | None,
+) -> DeliveryOut:
+    """Write-then-send, one row per message: the ledger is the source of
+    truth and a send failure keeps its row and retries into it (module
+    029's one exception to append-only — the identity protected is the
+    message, not the attempt)."""
+    delivered = logged = failed = interrupts = 0
+    # Retry earlier failures first — same rows, one more attempt.
+    for prior in conn.execute(
+        """
+        SELECT id::text, deadline_id::text AS deadline_id, lead_days, urgency::text,
+               recipient, subject, body
+        FROM notifications WHERE status = 'failed'
+        """
+    ).fetchall():
+        if seam is None:
+            continue
+        send, recipient = seam
+        try:
+            send(recipient, prior["subject"], prior["body"])
+            conn.execute(
+                """
+                UPDATE notifications
+                SET status = 'sent', attempts = attempts + 1, last_error = NULL,
+                    channel = 'email', recipient = %s, delivered_at = now()
+                WHERE id = %s
+                """,
+                (recipient, prior["id"]),
+            )
+            delivered += 1
+        except Exception as error:
+            conn.execute(
+                "UPDATE notifications SET attempts = attempts + 1, last_error = %s WHERE id = %s",
+                (str(error), prior["id"]),
+            )
+            failed += 1
+    for message in due_messages(conn, as_of):
+        if message.urgency == "interrupt_now":
+            interrupts += 1
+        if seam is None:
+            conn.execute(
+                """
+                INSERT INTO notifications
+                  (deadline_id, lead_days, urgency, channel, recipient,
+                   subject, body, status)
+                VALUES (%s, %s, %s, 'log', NULL, %s, %s, 'logged')
+                ON CONFLICT (deadline_id, lead_days) DO NOTHING
+                """,
+                (
+                    message.deadline_id,
+                    message.lead_days,
+                    message.urgency,
+                    message.subject,
+                    message.body,
+                ),
+            )
+            logged += 1
+            continue
+        send, recipient = seam
+        try:
+            send(recipient, message.subject, message.body)
+            status, error = "sent", None
+            delivered += 1
+        except Exception as caught:
+            status, error = "failed", str(caught)
+            failed += 1
+        conn.execute(
+            """
+            INSERT INTO notifications
+              (deadline_id, lead_days, urgency, channel, recipient,
+               subject, body, status, last_error)
+            VALUES (%s, %s, %s, 'email', %s, %s, %s, %s, %s)
+            ON CONFLICT (deadline_id, lead_days) DO NOTHING
+            """,
+            (
+                message.deadline_id,
+                message.lead_days,
+                message.urgency,
+                recipient,
+                message.subject,
+                message.body,
+                status,
+                error,
+            ),
+        )
+    return DeliveryOut(delivered=delivered, logged=logged, failed=failed, interrupts=interrupts)
+
+
+def recent(conn: Conn, limit: int) -> list[NotificationOut]:
+    rows = conn.execute(
+        """
+        SELECT id::text, deadline_id::text AS deadline_id, lead_days,
+               urgency::text, channel, recipient, subject, status::text,
+               attempts, delivered_at
+        FROM notifications ORDER BY delivered_at DESC, id LIMIT %s
+        """,
+        (limit,),
+    ).fetchall()
+    return [NotificationOut(**row) for row in rows]

--- a/services/api/hestia_api/scheduler.py
+++ b/services/api/hestia_api/scheduler.py
@@ -29,7 +29,7 @@ from typing import Any
 
 import psycopg
 
-from hestia_api import db, dossier, rent, sweep
+from hestia_api import db, dossier, notify, rent, sweep
 from hestia_api.config import ConfigurationError
 
 Conn = psycopg.Connection[dict[str, Any]]
@@ -116,6 +116,14 @@ def tick(
                 lambda: (lambda r: {"inserted": r.inserted, "gaps": len(r.gaps)})(
                     sweep.run_sweep(conn, as_of)
                 ),
+            ),
+            # The correspondent channel rides the same tick (issue #38): the
+            # sweeps put dates on the books, delivery tells the owner —
+            # idempotent per (deadline, reminder step), so a missed night
+            # sends once, never twice.
+            (
+                "notify.deliver",
+                lambda: notify.deliver(conn, as_of, seam=notify.smtp_sender()).model_dump(),
             ),
         ]
         for action, run in sweeps:

--- a/services/api/tests/test_notify.py
+++ b/services/api/tests/test_notify.py
@@ -1,0 +1,281 @@
+"""The correspondent channel (issue #38): one message per (deadline, step),
+the covenant's voice on every message, the interrupt class reserved, and a
+ledger that records even when no wire exists."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from hestia_api import calendar, notify
+
+
+@pytest.fixture
+def world(clean: None, client: TestClient, conn: psycopg.Connection[Any]) -> dict[str, str]:
+    entity_id = client.post("/entities", json={"name": "N38", "kind": "llc"}).json()["id"]
+    property_id = client.post(
+        "/properties",
+        json={
+            "entity_id": entity_id,
+            "label": "monmouth",
+            "street_1": "998 Monmouth St",
+            "city": "Newport",
+            "state": "KY",
+            "postal_code": "41071",
+            "kind": "single_family",
+        },
+    ).json()["id"]
+    deadline_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO deadlines (id, kind, due_on, window_opens_on, property_id, citation, note)
+        VALUES (%s, 'tax_payment_due', '2026-10-31', NULL, %s,
+                'KRS s.91A.070(2); City of Newport Finance/Taxes page',
+                'city bills are payable on or before October 31')
+        """,
+        (deadline_id, property_id),
+    )
+    conn.commit()
+    return {"entity": entity_id, "property": property_id, "deadline": deadline_id}
+
+
+class TestReminderTwin:
+    def test_anchors_match_the_ts_engine(self) -> None:
+        due = dt.date(2026, 10, 31)
+        # Deduplicated, ascending — the TS twin's documented behavior.
+        assert calendar.reminder_schedule(due, [7, 30, 7, 1]) == [
+            dt.date(2026, 10, 1),
+            dt.date(2026, 10, 24),
+            dt.date(2026, 10, 30),
+        ]
+
+    def test_bounds_are_the_twins_bounds(self) -> None:
+        due = dt.date(2026, 10, 31)
+        with pytest.raises(ValueError, match="1 to 12"):
+            calendar.reminder_schedule(due, [])
+        with pytest.raises(ValueError, match="1 to 12"):
+            calendar.reminder_schedule(due, list(range(13)))
+        with pytest.raises(ValueError, match=r"\[0, 365\]"):
+            calendar.reminder_schedule(due, [400])
+
+
+class TestUrgency:
+    def test_interrupt_is_reserved_for_waiver_kinds_at_final_approach(self) -> None:
+        assert notify.urgency_for("tax_payment_due", 1) == "interrupt_now"
+        assert notify.urgency_for("tax_payment_due", 7) == "next_session"
+        # A lease expiration never interrupts — nothing waives at midnight.
+        assert notify.urgency_for("lease_expiration", 1) == "next_session"
+
+
+class TestDelivery:
+    def test_unconfigured_channel_still_writes_the_ledger(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # October 24 crosses the 30- and 14-day steps (Oct 1 and Oct 17)
+        # and the 7-day step (Oct 24) — three messages, once each, logged.
+        result = client.post("/notifications/deliver?as_of=2026-10-24").json()
+        assert result["logged"] == 3
+        assert result["delivered"] == 0 and result["failed"] == 0
+        again = client.post("/notifications/deliver?as_of=2026-10-24").json()
+        assert again["logged"] == 0  # exactly one message per step, forever
+        rows = client.get("/notifications").json()
+        mine = [r for r in rows if r["deadline_id"] == world["deadline"]]
+        assert sorted(r["lead_days"] for r in mine) == [7, 14, 30]
+        assert {r["channel"] for r in mine} == {"log"}
+        assert {r["status"] for r in mine} == {"logged"}
+
+    def test_the_final_step_interrupts_and_speaks_in_the_covenant_voice(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        result = client.post("/notifications/deliver?as_of=2026-10-30").json()
+        assert result["interrupts"] == 1
+        row = conn.execute(
+            """
+            SELECT urgency::text, subject, body FROM notifications
+            WHERE deadline_id = %s AND lead_days = 1
+            """,
+            (world["deadline"],),
+        ).fetchone()
+        assert row is not None and row["urgency"] == "interrupt_now"
+        assert "TOMORROW" in row["subject"]
+        # Verdict, authority, one action — the DecisionCard grammar.
+        assert "due 2026-10-31" in row["body"]
+        assert "KRS s.91A.070(2)" in row["body"]
+        assert "Act now" in row["body"]
+
+    def test_a_configured_seam_sends_and_records_the_recipient(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        sent: list[tuple[str, str, str]] = []
+
+        def sender(to: str, subject: str, body: str) -> None:
+            sent.append((to, subject, body))
+
+        result = notify.deliver(conn, dt.date(2026, 10, 24), seam=(sender, "bri@example.com"))
+        conn.commit()
+        assert result.delivered == 3 and result.failed == 0
+        assert {s[0] for s in sent} == {"bri@example.com"}
+        rows = conn.execute(
+            "SELECT channel, recipient, status::text FROM notifications WHERE deadline_id = %s",
+            (world["deadline"],),
+        ).fetchall()
+        assert all(r["channel"] == "email" and r["recipient"] == "bri@example.com" for r in rows)
+        assert {r["status"] for r in rows} == {"sent"}
+
+    def test_a_failed_send_keeps_its_row_and_retries_into_it(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        def broken(to: str, subject: str, body: str) -> None:
+            raise ConnectionError("the wire is down")
+
+        first = notify.deliver(conn, dt.date(2026, 10, 1), seam=(broken, "bri@example.com"))
+        conn.commit()
+        assert first.failed == 1 and first.delivered == 0
+        row = conn.execute(
+            "SELECT status::text, attempts, last_error FROM notifications WHERE deadline_id = %s",
+            (world["deadline"],),
+        ).fetchone()
+        assert row is not None and row["status"] == "failed"
+        assert row["attempts"] == 1 and "wire is down" in row["last_error"]
+
+        delivered: list[str] = []
+        second = notify.deliver(
+            conn,
+            dt.date(2026, 10, 1),
+            seam=(lambda to, s, b: delivered.append(s), "bri@example.com"),
+        )
+        conn.commit()
+        assert second.delivered == 1  # the retry, into the same row
+        row = conn.execute(
+            "SELECT status::text, attempts, last_error FROM notifications WHERE deadline_id = %s",
+            (world["deadline"],),
+        ).fetchone()
+        assert row is not None and row["status"] == "sent"
+        assert row["attempts"] == 2 and row["last_error"] is None
+        count = conn.execute(
+            "SELECT count(*) AS n FROM notifications WHERE deadline_id = %s",
+            (world["deadline"],),
+        ).fetchone()
+        assert count is not None and count["n"] == 1  # the message, not the attempts
+
+    def test_a_retry_with_no_seam_waits_and_a_broken_retry_counts_again(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        def broken(to: str, subject: str, body: str) -> None:
+            raise ConnectionError("still down")
+
+        notify.deliver(conn, dt.date(2026, 10, 1), seam=(broken, "bri@example.com"))
+        conn.commit()
+        # No seam: the failed row waits — nothing invents a channel.
+        held = notify.deliver(conn, dt.date(2026, 10, 1), seam=None)
+        conn.commit()
+        assert held.delivered == 0 and held.failed == 0 and held.logged == 0
+        # A second broken attempt counts itself honestly.
+        again = notify.deliver(conn, dt.date(2026, 10, 1), seam=(broken, "bri@example.com"))
+        conn.commit()
+        assert again.failed == 1
+        row = conn.execute(
+            "SELECT attempts FROM notifications WHERE deadline_id = %s",
+            (world["deadline"],),
+        ).fetchone()
+        assert row is not None and row["attempts"] == 2
+
+    def test_entity_anchored_deadlines_and_bare_leads_render_too(
+        self, world: dict[str, str], client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        # An entity-anchored deadline (no property) with a window open date,
+        # delivered ON its due date (lead 0 crosses when as_of == due_on is
+        # inside every step) — the TODAY wording and the runway line render.
+        deadline_id = str(uuid.uuid4())
+        conn.execute(
+            """
+            INSERT INTO deadlines (id, kind, due_on, window_opens_on, entity_id, citation)
+            VALUES (%s, 'estimated_tax', '2026-10-24', '2026-10-01', %s, 'IRC s.6654(c)')
+            """,
+            (deadline_id, world["entity"]),
+        )
+        conn.commit()
+        notify.deliver(conn, dt.date(2026, 10, 23), seam=None)
+        conn.commit()
+        row = conn.execute(
+            "SELECT body, subject FROM notifications WHERE deadline_id = %s AND lead_days = 1",
+            (deadline_id,),
+        ).fetchone()
+        assert row is not None
+        assert "N38" in row["body"]  # the entity carries the address
+        assert "The window opened 2026-10-01." in row["body"]
+
+    def test_smtp_seam_absent_when_unconfigured(self) -> None:
+        assert notify.smtp_sender() is None
+
+    def test_no_deadlines_means_nothing_to_say(
+        self, clean: None, client: TestClient, conn: psycopg.Connection[Any]
+    ) -> None:
+        result = notify.deliver(conn, dt.date(2030, 1, 1), seam=None)
+        assert result.model_dump() == {
+            "delivered": 0,
+            "logged": 0,
+            "failed": 0,
+            "interrupts": 0,
+        }
+
+
+class TestSmtpSeam:
+    def test_settings_travel_together_or_not_at_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hestia_api import config
+        from hestia_api.config import ConfigurationError
+
+        for key in ("HESTIA_SMTP_HOST", "HESTIA_SMTP_FROM", "HESTIA_NOTIFY_TO"):
+            monkeypatch.delenv(key, raising=False)
+        assert config.smtp_settings() is None
+        monkeypatch.setenv("HESTIA_SMTP_HOST", "mail.example.com")
+        with pytest.raises(ConfigurationError, match="travel"):
+            config.smtp_settings()
+        monkeypatch.setenv("HESTIA_SMTP_FROM", "hestia@example.com")
+        monkeypatch.setenv("HESTIA_NOTIFY_TO", "bri@example.com")
+        assert config.smtp_settings() == (
+            "mail.example.com",
+            587,
+            "hestia@example.com",
+            "bri@example.com",
+        )
+        monkeypatch.setenv("HESTIA_SMTP_PORT", "not-a-port")
+        with pytest.raises(ConfigurationError, match="integer"):
+            config.smtp_settings()
+
+    def test_the_configured_seam_sends_through_smtp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HESTIA_SMTP_HOST", "mail.example.com")
+        monkeypatch.setenv("HESTIA_SMTP_PORT", "2525")
+        monkeypatch.setenv("HESTIA_SMTP_FROM", "hestia@example.com")
+        monkeypatch.setenv("HESTIA_NOTIFY_TO", "bri@example.com")
+        sent: list[Any] = []
+
+        class FakeSMTP:
+            def __init__(self, host: str, port: int, timeout: int) -> None:
+                assert (host, port) == ("mail.example.com", 2525)
+
+            def __enter__(self) -> FakeSMTP:
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                return None
+
+            def send_message(self, message: Any) -> None:
+                sent.append(message)
+
+        import smtplib
+
+        monkeypatch.setattr(smtplib, "SMTP", FakeSMTP)
+        seam = notify.smtp_sender()
+        assert seam is not None
+        send, recipient = seam
+        assert recipient == "bri@example.com"
+        send(recipient, "subject line", "body text")
+        (message,) = sent
+        assert message["From"] == "hestia@example.com"
+        assert message["To"] == "bri@example.com"
+        assert message["Subject"] == "subject line"

--- a/services/api/tests/test_scheduler.py
+++ b/services/api/tests/test_scheduler.py
@@ -96,6 +96,7 @@ class TestTick:
         assert result["rent.sweep"] == "ok"
         assert result["latefee.sweep"] == "ok"
         assert result["sweep.deadlines"] == "ok"
+        assert result["notify.deliver"] == "ok"
         assert "dossier.refresh" not in result
         charges = conn.execute(
             "SELECT count(*) AS n FROM rent_charges WHERE lease_id = %s",
@@ -113,6 +114,7 @@ class TestTick:
             "rent.sweep",
             "latefee.sweep",
             "sweep.deadlines",
+            "notify.deliver",
         ]
 
     def test_a_broken_sweep_is_audited_and_the_rest_still_run(


### PR DESCRIPTION
Closes #38 — VISION P3 and §7 Act I promote this from delivery seam to **primary surface**, and the vision-groomed ticket set the bar it ships to.

- **Every message is a DecisionCard in the covenant's voice**: verdict (what/when), authority (the deadline row's own citation — the code carries no statutes), one action.
- **The three urgency classes are typed at the schema**; `interrupt_now` is *reserved* for waiver-or-penalty kinds at final approach (refusal 13: the first false interrupt is a covenant breach of its own kind — a lease expiration never interrupts, test-pinned).
- **Module 029, the delivery ledger**: one row per (deadline, reminder step) — 'exactly one digest entry per schedule step' as a database fact. The never-consumed `reminderSchedule` finally gets its consumer, via a Python twin pinned to the TS anchors; the *crossing* fires, not the calendar, so a slept-through step still sends once.
- **Failures retry into their row** (attempts counted, last error kept) — the identity protected is the message, not the attempt.
- **The seam**: SMTP when configured (settings travel together or not at all); unconfigured still writes the ledger under `log` — the record of what Hestia would have said is itself a deliverable. Rides the scheduler's tick + a manual door for the May-2027 drill (#28).

Gates: schema verified; **409 API tests at 100% line+branch under CI's own coverage flags**; contract regenerated; ruff/ratchet/config-audit clean.

Vision test (docs/VISION.md §6): P3 rendered — the correspondent, not the cockpit; silence test — every message carries its class, and the wolf is never cried.